### PR TITLE
Fix AI agent workflows by removing envsubst dependency

### DIFF
--- a/.github/workflows/agent-architect.yml
+++ b/.github/workflows/agent-architect.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_COLLAB="$collaboration_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Architect-agentens riktlinje
 
 ## Mål

--- a/.github/workflows/agent-designer.yml
+++ b/.github/workflows/agent-designer.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_RESEARCH="$research_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Designer-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-developer.yml
+++ b/.github/workflows/agent-developer.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_RISKS="$risk_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Developer-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-editor.yml
+++ b/.github/workflows/agent-editor.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_STYLE="$style_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Editor-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-graphic-designer.yml
+++ b/.github/workflows/agent-graphic-designer.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_ASSETS="$asset_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Graphic Designer-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-project-manager.yml
+++ b/.github/workflows/agent-project-manager.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_BACKLOG="$backlog_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Project Manager-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-quality-control.yml
+++ b/.github/workflows/agent-quality-control.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_DEFECTS="$defect_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Quality Control-agentens plan
 
 ## Mål

--- a/.github/workflows/agent-requirements-analyst.yml
+++ b/.github/workflows/agent-requirements-analyst.yml
@@ -62,7 +62,7 @@ jobs:
           export AGENT_DEPENDENCIES="$dependency_value"
 
           summary=$(
-            cat <<'PLAN' | envsubst
+            cat <<PLAN
 # Requirements Analyst-agentens plan
 
 ## Mål


### PR DESCRIPTION
## Summary
- replace envsubst-based templating in all agent workflows with native shell heredocs
- avoid missing envsubst command from blocking AI agent workflows from starting

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e39d3215fc8330bf234c2529fceec8