### PR TITLE
Handle missing summary files in architect workflow

### DIFF
--- a/.github/workflows/agent-architect.yml
+++ b/.github/workflows/agent-architect.yml
@@ -100,9 +100,15 @@ PLAN
             )
 
           printf '%s\n' "$summary"
-          printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
-          {
-            echo "plan<<EOF"
-            printf '%s\n' "$summary"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+              echo "plan<<EOF"
+              printf '%s\n' "$summary"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
## Summary
- guard writing to GITHUB_STEP_SUMMARY and GITHUB_OUTPUT in the architect workflow
- prevent failures when those environment variables are unavailable in reusable contexts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a8db86248330a294578dcea8b8f1