### PR TITLE
Enable manual architect agent dispatch

### DIFF
--- a/.github/workflows/agent-architect.yml
+++ b/.github/workflows/agent-architect.yml
@@ -45,14 +45,21 @@ jobs:
           OBJECTIVE: ${{ inputs.objective }}
           ARCHITECTURE_CONTEXT: ${{ inputs.architecture_context }}
           COLLABORATION_NOTES: ${{ inputs.collaboration_notes }}
+          DISPATCH_OBJECTIVE: ${{ github.event.inputs.objective }}
+          DISPATCH_CONTEXT: ${{ github.event.inputs.architecture_context }}
+          DISPATCH_COLLABORATION: ${{ github.event.inputs.collaboration_notes }}
         run: |
           set -euo pipefail
-          objective="${OBJECTIVE:-Ingen specifik målsättning angiven.}"
-          context_value="${ARCHITECTURE_CONTEXT:-}"
+          objective_source="${OBJECTIVE:-${DISPATCH_OBJECTIVE:-}}"
+          objective="${objective_source:-Ingen specifik målsättning angiven.}"
+
+          context_source="${ARCHITECTURE_CONTEXT:-${DISPATCH_CONTEXT:-}}"
+          context_value="${context_source:-}"
           if [ -z "$context_value" ]; then
             context_value="Ingen ytterligare kontext angiven."
           fi
-          collaboration_value="${COLLABORATION_NOTES:-}"
+          collaboration_source="${COLLABORATION_NOTES:-${DISPATCH_COLLABORATION:-}}"
+          collaboration_value="${collaboration_source:-}"
           if [ -z "$collaboration_value" ]; then
             collaboration_value="Inga samarbetsnoteringar angivna."
           fi
@@ -100,9 +107,15 @@ PLAN
             )
 
           printf '%s\n' "$summary"
-          printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
-          {
-            echo "plan<<EOF"
-            printf '%s\n' "$summary"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+              echo "plan<<EOF"
+              printf '%s\n' "$summary"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -144,6 +144,17 @@ To operationalize the virtual team defined in `docs/28_ai_agent_team.md`, dedica
 
 Each workflow accepts three text-based inputs (`objective` plus two optional context fields tailored to the role) and renders a structured checklist aligned with the responsibilities and ceremonies described in the AI agent team playbook. This makes it easy to orchestrate or audit agent contributions directly from GitHub Actions.
 
+To launch an agent manually from the repository root, supply the inputs when invoking the workflow with the GitHub CLI:
+
+```bash
+gh workflow run agent-architect.yml \
+  -f objective="Kartlägg integrationsmönster" \
+  -f architecture_context="Fokus på säkerhet och dataflöden" \
+  -f collaboration_notes="Synka med Developer om latency" 
+```
+
+Omit optional fields to fall back on the default guidance defined in the workflow.
+
 ## Release Types
 
 ### Unified Release Tags


### PR DESCRIPTION
## Summary
- add workflow input fallbacks so the architect agent can be triggered via manual dispatch as well as reusable calls
- document how to invoke the architect agent manually with the GitHub CLI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a8db86248330a294578dcea8b8f1