### PR TITLE
Refresh README with repository-wide overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,257 +1,70 @@
-# Architecture as Code - Book Project
+# Architecture as Code – Repository Overview
 
-A comprehensive book about Architecture as Code, with practical examples and case studies.
+This repository is the working space for the "Architecture as Code" publishing initiative. It combines long-form book content, presentation and whitepaper pipelines, and a React + TypeScript dashboard that showcases the material. The goal is to treat all deliverables as code: every artifact is generated, validated, and released automatically from this single source of truth.
 
-## 📚 About the Book
+## 📦 Core Deliverables
+- **Book** – 27 chapter manuscript with diagrams and supporting assets located in `docs/`.
+- **Presentation Pack** – Speaker-ready slide decks produced per release in `releases/presentation/` and `templates/`.
+- **Whitepapers** – Chapter-specific HTML whitepapers rendered through the automation workflows in `releases/whitepapers/`.
+- **Static Website** – React-powered documentation and dashboard bundled from the `src/` application and the `public/` assets directory.
 
-This book covers Architecture as Code from fundamental principles to advanced implementation, with a focus on practical application.
+## 🗂️ Repository Structure
+| Path | Purpose |
+| --- | --- |
+| `docs/` | Markdown chapters, mermaid diagrams, and the LaTeX-friendly build scripts for the book PDF. |
+| `releases/` | Canonical outputs for book, presentation, whitepaper, and website bundles grouped by release cycle. |
+| `templates/` | Hand-crafted slide and document templates that seed new release assets. |
+| `scripts/` | Python utilities for link validation, asset checks, and release automation. |
+| `src/` | React + TypeScript dashboard built with Vite, Tailwind CSS, and shadcn/ui components. |
+| `public/` | Static assets consumed by the dashboard (favicons, manifest, imagery). |
+| `exports/` | Intermediate build artifacts shared across release steps. |
+| `tests/` | Automated checks for documentation structure and dashboard behaviour. |
+| Root guides (`*.md`) | Project playbooks, retrospectives, and status reports for content, localization, branding, and automation. |
 
-### Target Audience
-- system architects
-- DevOps Engineers  
-- Developers
-- Project Managers
-- IT Managers
+## ⚙️ Automation & Tooling
+- **GitHub Actions** (`.github/workflows/`) orchestrate unified build-and-release jobs, standalone whitepaper generation, presentation builds, and content validation.
+- **Node.js Tooling** uses Vite for bundling, Tailwind for styling, and ESLint/TypeScript for quality gates defined in `package.json`, `tsconfig*.json`, and `eslint.config.js`.
+- **Python Scripts** automate documentation health checks such as `scripts/verify_links.py` with configurable outputs.
+- **Shell Utilities** like `build_release.sh` and `docs/build_book.sh` provide reproducible local builds mirroring CI behaviour.
 
-### Contents
-27 chapters covering:
-- Fundamental principles of Architecture as Code
-- Version control and code structures
-- Cloud architecture and automation
-- Security and compliance
-- CI/CD and testing strategies
-- Organizational transformation
-- Practical case studies and implementations
-
-## 🛠️ Technical implementation
-
-### Structure
-```
-docs/                    # Book content
-├── *.md                # Markdown chapters (01_inledning.md, 02_grundlaggande_principer.md, etc.)
-├── images/             # Mermaid diagrams
-│   └── *.mmd          # Mermaid source files
-├── build_book.sh      # Local build script
-└── arkitektur_som_kod.pdf  # Generated book
-
-releases/                 # All deliverables organized for distribution
-├── book/               # Book formats (PDF, EPUB, DOCX)
-├── presentation/       # Presentation materials (PPTX, PDF)
-├── whitepapers/        # HTML whitepapers per chapter
-└── website/           # Complete static website
-
-.github/workflows/      # CI/CD automation
-├── unified-build-release.yml    # Unified comprehensive workflow (ALL formats)
-├── generate-whitepapers.yml    # Standalone whitepaper generation
-├── generate-presentations.yml  # Standalone presentation generation  
-└── content-validation.yml      # Repository content validation
-```
-
-### Release Deliverables
-
-All releases are automatically generated and published through GitHub Actions workflows.
-
-**Book Formats:**
-- PDF (using Pandoc + Eisvogel template)
-- EPUB (electronic book format)
-- DOCX (Microsoft Word format)
-
-**Presentation Materials:**
-- PowerPoint (PPTX) with speaker notes
-- PDF version for easy sharing
-- Individual chapter slides
-
-**Whitepapers:**
-- HTML whitepapers for each chapter
-- Responsive design for web publishing
-- Includes diagrams and code examples
-
-**Website:**
-- Complete static site with all content
-- Chapter navigation
-- Search functionality
-- Mobile-responsive design
-
-## 🚀 Building the Book
-
-### Prerequisites
-
-**For PDF Generation:**
+## 🚀 Getting Started
+### Install Dependencies
 ```bash
-# Install Pandoc (3.1.9 or later)
-wget https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-amd64.deb
-sudo dpkg -in pandoc-3.1.9-1-amd64.deb
+# Install JavaScript dependencies (React dashboard & tooling)
+npm install --legacy-peer-deps
 
-# Install LaTeX (for PDF generation)
-sudo apt-get update
-sudo apt-get install -y texlive-xetex texlive-fonts-recommended texlive-plain-generic
-
-# Install Mermaid CLI (for diagram conversion)
+# Optional: global tools for diagram and document generation
 npm install -g @mermaid-js/mermaid-cli
 ```
 
-**For Web Dashboard:**
+### Build the Manuscript
 ```bash
-# Install Node.js dependencies
-# Note: Requires --legacy-peer-deps due to @toast-ui/react-editor React 17 compatibility
-npm install --legacy-peer-deps
+python3 generate_book.py      # Refresh markdown sources from templates
+cd docs && ./build_book.sh    # Render PDF with diagrams via Pandoc + LaTeX
 ```
 
-**Known Security Issues:**
-- The `markdown` package has a ReDoS vulnerability (GHSA-wx77-rp39-c6vg) with no fix available. The impact is minimal as it's only used for static content rendering.
-- Some dependencies require `--legacy-peer-deps` due to React version compatibility. See [package.json](package.json) for details.
-
-### Build Commands
-
-**Generate Book Content:**
+### Run the Dashboard
 ```bash
-# Generate all markdown files
-python3 generate_book.py
-
-# Build PDF with diagrams
-cd docs && ./build_book.sh
+npm run dev    # Start Vite dev server
+npm run build  # Create production bundle in dist/
 ```
 
-**Run Web Dashboard:**
+### End-to-End Release
 ```bash
-# Development server
-npm run dev
-
-# Production build
-npm run build
+./build_release.sh            # Generate book, presentations, whitepapers, and web bundle
 ```
 
-**Generate All Formats:**
-```bash
-# Complete release build
-./build_release.sh
-```
+## 🧭 Documentation Map
+The root directory holds curated guidance that documents the state of the project:
+- `ANALYSIS_SUMMARY.md`, `CODEBASE_ANALYSIS.md`, and `REMAINING_WORK.md` outline technical findings and TODOs.
+- `BRAND_GUIDELINES.md`, `VISUAL_ELEMENTS_GUIDE.md`, and `DESIGN_SYSTEM.md` define visual identity and UI standards.
+- `TRANSLATION_PROJECT.md`, `ENGLISH_STATUS.md`, and related files track localization and editorial progress.
+- `DOCS_PROTECTION.md`, `TEST_WORKFLOW.md`, and `CICD_SETUP.md` cover process governance and automation.
 
-## 📖 Chapter Overview
-
-1. **Introduction** - Introduction to Architecture as Code
-2. **Fundamental Principles** - Core principles of Architecture as Code
-3. **Version Control** - Version management and code structure
-4. **ADR** - Architecture Decision Records
-5. **Automation & CI/CD** - Automation, DevOps and CI/CD
-6. **Cloud Architecture** - Cloud architecture as code
-7. **Containerization** - Containerization and orchestration
-8. **Microservices** - Microservices and API design
-9. **Security** - Security in Architecture as Code
-10. **Policy as Code** - Policy as code and security automation
-11. **Compliance** - Compliance and regulatory adherence
-12. **Testing** - Testing strategies for architecture code
-13. **implementation** - Practical implementation
-14. **Cost Optimization** - Cost optimization and resource management
-15. **Migration** - Migration from traditional infrastructure
-16. **Organizational Change** - Organizational change and cultural transformation
-17. **Team Structure** - Team structure and competencies
-18. **Digitalization** - Digitalization and business value
-19. **Lovable Mockups** - Lovable mockups and user-centered design
-20. **Future Trends** - Future trends in Architecture as Code
-21. **Best Practices** - Best practices and lessons learned
-22. **Conclusion** - Conclusion
-23. **Glossary** - Glossary of terms
-24. **About Authors** - About the authors
-25. **Future Development** - Future development and roadmap
-26. **Appendix** - Code examples and templates
-27. **Technical Architecture** - Technical architecture of the book
-
-## 🎨 React Dashboard
-
-The project includes a React-based web dashboard that provides:
-- Book project status overview
-- Chapter structure visualization
-- CI/CD pipeline status
-- Build artifacts and downloads
-
-**Technologies:**
-- React + TypeScript
-- Vite (build tool)
-- Tailwind CSS + shadcn/ui components
-- React Router
-- react-syntax-highlighter with Prism.js (code syntax highlighting)
-
-**Code Syntax Highlighting:**
-
-The book preview feature uses Prism.js via `react-syntax-highlighter` to provide syntax highlighting for code blocks with a dark theme (VS Code Dark+). Supported languages include:
-- JavaScript/TypeScript
-- Python
-- YAML
-- JSON
-- Bash/Shell
-- Dockerfile
-- And many more...
-
-Code blocks in markdown are automatically detected and highlighted based on the language identifier (e.g., ` ```yaml`, ` ```python`, ` ```javascript`).
-
-## 🔄 CI/CD Workflows
-
-All builds are automated through GitHub Actions:
-
-### Unified Build & Release
-Triggers on push to main branch or docs changes:
-- Builds all book formats (PDF, EPUB, DOCX)
-- Generates presentations
-- Creates whitepapers
-- Builds static website
-- Creates GitHub release with all artifacts
-
-### Individual Workflows
-- `generate-whitepapers.yml` - Standalone whitepaper generation
-- `generate-presentations.yml` - Standalone presentation generation
-- `content-validation.yml` - Validates markdown and structure
-
-## 📝 Contributing
-
-To contribute to the book content:
-
-1. Edit markdown files in `docs/` directory
-2. Follow the existing structure and style
-3. Test locally with `python3 generate_book.py && cd docs && ./build_book.sh`
-4. Submit a pull request
-
-## 🔍 Link Verification
-
-The repository includes a comprehensive link verification tool to ensure all links in documentation are valid.
-
-**Run link verification:**
-```bash
-python3 scripts/verify_links.py
-```
-
-This generates three reports:
-- `link-verification-report.md` - Markdown summary
-- `link-verification-report.html` - Interactive HTML report
-- `link-verification-report.json` - Machine-readable JSON
-
-**Advanced options:**
-```bash
-# Custom timeout for slow connections
-python3 scripts/verify_links.py --timeout 20
-
-# Verbose output
-python3 scripts/verify_links.py --verbose
-
-# Custom output location
-python3 scripts/verify_links.py --output reports/links
-```
-
-For complete documentation, see [LINK_VERIFICATION.md](LINK_VERIFICATION.md)
+## 🤝 Contributing
+1. Update the relevant markdown chapters or dashboard components.
+2. Run local validation (`python3 scripts/verify_links.py` and/or project build commands above).
+3. Commit changes with clear messages and open a pull request that references the release checklist in `WORKFLOWS.md`.
 
 ## 📄 License
-
-This book project is maintained by Geonit AB.
-
-## 🔗 Related Resources
-
-- [Architecture as Code Principles](https://www.thoughtworks.com/radar/techniques/architecture-as-code)
-- [Infrastructure as Code Best Practices](https://www.terraform.io/docs)
-- [Documentation as Code](https://www.writethedocs.org/guide/docs-as-code/)
-
----
-
-## 🌍 Language
-
-All book content is in English.
-
+The "Architecture as Code" materials are maintained and published by Geonit AB. Please consult project leads for licensing details prior to distribution.


### PR DESCRIPTION
## Summary
- replace the previous book-focused readme with a holistic description of all deliverables
- document the major directories, automation tooling, and supporting guides in the repository
- streamline setup instructions for building the manuscript, dashboard, and release pipeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3acd7db608330b0e3ee919978ab1c