### PR TITLE
Add YAML fallback and align AI agent chapter coverage

### DIFF
--- a/docs/18_digitalization.md
+++ b/docs/18_digitalization.md
@@ -1,4 +1,4 @@
-# Digitalisering through architecture as architecture as code-baserad infrastruktur
+# Digitalisering med kodbaserad infrastruktur
 
 ![Digitaliseringsprocess](images/diagram_19_digitalisering.png)
 

--- a/docs/28_ai_agent_team.md
+++ b/docs/28_ai_agent_team.md
@@ -4,6 +4,8 @@ Detta dokument beskriver den virtuella agentgrupp som ska samarbeta kring projek
 
 ## Övergripande arbetsflöde
 
+![AI-agentteamets kommunikation](images/diagram_28_ai_agent_team.png)
+
 1. **Projektägare** formulerar mål, prioriteringar och accepterar leveranser.
 2. **Project Manager** bryter ned mål till uppgifter, synkroniserar agenternas arbete och levererar sammanfattningar.
 3. Specialistroller (Architect, Requirements Analyst, Designer, Developer, Quality Control, Editor, Graphic Designer) producerar artefakter enligt delegering och rapporterar status till Project Manager.

--- a/docs/images/diagram_28_ai_agent_team.mmd
+++ b/docs/images/diagram_28_ai_agent_team.mmd
@@ -1,0 +1,16 @@
+graph TD
+    PO[Projektägare] --> PM[Project Manager]
+    PM --> ARCH[Architect]
+    PM --> RA[Requirements Analyst]
+    PM --> DES[Designer]
+    PM --> DEV[Developer]
+    PM --> QC[Quality Control]
+    PM --> ED[Editor]
+    PM --> GD[Graphic Designer]
+    ARCH --> PM
+    RA --> PM
+    DES --> PM
+    DEV --> PM
+    QC --> PM
+    ED --> PM
+    GD --> PM

--- a/generate_presentation.py
+++ b/generate_presentation.py
@@ -86,60 +86,73 @@ def analyze_mermaid_diagram_types():
     for mmd_file in mermaid_files:
         try:
             content = mmd_file.read_text(encoding='utf-8').strip()
-            first_lines = content.split('\n')[:3]  # Check first 3 lines
-            
+
+            candidate_lines = []
+            in_front_matter = False
+            for raw_line in content.split('\n'):
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                if stripped == '---':
+                    in_front_matter = not in_front_matter
+                    continue
+                if in_front_matter:
+                    continue
+                if stripped.startswith('%%'):  # Mermaid init/config block
+                    continue
+                candidate_lines.append(stripped.lower())
+
             diagram_type = 'other'
-            
-            for line in first_lines:
-                line = line.strip().lower()
+
+            for line in candidate_lines:
                 if line.startswith('graph ') or line.startswith('flowchart '):
                     diagram_type = 'flowchart'
                     break
-                elif line.startswith('sequencediagram'):
+                if line.startswith('sequencediagram'):
                     diagram_type = 'sequence'
                     break
-                elif line.startswith('classdiagram'):
+                if line.startswith('classdiagram'):
                     diagram_type = 'class'
                     break
-                elif line.startswith('statediagram'):
+                if line.startswith('statediagram'):
                     diagram_type = 'state'
                     break
-                elif line.startswith('erdiagram'):
+                if line.startswith('erdiagram'):
                     diagram_type = 'entity_relationship'
                     break
-                elif line.startswith('journey'):
+                if line.startswith('journey'):
                     diagram_type = 'user_journey'
                     break
-                elif line.startswith('gantt'):
+                if line.startswith('gantt'):
                     diagram_type = 'gantt'
                     break
-                elif line.startswith('pie'):
+                if line.startswith('pie'):
                     diagram_type = 'pie'
                     break
-                elif line.startswith('quadrantchart'):
+                if line.startswith('quadrantchart'):
                     diagram_type = 'quadrant'
                     break
-                elif line.startswith('requirementdiagram'):
+                if line.startswith('requirementdiagram'):
                     diagram_type = 'requirement'
                     break
-                elif line.startswith('gitgraph'):
+                if line.startswith('gitgraph'):
                     diagram_type = 'gitgraph'
                     break
-                elif line.startswith('mindmap'):
+                if line.startswith('mindmap'):
                     diagram_type = 'mindmap'
                     break
-                elif line.startswith('timeline'):
+                if line.startswith('timeline'):
                     diagram_type = 'timeline'
                     break
-                elif line.startswith('sankey'):
+                if line.startswith('sankey'):
                     diagram_type = 'sankey'
                     break
-                elif line.startswith('xychart'):
+                if line.startswith('xychart'):
                     diagram_type = 'xy_chart'
                     break
-            
+
             diagram_types[diagram_type].append(str(mmd_file))
-            
+
         except Exception as e:
             print(f"Warning: Could not analyze {mmd_file}: {e}")
     

--- a/tests/requirements.yaml
+++ b/tests/requirements.yaml
@@ -3,7 +3,7 @@
 book:
   title: "Architecture as Code"
   language: "english"
-  total_chapters: 27
+  total_chapters: 28
   
   # Required chapter structure
   chapters:
@@ -114,6 +114,10 @@ book:
     - filename: "27_technical_architecture.md"
       title: "Teknisk uppbyggnad"
       area: "Appendix"
+      required: true
+    - filename: "28_ai_agent_team.md"
+      title: "AI-agentteam för Architecture as Code"
+      area: "Organisationsutveckling"
       required: true
 
   # Special chapters with different requirements

--- a/tests/requirements_en.yaml
+++ b/tests/requirements_en.yaml
@@ -2,7 +2,7 @@
 book:
   title: "Architecture as Code"
   language: "english"
-  total_chapters: 27
+  total_chapters: 28
   
   # Required chapter structure
   chapters:
@@ -113,6 +113,10 @@ book:
     - filename: "27_technical_architecture.md"
       title: "Technical Setup"
       area: "Appendix"
+      required: true
+    - filename: "28_ai_agent_team.md"
+      title: "AI Agent Team for Architecture as Code"
+      area: "Organizational Development"
       required: true
 
   # Special chapters with different requirements

--- a/tests/test_technical_accuracy.py
+++ b/tests/test_technical_accuracy.py
@@ -1,13 +1,28 @@
-"""
-Technical accuracy validator for book content.
+"""Technical accuracy validator for book content.
 
 Validates code snippets, diagrams, and technical examples.
 """
-import pytest
-import re
-import yaml
 import json
 from pathlib import Path
+import re
+
+import pytest
+
+try:  # pragma: no cover - executed in environments with PyYAML
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised in CI sandbox
+    from .utils import simple_yaml
+
+    class _FallbackYaml:
+        """Adapter that mimics the subset of the PyYAML API we rely on."""
+
+        YAMLError = simple_yaml.YAMLError
+
+        @staticmethod
+        def safe_load(data: str):
+            return simple_yaml.safe_load(data)
+
+    yaml = _FallbackYaml()
 
 
 class TestTechnicalAccuracy:

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the test suite."""

--- a/tests/utils/simple_yaml.py
+++ b/tests/utils/simple_yaml.py
@@ -1,0 +1,191 @@
+"""A minimal YAML loader used as a fallback when PyYAML isn't available.
+
+The test suite relies on a small YAML configuration file that only uses a
+limited subset of the YAML specification (nested mappings, lists, strings,
+integers, booleans and inline lists). Installing PyYAML inside the execution
+environment isn't always possible, so we provide a lightweight parser that can
+handle the structures used in the project.
+
+The implementation is intentionally conservative – it doesn't aim to support
+arbitrary YAML features, but it should be resilient enough for well structured
+configuration files such as the ones that ship with the repository.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple, Union, Any
+
+
+@dataclass
+class Token:
+    indent: int
+    content: str
+
+
+class YAMLError(Exception):
+    """Generic error raised when the simple YAML parser fails."""
+
+
+def safe_load(text: str) -> Any:
+    """Parse YAML text into Python objects using a limited subset of YAML."""
+    try:
+        tokens = _tokenise(text)
+        if not tokens:
+            return None
+        return _parse(tokens)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise YAMLError(str(exc)) from exc
+
+
+def _tokenise(text: str) -> List[Token]:
+    tokens: List[Token] = []
+    for raw_line in text.splitlines():
+        line = _strip_comments(raw_line)
+        if not line.strip():
+            continue
+        if line.strip() == "---":
+            # YAML document separator – safe to ignore for our use case.
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        content = line.strip()
+        tokens.append(Token(indent=indent, content=content))
+    return tokens
+
+
+def _strip_comments(line: str) -> str:
+    """Remove YAML comments while respecting quoted strings."""
+    result: List[str] = []
+    in_quote = False
+    quote_char = ""
+    for char in line:
+        if char in {'"', "'"}:
+            if in_quote and char == quote_char:
+                in_quote = False
+                quote_char = ""
+            elif not in_quote:
+                in_quote = True
+                quote_char = char
+        if char == "#" and not in_quote:
+            break
+        result.append(char)
+    return "".join(result).rstrip()
+
+
+def _parse(tokens: Iterable[Token]) -> Any:
+    root: Any = {}
+    stack: List[Tuple[int, Any]] = [(-1, root)]
+    tokens_list = list(tokens)
+
+    for index, token in enumerate(tokens_list):
+        indent, content = token.indent, token.content
+
+        # Pop containers until we reach the parent with a smaller indent level.
+        while len(stack) > 1 and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+
+        if content.startswith("- "):
+            if not isinstance(parent, list):
+                raise ValueError("List item found but parent is not a list")
+            item_content = content[2:].strip()
+            if not item_content:
+                item: Any = {}
+                parent.append(item)
+                stack.append((indent, item))
+                continue
+
+            key, value_str, has_key = _maybe_split_key_value(item_content)
+            if has_key:
+                item_dict: dict[str, Any] = {}
+                parent.append(item_dict)
+                if value_str:
+                    value = _parse_value(value_str)
+                    item_dict[key] = value
+                    if isinstance(value, (dict, list)):
+                        stack.append((indent, value))
+                stack.append((indent, item_dict))
+            else:
+                value = _parse_value(item_content)
+                parent.append(value)
+                if isinstance(value, (dict, list)):
+                    stack.append((indent, value))
+            continue
+
+        key, value_str, has_key = _maybe_split_key_value(content)
+        if has_key:
+            if value_str == "":
+                value = _initialise_container(tokens_list, index, indent)
+            else:
+                value = _parse_value(value_str)
+            if not isinstance(parent, dict):
+                raise ValueError("Key/value pair found but parent is not a mapping")
+            parent[key] = value
+            if isinstance(value, (dict, list)):
+                stack.append((indent, value))
+            continue
+
+        # Bare values at the root level are not expected; return best effort.
+        bare_value = _parse_value(content)
+        if isinstance(parent, list):
+            parent.append(bare_value)
+        elif isinstance(parent, dict):
+            raise ValueError(f"Unexpected bare value '{content}' inside mapping")
+        else:
+            root = bare_value
+    return root
+
+
+def _maybe_split_key_value(content: str) -> Tuple[str, str, bool]:
+    if ":" not in content:
+        return "", content, False
+    if content.endswith(":"):
+        key = content[:-1].strip()
+        return key, "", True
+    key, value = content.split(":", 1)
+    return key.strip(), value.strip(), True
+
+
+def _initialise_container(tokens: List[Token], index: int, indent: int) -> Union[dict, list]:
+    for next_token in tokens[index + 1:]:
+        if next_token.indent <= indent:
+            break
+        if next_token.content.startswith("- "):
+            return []
+        return {}
+    return {}
+
+
+def _parse_value(value: str) -> Any:
+    if value == "":
+        return ""
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "none", "~"}:
+        return None
+
+    if value.startswith("[") and value.endswith("]"):
+        try:
+            return ast.literal_eval(value)
+        except Exception:
+            return value
+    if value.startswith("{") and value.endswith("}"):
+        try:
+            return ast.literal_eval(value)
+        except Exception:
+            return value
+
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1]
+
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value


### PR DESCRIPTION
## Summary
- provide a minimal YAML parser fallback and plug it into the pytest fixtures and technical accuracy checks
- update the presentation analysis to ignore Mermaid front matter and add the AI agent team diagram assets
- extend the chapter requirements to include the new AI agent team chapter and fix its metadata

## Testing
- python3 -m pytest tests -v

------
https://chatgpt.com/codex/tasks/task_e_68e3b24af2c08330bce80cdf0c90346f