### PR TITLE
Translate and expand governance as code guidance

### DIFF
--- a/docs/05_automation_devops_cicd.md
+++ b/docs/05_automation_devops_cicd.md
@@ -72,6 +72,57 @@ This holistiska approach requires DevOps practices as can handle komplexiteten o
 
 **Full traceability:** From business requirements to implemented architecture must each change vara traceable through entire system landscape. This includes impact on applications, data, infrastructure and organizational processes.
 
+### Deep dive: Governance as Code in practice
+
+Governance as Code is more than writing policy statements in a declarative syntax; it relocates the entire governance model for architecture and technology into executable source code. When principles, target architectures, standards, and decision processes are handled as code, organisations gain a new way to coordinate control, risk management, and innovation. For Swedish organisations operating under strict regulation—from GDPR and NIS2 to sector guidance from Finansinspektionen or the National Board of Health and Welfare—this creates a disciplined path to automate, audit, and reuse governance with the same rigour as application logic. Codified rules can be versioned, peer-reviewed, and tested before they influence production, reducing the risk of manual interpretation and ensuring consistent compliance.
+
+A practical starting point is to establish a shared repository for architectural guidance where policy definitions, decisions, and exceptions are captured in machine-readable form. Architecture principles can be expressed as YAML or JSON structures that describe the patterns allowed in different domains—from security levels for APIs to data-classification requirements. These artefacts can be consumed by validation tools in the CI/CD pipeline to approve or block changes automatically. By mapping each policy to a unique identifier and linking it to concrete control points such as test cases or Open Policy Agent (OPA) rules, teams clarify what is being verified and why.
+
+To keep governance alive, the policy lifecycle must follow the same change-management flow as any other code: proposals through pull requests, technical and legal review, automated testing, and traceable releases into production. Version history then gives auditors visibility into when a control was introduced, the discussions that preceded the decision, and the environments it affected. Swedish organisations can link these commits to archived decisions or risk assessments to strengthen the connection between business governance and technical execution.
+
+A recurring obstacle is that governance functions and engineering teams work in separate toolchains. Governance as Code requires these worlds to converge. Modelling languages such as C4, ArchiMate, or internal taxonomies can be translated into code representations that feed pipeline steps analysing whether proposed architecture changes violate dependency principles or structural guardrails. If a solution introduces a new data flow that crosses national borders, the policy can automatically flag the need for a Data Protection Impact Assessment (DPIA) before deployment proceeds.
+
+Automated governance must also be measurable. Introducing governance metrics—such as policy-compliance rate, time-to-approved-exception, or deployments blocked by policy—gives leadership insight into how well the rule set performs. These metrics can be visualised in dashboards and linked to OKRs or risk indicators. Pipeline telemetry highlights bottlenecks, for example repeated violations of the same rule, signalling when a policy should be clarified or a team needs targeted training.
+
+Exception management is another critical pillar. Every rule has legitimate deviations, and in a Governance as Code model the exception workflow should likewise be codified. Structured requests—perhaps a YAML file describing the risk, duration, compensating controls, and approvals—allow pipelines to determine automatically whether a deployment may continue even when a guardrail is breached. Exceptions are logged, time boxed, and must be reviewed before they expire, creating transparency and enabling security or compliance teams to follow up proactively.
+
+Larger organisations benefit from an explicit ownership structure. Each policy needs a steward who keeps the rule current and relevant. A federated model works well: central teams define shared control frameworks while product or domain teams augment them with detailed rules. Using inheritance or module composition in the policy code lets local variations coexist with global requirements, balancing autonomy and control.
+
+Integration with external sources strengthens governance. Financial institutions can ingest updated regulations from Finansinspektionen and automatically generate new pipeline control points, while public-sector entities can connect to Kammarkollegiet framework agreements to validate procurement constraints. Machine-readable compliance formats such as OSCAL make it possible to align technical policies with formal assurance frameworks, simplifying audits and reporting.
+
+Finally, treat Governance as Code as a product. It deserves a roadmap, backlog, service levels, and feedback loops with its users—architects, developers, security specialists, and business representatives. Applying product management practices ensures the governance framework continues delivering value, evolves with new needs, and avoids becoming a static obstacle course. Managing governance with the same modern engineering techniques as the rest of the software landscape builds a resilient platform for sustainable digitalisation where innovation and compliance advance together.
+
+### Policy lifecycle automation and continuous assurance
+
+Codifying the policy lifecycle introduces repeatable stages that can be automated end-to-end. A policy proposal begins as a pull request containing the policy definition, metadata about regulatory drivers, and references to impacted domains. Static analysis checks validate the syntax, mandatory metadata fields, and link integrity. Automated reviewers—implemented through GitHub Apps or GitLab bots—enforce segregation of duties by ensuring that the policy author cannot approve their own change. Once merged, release pipelines publish the policy to a central registry, update documentation sites, and trigger downstream validations so that dependent teams are alerted before the new requirement becomes enforceable.
+
+Continuous assurance extends this lifecycle beyond approval. Scheduled pipeline runs re-validate production environments against the policy catalogue and compare runtime telemetry with declared guardrails. Drift detection scripts flag any infrastructure or application component that falls out of compliance, generating issues directly in the owning team’s backlog. For Swedish organisations subject to supervisory reporting, these automated checks supply evidence packs—timestamped logs, compliance dashboards, and remediation tickets—that can be shared with regulators without manual consolidation.
+
+### Measuring and iterating on governance value
+
+Quantitative feedback closes the loop between governance intent and organisational outcomes. Key metrics include:
+
+- **Governance lead time:** elapsed time from policy proposal to production enforcement. Tracking this metric exposes bottlenecks in review or testing.
+- **Prevented incidents:** number of pipeline stops or runtime alerts that blocked non-compliant changes, linked to avoided risk scenarios.
+- **Cost of compliance:** effort hours or cloud spend associated with implementing new controls, helping prioritise automation investments.
+- **Team sentiment:** qualitative surveys embedded in retrospectives or governance reviews to understand perceived friction.
+
+Dashboards aggregating these indicators enable CISO, CIO, and enterprise-architecture leaders to prioritise backlog items, sunset ineffective controls, and justify investments in automation platforms. Coupling metrics with hypothesis-driven experiments—such as piloting a new policy pattern with one product team before rolling it out organisation-wide—keeps the governance system adaptive instead of rigid.
+
+### Federated governance operating model
+
+An effective Governance as Code programme balances central authority with local empowerment. Central architecture or risk teams define baseline policies, manage the shared tooling, and curate reusable modules (for instance, a standard encryption policy package). Domain teams extend these modules with context-specific rules, implement compensating controls, and own the exception backlog for their products. Shared libraries and templates reduce duplication while code review gates maintain architectural coherence. Communities of practice and lunch-and-learn sessions ensure that policy stewards across domains exchange lessons learned, aligning interpretations and keeping terminology consistent.
+
+Contractual interfaces between central and domain teams can be codified using service-level objectives (SLOs). For example, central teams commit to reviewing policy changes within five business days, while domain teams agree to remediate high-severity violations within 48 hours. Monitoring these SLOs through automated status pages fosters trust and transparency across the governance network.
+
+### Integrating governance with developer experience
+
+Governance controls should appear inside the developer workflow rather than as after-the-fact audits. IDE extensions, pre-commit hooks, and ChatOps assistants surface relevant policies at design time. When developers submit merge requests, bot comments summarise the policies evaluated, the evidence collected, and any remediation guidance. Feature-flag frameworks can roll out new policies gradually, limiting enforcement to canary teams until confidence grows. Providing self-service sandboxes where teams can validate their changes against the full policy suite encourages experimentation while keeping production safe.
+
+### Aligning governance code with legal and procurement ecosystems
+
+Legal, procurement, and risk-management teams often maintain their own document-centric processes. Bridging these disciplines requires translation layers between code and contracts. Structured policy metadata—such as regulation references, clause numbers, or procurement thresholds—enables automated generation of legal briefs and supplier questionnaires. When regulators publish updates, notification pipelines create issues for relevant policy stewards, attach the official documents, and propose baseline changes. Embedding governance code into procurement workflows ensures that new vendors, cloud services, or software licences trigger compliance checks before contracts are signed, avoiding late-stage surprises.
+
 **Svenska efterlevnadsintegration:** GDPR, MSB-security requirements and sektorsspecifik reglering integreras naturligt in arkitekturkoden rather than as externa controls.
 
 **Gemensam arkitekturutveckling:** Svensk konsensuskultur be applied at arkitekturevolution where all stakeholders contributes to arkitekturkodbasen through transparent, demokratiska processes.


### PR DESCRIPTION
## Summary
- translated the existing governance-as-code deep dive into English to retain the original intent while meeting language expectations
- added detailed sections covering policy lifecycle automation, quantitative governance metrics, federated ownership models, developer experience integration, and legal/procurement alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c9fe09f08330ba64310a556aa253