### PR TITLE
Add design tokens chapter to documentation

### DIFF
--- a/docs/29_design_tokens.md
+++ b/docs/29_design_tokens.md
@@ -1,0 +1,132 @@
+# Design Tokens as the Backbone of Cross-Channel Experience
+
+Design tokens provide the canonical vocabulary that connects branding intent, design decisions, and implementation details across every channel where the organization communicates—web applications, dynamically generated PDFs, slide presentations, and emerging interfaces. By treating tokens as executable design requirements, Architecture as Code teams can ensure that aesthetic, accessibility, and interaction rules remain synchronized regardless of the rendering technology.
+
+## Why Design Tokens Matter for Architecture as Code
+
+Design tokens translate human-centered design guidance into technology-neutral building blocks. Each token captures an atomic decision—colors, typography, spacing, animation timing, data visualization palettes—and stores it in a format that both designers and developers can consume. A well-governed token system:
+
+- **Creates a shared source of truth** for visual and behavioral rules, enabling design hand-offs that are traceable and version-controlled.
+- **Supports automated distribution** into codebases, documentation, and asset pipelines, eliminating manual reimplementation.
+- **Allows architectural guardrails** to be enforced programmatically, just like policy-as-code, ensuring that every surface respects brand and accessibility criteria.
+
+Within Architecture as Code programs, tokens become another artifact alongside infrastructure templates, policy definitions, and compliance scripts. They can be versioned, reviewed, and tested, and they participate in CI/CD pipelines to guarantee that design decisions are applied consistently.
+
+## Token Taxonomy and Governance
+
+A comprehensive token system is layered so that changes propagate in a controlled manner:
+
+1. **Core tokens**: Immutable foundations that express semantic intent such as `color.brand.primary`, `font.family.base`, or `spacing.scale.04`. These map directly to brand guidelines and accessibility rules.
+2. **Derived tokens**: Contextual variations such as `color.background.surface`, `border.radius.interactive`, or `shadow.elevation.medium`. Derived tokens reference core values, making it possible to adjust the brand without rewriting components.
+3. **Component tokens**: Application- or platform-specific overrides such as `button.primary.background.rest` or `table.header.text.strong`. These tokens allow precise tuning while keeping inheritance chains clear.
+4. **Mode tokens**: Variants for dark mode, high contrast, motion-reduced contexts, and platform conventions (web vs. PDF vs. presentation).
+
+Governance should mirror infrastructure change management. Token repositories benefit from:
+
+- **Design pull requests** with review gates for brand stewards, accessibility experts, and engineering leads.
+- **Automated validation** that checks naming conventions, contrast ratios, and downstream build results.
+- **Change logs and release notes** so consuming teams can plan adoption.
+- **Backwards compatibility policies** that communicate deprecations and migration paths for renamed or removed tokens.
+
+## Cross-Platform Distribution
+
+Design tokens must flow into multiple rendering environments. A typical distribution pipeline looks like:
+
+1. **Authoring**: Designers define tokens in Figma or another design tool that exports JSON, YAML, or Style Dictionary formats.
+2. **Transformation**: CI scripts convert the canonical token file into platform-specific outputs—CSS variables, TypeScript constants, PDF styling directives, and presentation template manifests.
+3. **Packaging**: Each platform receives its own package or asset bundle, versioned via package managers (npm), artifact repositories, or direct Git submodules.
+4. **Verification**: Automated visual regression, accessibility checks, and formatting linting ensure parity across outputs.
+
+### Web Applications
+
+- Tokens convert into CSS custom properties, Tailwind configuration entries, or utility classes.
+- Component libraries bind ARIA attributes to semantic tokens, guaranteeing that state changes (hover, focus, disabled) align with the same color and motion guidance defined by design.
+- Storybook or similar tools can ingest tokens to generate interactive documentation for developers and QA.
+
+### PDFs and Print-Ready Content
+
+- Token outputs map to styling instructions in tools like Pandoc, LaTeX templates, or CSS for print.
+- Typography tokens ensure PDF exports maintain brand-approved font stacks and sizing relationships even when generated programmatically.
+- Color and spacing tokens inform infographics and charts, keeping data visualization consistent with web dashboards.
+
+### Slide Presentations
+
+- Presentation templates (e.g., PowerPoint, Google Slides) reference exported theme files where colors, typography, and spacing align with the token definitions.
+- Interactive motion tokens guide transitions and animations, providing consistency between live demos and recorded walkthroughs.
+- Automated template builders can regenerate slide masters whenever token versions change, preventing drift between marketing and product presentations.
+
+## Integration with Architecture Workflows
+
+Tokens fit naturally into an Architecture as Code toolchain:
+
+- **Version control**: Store token definitions alongside other infrastructure code in Git, enabling peer review, branching strategies, and audit trails.
+- **CI/CD**: Run token pipelines whenever design or brand changes are merged, propagating updates to all channels simultaneously.
+- **Testing**: Combine visual regression suites with accessibility tooling (e.g., Axe, Pa11y) to validate that token outputs meet compliance requirements.
+- **Documentation**: Generate automated style guides and architecture blueprints that embed live token values, ensuring the book, PDF deliverables, and online documentation are synchronized.
+
+### Example Token Definition (Style Dictionary JSON)
+
+```json
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "#0057B8", "comment": "Main blue, WCAG AA on white" }
+    },
+    "feedback": {
+      "success": { "value": "#1E8E3E" },
+      "error": { "value": "#B00020" }
+    }
+  },
+  "font": {
+    "size": {
+      "base": { "value": "16px" },
+      "scale": {
+        "sm": { "value": "14px" },
+        "lg": { "value": "20px" }
+      }
+    }
+  },
+  "elevation": {
+    "surface": {
+      "rest": { "value": "0 1px 3px rgba(0,0,0,0.12)" }
+    }
+  }
+}
+```
+
+This single source can generate CSS variables, SCSS maps, TypeScript typings, JSON schema for PDF generators, and theme descriptors for presentation software.
+
+## Enforcing ARIA Compliance Through Tokens
+
+Design tokens are powerful enablers for accessible experiences because they encapsulate the visual and interactive semantics that screen reader and assistive technology users rely on. By aligning tokens with ARIA states and patterns, teams can enforce accessibility rules at compile time and during runtime.
+
+1. **Semantic Naming**: Tokens such as `state.focus.outline` or `state.disabled.opacity` make it explicit that they are tied to `aria-focus`, `aria-selected`, or `aria-disabled` states. Component generators can map ARIA attributes directly to these tokens, ensuring consistent styling when state changes occur.
+2. **Contrast Automation**: Include metadata within tokens specifying required contrast ratios (e.g., `"wcag": { "minContrast": 4.5 }`). CI scripts can compute color combinations and block merges that fail WCAG AA/AAA thresholds.
+3. **Motion Sensitivity**: Tokens defining animation durations and easing curves can include flags such as `"prefersReducedMotion": true`. When user agents signal reduced motion preferences, components automatically switch to token values that respect the preference and remain compliant with ARIA authoring practices.
+4. **Focus Visibility**: Tokens governing focus rings, outlines, and focus shadows should be mandatory for interactive components. Linting rules can ensure that any component with `role="button"` or `tabindex="0"` references the approved focus tokens, preventing accidental removal of focus indicators.
+5. **State Synchronization**: Establish token-driven mappings between ARIA states and design states. For example:
+
+   - `aria-pressed="true"` → `toggle.active.background`
+   - `aria-expanded="false"` → `accordion.collapsed.icon.rotation`
+   - `aria-invalid="true"` → `form.control.border.error`
+
+   By encapsulating these relationships in token metadata, UI frameworks can dynamically apply correct visual feedback whenever ARIA attributes change.
+
+6. **Documentation and Training**: Auto-generate accessibility guidance from token definitions. Each token can link to usage notes clarifying which ARIA patterns it supports, improving education for developers and designers.
+
+### Compliance Workflow
+
+- **Design-time checks**: Figma plugins or design linters validate that color, typography, and interaction tokens applied to components meet WCAG and ARIA authoring recommendations.
+- **Build-time checks**: Token processors run automated tests (e.g., `npm run tokens:a11y`) verifying that generated CSS or PDF stylesheets maintain contrast and focus indicators.
+- **Runtime checks**: Component libraries include unit tests that mount components with various ARIA attributes, ensuring that the correct token-based styling is applied and that assistive technology announcements are triggered.
+
+## Measuring Success
+
+To confirm that tokens deliver value across platforms:
+
+- Track the number of manual overrides in web, PDF, and presentation builds—declining overrides indicate healthier token adoption.
+- Monitor accessibility audit scores across channels, correlating improvements with token releases.
+- Survey design and engineering teams about the clarity of token documentation and the speed of adopting brand updates.
+- Maintain dashboards that surface token usage analytics, highlighting which components or platforms lag behind compliance targets.
+
+By investing in a disciplined design token strategy, Architecture as Code initiatives can deliver visually coherent, accessible, and brand-aligned experiences wherever content is consumed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ Organizational transformation, teams, digitalization, future trends, and conclus
 | `26_appendix_code_examples.md` | Appendix A: Code Examples and Technical Implementations | Technical architecture code implementations |
 | `27_technical_architecture.md` | Technical Structure for Book Production | Technical book production infrastructure |
 | `28_ai_agent_team.md` | AI-agentteam för projektleverans | Struktur, roller och processer för virtuellt agentteam |
+| `29_design_tokens.md` | Design Tokens as the Backbone of Cross-Channel Experience | Cross-channel design governance, accessibility, and ARIA alignment |
 
 ---
 


### PR DESCRIPTION
## Summary
- add a comprehensive design tokens chapter detailing governance and distribution across platforms
- document how tokens enforce ARIA-aligned accessibility outcomes
- register the new chapter in the docs appendix table of contents

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e3d3081b588330891998bed01d189e