### PR TITLE
Skip website build in unified release workflow

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -74,7 +74,6 @@ on:
           - 'book-only'
           - 'presentations-only'
           - 'whitepapers-only'
-          - 'website-only'
 
 env:
   PANDOC_VERSION: "3.1.9"
@@ -341,14 +340,9 @@ jobs:
               ls -la releases/whitepapers/ || echo "⚠️ No whitepaper files found"
               ;;
             "website-only")
-              echo "🌐 Building website only..."
-              npm run build
-              echo "📝 Verifying website build..."
-              ls -la dist/ || echo "⚠️ No dist directory found"
+              echo "🌐 Skipping website build (no frontend available)..."
               mkdir -p releases/website
-              cp -r dist/* releases/website/
-              echo "📝 Verifying website files in releases..."
-              ls -la releases/website/ | head -10
+              echo "📝 Website deliverable skipped"
               ;;
             "all"|*)
               echo "📦 Building all deliverables..."
@@ -512,11 +506,9 @@ jobs:
           python3 generate_book.py
           echo "✅ Book content generated"
 
-      - name: 🌐 Build website
+      - name: 🌐 Skip website build
         run: |
-          echo "=== Building website ==="
-          npm run build
-          echo "✅ Website built successfully"
+          echo "=== Skipping website build (no frontend available) ==="
 
       - name: 🏗️ Build all formats in Docker container
         run: |
@@ -568,7 +560,7 @@ jobs:
                   ls -la releases/whitepapers/ || echo '⚠️ No whitepaper files found'
                   ;;
                 'website-only')
-                  echo '🌐 Website already built, nothing to do in Docker...'
+                  echo '🌐 Skipping website build (no frontend available)...'
                   ;;
                 'all'|*)
                   echo '📦 Building all deliverables...' &&
@@ -603,27 +595,9 @@ jobs:
               find releases/ -type f | wc -l
             "
 
-      - name: 🌐 Copy website to release
+      - name: 🌐 Skip website copy
         run: |
-          echo "=== Copying website to release folder ==="
-          if [ -d "dist" ]; then
-            # Clean releases/website directory safely
-            if [ -d "releases/website" ]; then
-              # Change ownership if files exist (Docker may create them as different user)
-              if [ "$(ls -A releases/website/)" ]; then
-                sudo chown -R $(id -u):$(id -g) releases/website/ || true
-              fi
-              rm -rf releases/website/*
-            fi
-            cp -r dist/* releases/website/
-            echo "✅ Website copied to releases/website/"
-            echo "📝 Website files copied:"
-            find releases/website -type f | head -10
-            echo "📊 Total website files: $(find releases/website -type f | wc -l)"
-          else
-            echo "❌ Website build directory 'dist' not found"
-            exit 1
-          fi
+          echo "=== Skipping website copy (no website build artifacts) ==="
 
       - name: 🔍 Verify files were created (Docker)
         run: |
@@ -871,7 +845,6 @@ jobs:
             - ✅ Docker-optimized builds with caching
             - ✅ Traditional comprehensive builds
             - ✅ Standalone presentations and whitepapers
-            - ✅ Website generation
 
             ### 📦 Complete Release Package Contents:
 
@@ -888,15 +861,12 @@ jobs:
             - Individual HTML whitepapers for each chapter
             - `whitepapers_combined.pdf` - All whitepapers in single PDF
 
-            #### 🌐 Website
-            - Complete static website build ready for deployment
-
             **🛠️ Build Information:**
             - Built with unified workflow (replaces 3 separate workflows)
             - Pandoc ${{ env.PANDOC_VERSION }} with XeLaTeX PDF-engine
             - Docker optimization for faster builds
             - Mermaid diagrams converted to PNG
-            - React application built for production
+            - Website generation skipped (frontend not available)
             - Python-generated presentations and whitepapers
 
             **📥 Download Options:**

--- a/build_release.sh
+++ b/build_release.sh
@@ -158,36 +158,11 @@ else
     exit 1
 fi
 
-# 5. Build website and copy to release
-log "🌐 Step 5: Building website..."
-if command -v npm >/dev/null 2>&1; then
-    if npm run build; then
-        log "✅ Website built successfully"
-        # Verify dist directory exists
-        verify_directory "dist" "Website build directory"
-    else
-        log "❌ Website build failed"
-        exit 1
-    fi
-else
-    log "⚠️  npm not found, skipping website build"
-    exit 1
-fi
-
-log "📋 Step 6: Copying website to release folder..."
-if [ -d "dist" ]; then
-    rm -rf releases/website/*
-    cp -r dist/* releases/website/
-    log "✅ Website copied to releases/website/"
-    # Verify website files were copied
-    verify_directory "releases/website" "Website release directory"
-else
-    log "❌ Website build directory 'dist' not found"
-    exit 1
-fi
+# 5. Website build skipped (frontend removed)
+log "🌐 Step 5: Skipping website build (no frontend available)"
 
 # 6. Generate combined whitepaper PDF (optional)
-log "📑 Step 7: Generating combined whitepaper PDF..."
+log "📑 Step 6: Generating combined whitepaper PDF..."
 if command -v pandoc >/dev/null 2>&1; then
     # Create a temporary combined markdown file from all HTML whitepapers
     log "Creating combined whitepaper content..."
@@ -233,7 +208,7 @@ else
 fi
 
 # 7. Generate presentation PDF (if PPTX exists)
-log "🎥 Step 8: Attempting to generate presentation PDF..."
+log "🎥 Step 7: Attempting to generate presentation PDF..."
 if [ -f "releases/presentation/arkitektur_som_kod_presentation.pptx" ]; then
     log "⚠️  PowerPoint to PDF conversion requires additional tools (LibreOffice or similar)"
     log "   Manual conversion recommended for presentation PDF"


### PR DESCRIPTION
## Summary
- skip the website build steps in the unified release workflow now that the frontend has been removed
- adjust build_release.sh to skip website generation while keeping the remaining deliverables intact
- update release notes to clarify that website generation is no longer produced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40c055a3c8330ac91c0a8108d9a72