### PR TITLE
Add orchestrator workflow with ChatGPT query capability

### DIFF
--- a/.github/workflows/orchestrator-agent.yml
+++ b/.github/workflows/orchestrator-agent.yml
@@ -1,0 +1,102 @@
+name: Orchestrator Agent - Start Other Agents
+
+on:
+  workflow_dispatch:
+    inputs:
+      agents_to_start:
+        description: 'Which agents to start (comma-separated, e.g., agent-1,agent-2)'
+        required: true
+        default: 'agent-1,agent-2'
+      chatgpt_question:
+        description: 'Question to ask ChatGPT before starting agents'
+        required: false
+        default: 'Provide a high-level operational plan for today\'s automation run.'
+  schedule:
+    - cron: '0 */6 * * *'
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+jobs:
+  orchestrate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub CLI
+        uses: cli/cli@v2
+        with:
+          version: latest
+
+      - name: Authenticate with GitHub CLI
+        if: env.GH_TOKEN != ''
+        run: gh auth login --with-token <<< "$GH_TOKEN"
+
+      - name: Ask ChatGPT
+        id: chatgpt
+        run: |
+          QUESTION="${{ github.event.inputs.chatgpt_question }}"
+          if [ -z "${QUESTION}" ]; then
+            QUESTION="${{ vars.DEFAULT_CHATGPT_QUESTION }}"
+          fi
+          if [ -z "${QUESTION}" ]; then
+            QUESTION='Provide a high-level operational plan for today''s automation run.'
+          fi
+
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY not provided. Skipping ChatGPT query."
+            echo "response=No OpenAI API key available." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg question "$QUESTION" \
+            '{
+              model: "gpt-4o-mini",
+              messages: [
+                {role: "system", content: "You are an automation strategist that provides concise, actionable guidance."},
+                {role: "user", content: $question}
+              ],
+              temperature: 0.3
+            }')
+
+          RESPONSE=$(curl -sS -X POST https://api.openai.com/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -d "$PAYLOAD" | jq -r '.choices[0].message.content // "No response received."')
+
+          echo "ChatGPT response:\n$RESPONSE"
+          printf '%s' "$RESPONSE" > chatgpt_response.txt
+          echo "response<<'CHATGPT'" >> "$GITHUB_OUTPUT"
+          echo "$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "CHATGPT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload ChatGPT response
+        if: env.OPENAI_API_KEY != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatgpt-response
+          path: chatgpt_response.txt
+
+      - name: Start Specified Agents
+        run: |
+          AGENTS="${{ github.event.inputs.agents_to_start || 'agent-1,agent-2' }}"
+          if [ -z "$AGENTS" ]; then
+            echo "No agents specified. Skipping start sequence."
+            exit 0
+          fi
+          for agent in $(echo "$AGENTS" | tr ',' ' '); do
+            echo "Starting agent: $agent"
+            gh workflow run "$agent.yml" --repo "${{ github.repository }}" || echo "Error starting $agent"
+          done
+
+      - name: Log Status
+        run: |
+          echo "All requested agents started."
+          if [ "${{ steps.chatgpt.outputs.response }}" != '' ]; then
+            echo "ChatGPT Guidance:"
+            echo "${{ steps.chatgpt.outputs.response }}"
+          fi


### PR DESCRIPTION
## Summary
- add a new orchestrator workflow that queries ChatGPT before triggering agent workflows
- capture ChatGPT guidance as an artifact and echo it in the workflow logs
- continue to authenticate with GitHub CLI and start the selected downstream agents

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e411a03a308330b42b630d9860ec4a