### PR TITLE
Fix agent project manager workflow default inputs

### DIFF
--- a/.github/workflows/agent-project-manager.yml
+++ b/.github/workflows/agent-project-manager.yml
@@ -5,7 +5,8 @@ on:
     inputs:
       objective:
         description: "Vilket mål ska Project Manager-agenten fokusera på?"
-        required: true
+        required: false
+        default: "Ingen specifik målsättning angiven."
       sprint_context:
         description: "Ytterligare kontext, länkar eller hinder som påverkar sprinten"
         required: false
@@ -22,8 +23,9 @@ on:
   workflow_call:
     inputs:
       objective:
-        required: true
+        required: false
         type: string
+        default: "Ingen specifik målsättning angiven."
       sprint_context:
         required: false
         type: string


### PR DESCRIPTION
## Summary
- allow the project manager workflow to provide default values for the objective input when invoked automatically
- prevent the workflow from failing validation when triggered by repository pushes without explicit inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e495526e4483308e28a37bf38f7ba3