### PR TITLE
Add placeholder agent workflow

### DIFF
--- a/.github/workflows/agent-placeholder.yml
+++ b/.github/workflows/agent-placeholder.yml
@@ -1,0 +1,67 @@
+name: Placeholder Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      objective:
+        description: "Optional objective for the placeholder agent"
+        required: false
+        default: ""
+  workflow_call:
+    inputs:
+      objective:
+        required: false
+        type: string
+        default: ""
+    outputs:
+      plan:
+        description: "Summary emitted by the placeholder agent"
+        value: ${{ jobs.bootstrap.outputs.plan }}
+
+jobs:
+  bootstrap:
+    name: Initialize placeholder agent
+    runs-on: ubuntu-latest
+    outputs:
+      plan: ${{ steps.summarize.outputs.plan }}
+    steps:
+      - name: Summarize agent state
+        id: summarize
+        env:
+          OBJECTIVE_INPUT: ${{ inputs.objective }}
+          DISPATCH_OBJECTIVE: ${{ github.event.inputs.objective }}
+        run: |
+          set -euo pipefail
+          objective_source="${OBJECTIVE_INPUT:-${DISPATCH_OBJECTIVE:-}}"
+          if [ -z "$objective_source" ]; then
+            objective_source="No specific objective provided."
+          fi
+
+          summary=$(cat <<PLAN
+# Placeholder Agent
+
+## Objective
+$objective_source
+
+## Status
+- Agent initialized successfully.
+- No default actions are defined. Configure steps as needed.
+
+## Notes
+This workflow is intentionally minimal so it can always start and be extended safely.
+PLAN
+)
+
+          printf '%s\n' "$summary"
+
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+              echo "plan<<EOF"
+              printf '%s\n' "$summary"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
## Summary
- add a minimal GitHub Actions workflow that defines a placeholder agent
- ensure the workflow can be triggered manually or by other workflows while returning a status summary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4afd0318083308a9bf72288122d7e