### PR TITLE
Fix placeholder workflow objective parsing

### DIFF
--- a/.github/workflows/agent-placeholder.yml
+++ b/.github/workflows/agent-placeholder.yml
@@ -31,9 +31,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          objective="${{ inputs.objective }}"
-          if [ -z "$objective" ]; then
-            objective="$(jq -r '.inputs.objective // ""' "$GITHUB_EVENT_PATH")"
+          objective=""
+          if [ -f "$GITHUB_EVENT_PATH" ]; then
+            objective="$(jq -r '(
+              .inputs.objective //
+              .workflow_call.inputs.objective //
+              .workflow_dispatch.inputs.objective //
+              ""
+            )' "$GITHUB_EVENT_PATH" 2>/dev/null || printf '')"
           fi
 
           if [ -z "$objective" ]; then


### PR DESCRIPTION
## Summary
- make the placeholder workflow derive its objective from the event payload instead of the unavailable `inputs` context
- fall back to a default message when no objective is supplied so the workflow can start even on push-triggered validations

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4b32524708330bfe97320b57a50d4