### PR TITLE
Use repository objective file for placeholder agent workflow

### DIFF
--- a/.github/workflows/agent-placeholder.yml
+++ b/.github/workflows/agent-placeholder.yml
@@ -2,17 +2,7 @@ name: Minimal Placeholder Agent
 
 on:
   workflow_dispatch:
-    inputs:
-      objective:
-        description: "Optional objective for the placeholder agent"
-        required: false
-        default: ""
   workflow_call:
-    inputs:
-      objective:
-        required: false
-        type: string
-        default: ""
     outputs:
       plan:
         description: "Summary emitted by the placeholder agent"
@@ -31,21 +21,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          objective=""
-          if [ -f "$GITHUB_EVENT_PATH" ]; then
-            objective="$(jq -r '(
-              .inputs.objective //
-              .workflow_call.inputs.objective //
-              .workflow_dispatch.inputs.objective //
-              ""
-            )' "$GITHUB_EVENT_PATH" 2>/dev/null || printf '')"
-          fi
+          objective_file="docs/agents/placeholder-objective.md"
 
-          if [ -z "$objective" ]; then
-            objective="No specific objective provided."
+          if [ -f "$objective_file" ]; then
+            objective="$(cat "$objective_file")"
+          else
+            objective="Objective file '$objective_file' was not found."
           fi
 
           summary="# Placeholder Agent
+
+## Objective Source
+- $objective_file
 
 ## Objective
 $objective

--- a/docs/agents/placeholder-objective.md
+++ b/docs/agents/placeholder-objective.md
@@ -1,0 +1,1 @@
+Establish a repeatable workflow summary that demonstrates how the placeholder agent can initialize itself without relying on runtime inputs.


### PR DESCRIPTION
## Summary
- remove manual inputs from the placeholder agent workflow so it can run without parameters
- read the placeholder agent objective from `docs/agents/placeholder-objective.md` and display the source in the generated summary
- add the repository objective file that documents the default placeholder agent goal

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e4b6eea11083309dd3065b0c915ba3