### PR TITLE
Ensure issue responder bots use English names

### DIFF
--- a/.github/workflows/issue-response.yml
+++ b/.github/workflows/issue-response.yml
@@ -39,17 +39,17 @@ jobs:
 
             const botAssignments = [
               { name: 'Designer', keywords: ['ui', 'ux', 'visual', 'styling', 'layout', 'mockup', 'branding'] },
-              { name: 'Arkitekt', keywords: ['architecture', 'architectural', 'blueprint', 'system layout', 'system map', 'infrastructure'] },
-              { name: 'Kvalitetskontroll', keywords: ['bug', 'issue', 'error', 'test', 'testing', 'qa', 'quality', 'failure'] },
-              { name: 'Utvecklare', keywords: ['develop', 'development', 'implement', 'implementation', 'code', 'coding', 'feature', 'fix'] },
-              { name: 'Dokumentatör', keywords: ['documentation', 'document', 'docs', 'guide', 'manual', 'readme'] },
-              { name: 'Kravanalytiker', keywords: ['requirement', 'requirements', 'analysis', 'specification', 'user story', 'acceptance criteria'] },
-              { name: 'Redaktör', keywords: ['edit', 'editing', 'copy', 'proofread', 'language', 'grammar', 'tone'] },
+              { name: 'Architect', keywords: ['architecture', 'architectural', 'blueprint', 'system layout', 'system map', 'infrastructure'] },
+              { name: 'Quality Assurance', keywords: ['bug', 'issue', 'error', 'test', 'testing', 'qa', 'quality', 'failure'] },
+              { name: 'Developer', keywords: ['develop', 'development', 'implement', 'implementation', 'code', 'coding', 'feature', 'fix'] },
+              { name: 'Documentarian', keywords: ['documentation', 'document', 'docs', 'guide', 'manual', 'readme'] },
+              { name: 'Requirements Analyst', keywords: ['requirement', 'requirements', 'analysis', 'specification', 'user story', 'acceptance criteria'] },
+              { name: 'Editor', keywords: ['edit', 'editing', 'copy', 'proofread', 'language', 'grammar', 'tone'] },
             ];
 
             const assignedBot = botAssignments.find(({ keywords }) =>
               keywords.some((keyword) => content.includes(keyword))
-            )?.name || 'Kravanalytiker';
+            )?.name || 'Requirements Analyst';
 
             await github.rest.issues.createComment({
               owner,


### PR DESCRIPTION
## Summary
- update the issue responder workflow to rename all bot personas to English equivalents
- keep the default assignment aligned with the English Requirements Analyst bot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d7598d9483309c126c001578b14b