### PR TITLE
Add architect issue-response template and templated comments

### DIFF
--- a/.github/issue-response/architect.tml
+++ b/.github/issue-response/architect.tml
@@ -1,0 +1,12 @@
+Hello! After reviewing this issue, the {{bot_name}} bot will take the lead.
+
+**Architect Mission**
+- Translate "{{issue_title}}" into an architecture deliverable that aligns with the programme guardrails.
+- Confirm integration points, critical data flows, and non-functional constraints before implementation work begins.
+
+**Immediate Next Steps**
+1. Capture the current baseline architecture and highlight impacted components.
+2. Draft a proposed target architecture or sequence of diagrams outlining the desired end state.
+3. List technical risks, dependencies, and follow-up questions for the Developer and Project Manager bots.
+
+The Architect bot will share the first architecture outline shortly so the rest of the team can proceed with confidence.

--- a/.github/issue-response/issue-response.tml
+++ b/.github/issue-response/issue-response.tml
@@ -1,0 +1,1 @@
+Hello! After reviewing this issue, the {{bot_name}} bot will take the lead. They will follow up with the next steps shortly.

--- a/.github/workflows/issue-response.yml
+++ b/.github/workflows/issue-response.yml
@@ -18,6 +18,8 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const fs = require('fs');
+            const path = require('path');
 
             const { data: issues } = await github.rest.issues.listForRepo({
               owner,
@@ -51,11 +53,32 @@ jobs:
               keywords.some((keyword) => content.includes(keyword))
             )?.name || 'Requirements Analyst';
 
+            const templatesDir = path.join(process.env.GITHUB_WORKSPACE, '.github', 'issue-response');
+            const slugify = (value) => value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+            const templatePaths = [
+              path.join(templatesDir, `${slugify(assignedBot)}.tml`),
+              path.join(templatesDir, 'issue-response.tml'),
+            ];
+
+            let commentTemplate = `Hello! After reviewing this issue, the ${assignedBot} bot will take the lead. They will follow up with the next steps shortly.`;
+
+            for (const templatePath of templatePaths) {
+              if (fs.existsSync(templatePath)) {
+                commentTemplate = fs.readFileSync(templatePath, 'utf8');
+                break;
+              }
+            }
+
+            const commentBody = commentTemplate
+              .replace(/{{\s*bot_name\s*}}/gi, assignedBot)
+              .replace(/{{\s*issue_title\s*}}/gi, (latestIssue.title || '').trim())
+              .replace(/{{\s*issue_number\s*}}/gi, latestIssue.number);
+
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: latestIssue.number,
-              body: `Hello! After reviewing this issue, the ${assignedBot} bot will take the lead. They will follow up with the next steps shortly.`,
+              body: commentBody,
             });
 
             core.info(`Assigned ${assignedBot} bot to issue #${latestIssue.number}.`);


### PR DESCRIPTION
## Summary
- update the issue responder workflow to load role-specific comment templates
- add a shared issue-response template fallback
- provide an architect bot template with mission and immediate next steps

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4d83dd7088330b22d347a544dcfdd