### PR TITLE
Fix architect bot workflow label case sensitivity

### DIFF
--- a/.github/workflows/architect-bot.yml
+++ b/.github/workflows/architect-bot.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   prepare_architecture_pr:
-    if: github.event.label.name == 'architecture'
+    if: toLower(github.event.label.name) == 'architecture'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- normalize the label name comparison in the architect bot workflow so it runs regardless of label casing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4dff3b0e48330a49e0c701975711c