### PR TITLE
Fix architect bot label condition

### DIFF
--- a/.github/workflows/architect-bot.yml
+++ b/.github/workflows/architect-bot.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   prepare_architecture_pr:
-    if: toLower(github.event.label.name) == 'architecture'
+    if: contains(fromJSON('["architecture","Architecture","ARCHITECTURE"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- replace the unsupported `toLower` call with a case-insensitive label match compatible with GitHub Actions expressions

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e4e4731c74833093f538ca042be96e