### PR TITLE
Ensure architect bot triggers when label already present

### DIFF
--- a/.github/workflows/architect-bot.yml
+++ b/.github/workflows/architect-bot.yml
@@ -3,7 +3,9 @@ name: Architect Bot - Auto PR
 on:
   issues:
     types:
+      - opened
       - labeled
+      - reopened
 
 
 permissions:
@@ -13,7 +15,12 @@ permissions:
 
 jobs:
   prepare_architecture_pr:
-    if: contains(fromJSON('["architecture","Architecture","ARCHITECTURE"]'), github.event.label.name)
+    if: >-
+      contains(github.event.issue.labels.*.name, 'architecture') ||
+      contains(github.event.issue.labels.*.name, 'Architecture') ||
+      contains(github.event.issue.labels.*.name, 'ARCHITECTURE') ||
+      (github.event.label != null &&
+       contains(fromJSON('["architecture","Architecture","ARCHITECTURE"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- allow the architect bot workflow to trigger on opened and reopened issues that already include the architecture label
- expand the workflow condition so it checks the full label set and the latest event payload before running

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e4e786608c8330a888d828f9852771