### PR TITLE
Add delay before running specialized bots

### DIFF
--- a/.github/workflows/architect-bot.yml
+++ b/.github/workflows/architect-bot.yml
@@ -23,6 +23,9 @@ jobs:
        contains(fromJSON('["architecture","Architecture","ARCHITECTURE"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/designer-bot.yml
+++ b/.github/workflows/designer-bot.yml
@@ -22,6 +22,9 @@ jobs:
        contains(fromJSON('["design","Design","DESIGN"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/developer-bot.yml
+++ b/.github/workflows/developer-bot.yml
@@ -22,6 +22,9 @@ jobs:
        contains(fromJSON('["dev","Dev","DEV"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/editor-bot.yml
+++ b/.github/workflows/editor-bot.yml
@@ -22,6 +22,9 @@ jobs:
        contains(fromJSON('["documentation","Documentation","DOCUMENTATION"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/qa-bot.yml
+++ b/.github/workflows/qa-bot.yml
@@ -22,6 +22,9 @@ jobs:
        contains(fromJSON('["QA","qa","Qa"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/requirements-bot.yml
+++ b/.github/workflows/requirements-bot.yml
@@ -22,6 +22,9 @@ jobs:
        contains(fromJSON('["Req","req","REQ"]'), github.event.label.name))
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for issue response labeling
+        run: sleep 15
+
       - name: Check out repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- add a 15 second wait step to each specialized bot workflow so issue-response can finish labeling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e504b156dc8330a255496e10d1c80f