### PR TITLE
Add comprehensive management as code chapter

### DIFF
--- a/docs/31_management_as_code.md
+++ b/docs/31_management_as_code.md
@@ -1,0 +1,179 @@
+# Chapter 31: Management as Code
+
+## Introduction
+Management as Code (MaC) extends the well-established principles of Infrastructure as Code and Architecture as Code into the realm of organisational leadership. It treats management intent, governance routines, and decision frameworks as executable artefacts that can be versioned, tested, automated, and refined. In organisations where the entire delivery pipeline is codified, management practices that remain trapped in meetings, slide decks, or undocumented intuition quickly become bottlenecks. A MaC discipline eliminates that bottleneck by encoding strategic direction, operational constraints, and cultural values into the same repositories that power the technology stack. This chapter explores how MaC manifests in fully code-based environments, how management roles adapt to DevOps loops, and how tooling such as GitHub can embed leadership into the change lifecycle while addressing budgeting, capability development, and the orchestration of multiple teams or teams-of-teams.
+
+## Defining Management as Code
+At its core, MaC is the systematic translation of management artefacts into reproducible code. Policies, playbooks, delegation models, role definitions, and decision guardrails are captured as declarative specifications that tooling can enforce. Rather than issuing static policy documents, leadership teams create repositories that contain structured definitions for escalation thresholds, strategic objectives and key results (OKRs), and the criteria for portfolio prioritisation. Automation hooks process these definitions to trigger workflows, generate dashboards, or enforce access controls. By storing these assets in Git repositories, management directives acquire the same benefits as other code: auditability, peer review, continuous integration, and rollback.
+
+MaC differs from traditional management documentation in three crucial ways. The artefacts are executable—scripts, configuration files, or policy-as-code rules integrate directly with operational systems. Management inputs follow the same change management discipline as software features, so leaders iterate transparently. Finally, telemetry instruments every directive, enabling evidence-based leadership for globally distributed teams without waiting for synchronous communication.
+
+## Principles of MaC in Code-First Organisations
+Fully code-based organisations share a set of principles that underpin MaC. They prioritise declarative specifications over narrative documents, expecting every significant management decision to be represented in a machine-readable form. Version control governs all management artefacts, providing traceability for who authorised a particular policy and when it changed. Automated testing of management rules—such as simulated budget scenarios or compliance checks for role-based access control—ensures that leadership decisions do not break downstream systems.
+
+A key principle is alignment with continuous delivery cadences. Management cadences must be as responsive as the deployment frequency, using iterations of policy code to reflect business changes. Another principle is collaboration parity: management contributions use the same pull request (PR) pathways as engineering contributions, complete with reviews, automated checks, and documentation updates, so leadership work becomes inspectable and improvable through shared tooling.
+
+## Embedding Management in the DevOps Loop
+A DevOps loop is often depicted as a continuous cycle: plan, code, build, test, release, deploy, operate, observe, and feed insights back into planning. MaC expands this loop by articulating leadership responsibilities in each stage. During planning, management-as-code repositories define strategic intents, budget envelopes, and compliance constraints. The coding phase includes management scripts for feature approval workflows or objective tracking. Build and test stages incorporate automated validation of management artefacts, such as ensuring new OKRs align with portfolio policies. Release and deploy phases use policy-as-code to verify that launch criteria—risk sign-off, stakeholder notifications, capacity adjustments—are satisfied. The operate stage relies on management dashboards generated from code to review service health, financial performance, and staffing adequacy. Observation feeds into adaptive management routines, triggering updates to strategy code or organisational design specifications.
+
+```mermaid
+flowchart LR
+    A[Plan] --> B[Code]
+    B --> C[Build]
+    C --> D[Test]
+    D --> E[Release]
+    E --> F[Deploy]
+    F --> G[Operate]
+    G --> H[Observe]
+    H --> A
+    subgraph Management Contributions
+        MA[Strategic Objectives as Code]
+        MB[Policy Automation Scripts]
+        MC[Budget Guardrails]
+        MD[Operational Dashboards]
+        ME[Adaptive Governance Rules]
+    end
+    A -. consumes .-> MA
+    B -. references .-> MB
+    C -. validates .-> MC
+    F -. enforces .-> MB
+    G -. monitors .-> MD
+    H -. updates .-> ME
+```
+
+The diagram illustrates how management artefacts intersect with each loop phase. Instead of management being an external approval layer, MaC ensures that leadership intent is encoded at the same points where DevOps teams act. Planning repositories can provide strategic intents expressed in YAML files, while automation transforms these definitions into backlog templates or alerts when proposals deviate from strategic goals. During operation, monitoring dashboards generated from configuration code link service-level indicators to financial KPIs. As teams observe anomalies, adaptive governance rules encoded in policy files trigger scenario playbooks or review cadences.
+
+## Governance and Policy Automation
+MaC provides a robust foundation for governance-as-code, where leadership rules are implemented as automated checks. Access control policies become parameterised configurations that pipeline tools consume, ensuring only authorised roles can approve specific changes. Risk tolerance levels appear as threshold values in configuration files, automatically cross-referenced against deployment metrics. Governance repositories can also contain escalation playbooks, specifying decision-makers, communication channels, and response time objectives.
+
+Automated compliance tests run alongside software unit tests. For instance, a pull request adjusting a service’s operating budget triggers simulations that verify it stays within the portfolio guardrails declared in management code. If the change would breach the guardrails, the PR fails and prompts the contributor to adjust the request or seek executive approval. This automation dramatically reduces the manual overhead of governance and gives leaders more time to focus on strategic initiatives.
+
+```mermaid
+graph TD
+    subgraph Governance Repo
+        Policy[Policy Definitions]
+        Guardrails[Budget Guardrails]
+        Playbooks[Escalation Playbooks]
+        Roles[Approval Matrices]
+    end
+    Policy -->|CI Integration| Checks[Automated Policy Checks]
+    Guardrails -->|Simulation| Checks
+    Playbooks -->|Incident Automation| Workflow[Incident Workflow Engine]
+    Roles -->|Access Control| IAM[Identity and Access Platform]
+    Checks -->|Pass/Fail| PR[Pull Requests]
+    Workflow --> Response[Executive Response Team]
+    IAM --> PR
+```
+
+This governance diagram emphasises how management repositories integrate with CI pipelines, incident workflows, and identity platforms. By codifying playbooks and roles, leadership actions become auditable and repeatable. Every update to these artefacts follows the same review process as software code, enabling cross-functional transparency.
+
+## GitHub Configuration for MaC
+GitHub is a natural home for MaC artefacts due to its robust collaboration features. Organisations can create dedicated repositories for management policies, or integrate management directories into existing architecture-as-code projects. Protected branches and CODEOWNERS files map leadership responsibilities to directories—budget rules might require approval from finance leaders, while team competency matrices might need sign-off from HR directors.
+
+GitHub Actions automate the validation and deployment of management artefacts. A workflow might parse OKR definitions written in Markdown and publish them to an internal portal, while another converts competency frameworks encoded in JSON into dashboards. Actions can also notify leadership channels when management policies change, ensuring stakeholders are aware of updates in near real-time. Discussions and Issues offer living forums for management decisions, replacing informal email threads. Leadership proposals start as GitHub Issues with templates prompting for context, risk analysis, and resource implications. Discussions host exploratory conversations before a policy is formalised into code. Once consensus emerges, a PR updates the relevant management artefact, referencing the Issue or Discussion for traceability.
+
+```mermaid
+flowchart LR
+    Repo[Management Repository]
+    Issues[Structured Issue Templates]
+    Discussions[Leadership Discussions]
+    PRs[Pull Requests]
+    Actions[GitHub Actions]
+    Portal[Management Portal]
+    Alerts[Leadership Notifications]
+
+    Repo --> Issues
+    Repo --> Discussions
+    Issues --> PRs
+    Discussions --> PRs
+    PRs --> Actions
+    Actions --> Portal
+    Actions --> Alerts
+```
+
+The GitHub integration diagram shows how ideas move from Discussions to Issues, through PRs, and into automated publishing. This approach embeds management into the same cadence as engineering work while adding the visibility executives need for governance.
+
+## Management in Change Management Pipelines
+Fully codified environments rely on automated change management, and MaC keeps leadership in the loop without reintroducing bottlenecks. Change requests can reference management policies stored as code, enabling automated approval for low-risk changes while routing higher-risk items to the appropriate leaders. Because the criteria are codified, the pipeline logs every decision for audit purposes. Continuous delivery dashboards track change velocity, lead time for approvals, and adherence to strategic themes so leaders can adjust resources or guardrails proactively rather than reactively.
+
+## Issues and Discussions as Management Workflows
+GitHub Issues provide a structured interface for capturing management work. Custom templates ensure that leadership topics include expected data—financial impact, staffing needs, compliance considerations, risk assessments, and dependencies on other initiatives. Labels reflect strategic pillars, enabling filtering and reporting. Milestones can represent fiscal quarters or strategic horizons, helping management track progress across time.
+
+Discussions encourage asynchronous deliberation. Leadership teams can host strategic retrospectives, policy design workshops, or budget prioritisation debates within GitHub. Threads stay searchable, and the resulting consensus links directly to the code change that implements it, providing institutional memory that normalises management participation in developer-centric tools.
+
+```mermaid
+graph LR
+    Topic[Management Topic Raised]
+    Template[Issue Template Applied]
+    Analysis[Cross-Functional Analysis]
+    Decision[Decision Logged in PR]
+    FollowUp[Automated Follow-up Tasks]
+    Archive[Historical Record]
+
+    Topic --> Template
+    Template --> Analysis
+    Analysis --> Decision
+    Decision --> FollowUp
+    Decision --> Archive
+    FollowUp --> Archive
+```
+
+The workflow diagram demonstrates how Issues and Discussions guide management work from inception to archival, ensuring nothing gets lost and every action is traceable.
+
+## Budgeting as Code
+Budgeting as Code (BaC) is a crucial subset of MaC. Finance policies, spending limits, cost allocation rules, and investment hypotheses are encoded into version-controlled artefacts. YAML or JSON files define budget envelopes per product, platform, or team, and automated tests validate that proposed expenditures remain within budget. GitHub Actions integrate with financial systems to update actuals, enabling near real-time visibility of spending versus plan.
+
+BaC also supports scenario modelling. Leaders can adjust parameters—such as currency fluctuations, expected cloud usage, or headcount growth—and run simulations automatically. The results feed dashboards that highlight when adjustments are necessary. Encoding budget rules ensures that finance decisions align with engineering realities; for example, release pipelines can read the budget configuration to determine whether additional environments can be provisioned. When budgets must adjust, a PR proposes the change, complete with analysis and simulation results for finance, product, and engineering leaders to review together.
+
+## Competence Management as Code
+Competence development becomes more effective when treated as code. Competency frameworks become structured data that define skills, proficiency levels, and assessment criteria. Automation transforms these definitions into learning pathways, certification requirements, or mentoring pairings, and GitHub repositories can integrate with learning management systems (LMS) via Actions that push updates whenever competencies evolve.
+
+By version-controlling competence frameworks, organisations avoid the drift that occurs when role descriptions live in static documents. Every change is reviewed, with commentary from HR, engineering leadership, and learning teams. Executives can run analytics on the competency codebase to identify skills gaps, plan targeted hiring, or adjust training budgets, feeding workforce planning models that align capability development with strategic objectives.
+
+## Team Composition and Team-of-Teams Leadership
+MaC enables repeatable patterns for designing teams and scaling leadership across multiple squads. Team charters, role compositions, and interaction models are defined in code. Templates describe optimal ratios—such as the balance of senior to junior engineers, product managers, designers, and site reliability specialists. Leadership heuristics specify when a team should split or when additional support functions are needed.
+
+For teams of teams, MaC includes meta-structures that map dependencies, shared services, and governance forums. Executable artefacts can generate visualisations of team topology, highlight communication channels, and schedule synchronisation rituals. Leaders adjust structures through PRs that modify the underlying configuration, ensuring organisational design evolves deliberately while automation sets up collaboration infrastructure such as shared communication channels and recurring events.
+
+```mermaid
+flowchart TD
+    subgraph Squad Blueprint
+        Roles[Role Mix Definition]
+        Rituals[Team Rituals]
+        Interfaces[External Interfaces]
+    end
+    subgraph Team of Teams
+        Nexus[Nexus Governance]
+        SharedServices[Shared Services Agreements]
+        Dependencies[Dependency Map]
+    end
+    Roles --> Nexus
+    Rituals --> Nexus
+    Interfaces --> SharedServices
+    Dependencies --> Nexus
+    SharedServices --> Support[Support Functions Automation]
+    Nexus --> Visibility[Organisation Dashboard]
+```
+
+This team topology diagram demonstrates how squad-level definitions inform team-of-teams governance, with automation producing visibility and support structures.
+
+## Leading Multiple Teams Through Code
+When leaders oversee several teams or teams-of-teams, MaC provides the scaffolding to maintain coherence. Objectives cascade as code modules so portfolio-level OKRs break down into team objectives linked to backlog items and metrics. Leadership dashboards aggregate signals across squads, highlighting where intervention is needed, while automated alerts flag deviations from strategic priorities or capacity constraints. Playbooks codify coaching strategies, escalation patterns, and decision rights, and leaders can invoke these modules by triggering automation—such as launching a mediation workflow or scheduling a post-incident review—without manually coordinating every step.
+
+## Cultural and Behavioural Codification
+Culture often feels intangible, yet MaC encourages organisations to codify desired behaviours. Cultural principles become structured statements linked to behavioural examples, recognition programmes, and feedback loops. Automation can remind teams of cultural commitments during key events—such as including inclusivity reminders in retrospectives or surfacing customer empathy metrics during planning—while surveys feed analytics that compare actual behaviours to the coded ideals. Codifying culture does not remove human judgement; it provides scaffolding for consistency, and Git history keeps employees informed when cultural commitments evolve.
+
+## Measuring Management Effectiveness
+To evaluate MaC, organisations gather metrics similar to those used in DevOps: lead time for management decisions, change failure rates for policies, and mean time to recovery for organisational issues. Telemetry dashboards draw from management repositories, recording how long it takes to merge a policy update, how many stakeholders reviewed it, and how often policies revert, while integrated surveys capture qualitative understanding. These metrics fuel continuous improvement so leaders can experiment with governance models, use feature flags for management policies, and roll back ineffective approaches with scientific rigour.
+
+## Challenges and Mitigation Strategies
+Implementing MaC requires overcoming resistance from leaders accustomed to traditional methods. Training programmes must emphasise transparency, auditability, and automation, while coaching helps leaders express intent in declarative formats and participate in PR reviews. Automation should detect inactivity and prompt policy refreshes so artefacts remain relevant. Security is also critical: management repositories may contain sensitive information, so organisations must implement robust access controls, encryption, separation of duties, and automated secrets scanning in partnership with legal and compliance teams.
+
+## Case Study: Scaling Leadership with MaC
+Consider a global software company operating in regulated financial markets. The organisation adopts MaC to harmonise leadership practices across regions, creating a central management repository with directories for strategy, budgets, compliance policies, and team design templates. CODEOWNERS entries map to relevant executives, GitHub Actions convert strategic roadmaps into interactive dashboards, and Issues capture emerging regulatory updates while Discussions host asynchronous strategy forums. Decision lead time drops because policy updates no longer rely on lengthy email chains, compliance incidents decrease thanks to automated checks, and leaders can reconfigure squads quickly by updating configuration files that refresh communication channels and documentation.
+
+## Future Directions for MaC
+As artificial intelligence capabilities mature, MaC will incorporate intelligent agents that suggest policy updates based on observed outcomes. Machine learning models can analyse historical management changes and their impact on delivery performance, recommending adjustments to guardrails or team structures. Natural language processing can transform meeting transcripts into code updates, bridging human discussions and codified artefacts, while decentralised governance structures may use smart contracts to enforce management rules across partner ecosystems.
+
+## Conclusion
+Management as Code is the logical next step for organisations that already treat infrastructure and architecture as code. By encoding leadership intent into executable artefacts, organisations achieve transparency, speed, and adaptability. MaC embeds management into the DevOps loop, ensures governance is automated, and ties budgeting, competence development, and team leadership into a single continuous system. GitHub and similar platforms become hubs where executives and engineers collaborate seamlessly, with Issues, Discussions, and Actions transforming management from a peripheral function into a core element of the delivery pipeline. By embracing MaC, organisations unlock scalable, data-driven leadership capable of orchestrating multiple teams and responding rapidly to change.


### PR DESCRIPTION
## Summary
- add a new chapter detailing management as code practices in fully codified organisations
- document how GitHub workflows, issues, and discussions embed leadership into change management
- include multiple Mermaid diagrams highlighting management’s role in the DevOps loop, governance automation, collaboration flow, and team topology

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e563a4d53c833091d6b8e7bc0f24a0