### PR TITLE
Add part-aware headers to book build

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -194,33 +194,41 @@ echo "Genererar PDF med Pandoc-konfiguration..."
 
 # Build chapter list with descriptive names
 CHAPTER_FILES=(
+    "part_a_foundations.md"
     "01_introduction.md"
     "02_fundamental_principles.md"
     "03_version_control.md"
     "04_adr.md"
+    "part_b_architecture_platform.md"
     "05_automation_devops_cicd.md"
     "06_cloud_architecture.md"
     "07_containerization.md"
     "08_microservices.md"
+    "part_c_security_governance.md"
     "09_security.md"
     "10_policy_and_security.md"
     "11_governance_as_code.md"
     "12_compliance.md"
+    "part_d_delivery_operations.md"
     "13_testing_strategies.md"
     "14_practical_implementation.md"
     "15_cost_optimization.md"
     "16_migration.md"
+    "part_e_organization_leadership.md"
     "17_organizational_change.md"
     "18_team_structure.md"
     "19_management_as_code.md"
     "20_ai_agent_team.md"
     "21_digitalization.md"
+    "part_f_experience_best_practices.md"
     "22_lovable_mockups.md"
     "23_soft_as_code_interplay.md"
     "24_best_practices.md"
+    "part_g_future_wrap_up.md"
     "25_future_trends.md"
     "26_future_development.md"
     "27_conclusion.md"
+    "part_h_appendices.md"
     "28_glossary.md"
     "29_about_the_authors.md"
     "30_appendix_code_examples.md"
@@ -254,7 +262,7 @@ else
         --metadata title="Arkitektur som kod" \
         --metadata author="Kodarkitektur Bokverkstad" \
         --variable documentclass=book \
-        --variable classoption=oneside \
+        --variable classoption=twoside \
         --variable geometry=margin=2.5cm \
         --variable fontsize=11pt \
         2>&1; then

--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -33,8 +33,8 @@ metadata:
 # Variables for better compatibility
 variables:
   documentclass: book
-  classoption: 
-    - oneside
+  classoption:
+    - twoside
     - openany
   geometry:
     - top=2.5cm
@@ -55,9 +55,31 @@ variables:
   # Simplified header handling
   header-includes: |
     \usepackage{fancyhdr}
+    \usepackage{titlesec}
+    \setlength{\headheight}{14pt}
     \pagestyle{fancy}
-    \renewcommand{\chaptermark}[1]{\markboth{#1}{}}
-    \renewcommand{\sectionmark}[1]{\markright{#1}}
+    \fancyhf{}
+    \newcommand{\currentpartletter}{}
+    \newcommand{\currentparttitle}{}
+    \newcommand{\currentpartformat}{}
+    \newcommand{\setbookpart}[1]{%
+      \renewcommand{\currentpartletter}{\thepart}%
+      \renewcommand{\currentparttitle}{#1}%
+      \renewcommand{\currentpartformat}{PART~\thepart\space--\space #1}%
+    }
+    \renewcommand{\chaptermark}[1]{\markboth{\thechapter.\ #1}{}}
+    \fancyhead[LE]{\small\bfseries \currentpartformat}
+    \fancyhead[RO]{\small\bfseries \leftmark}
+    \fancyfoot[C]{\thepage}
+    \renewcommand{\headrulewidth}{0pt}
+    \renewcommand{\partname}{Part}
+    \renewcommand{\thepart}{\Alph{part}}
+    \titleformat{\part}[display]
+      {\bfseries\centering\Huge}
+      {PART \thepart}
+      {0pt}
+      {\thispagestyle{empty}\vspace*{0.5\textheight}}
+    \titlespacing*{\part}{0pt}{0pt}{0pt}
     \usepackage{graphicx}
     \usepackage{pdfpages}
 

--- a/docs/part_a_foundations.md
+++ b/docs/part_a_foundations.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Foundations}
+\setbookpart{Foundations}

--- a/docs/part_b_architecture_platform.md
+++ b/docs/part_b_architecture_platform.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Architecture Platform}
+\setbookpart{Architecture Platform}

--- a/docs/part_c_security_governance.md
+++ b/docs/part_c_security_governance.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Security and Governance}
+\setbookpart{Security and Governance}

--- a/docs/part_d_delivery_operations.md
+++ b/docs/part_d_delivery_operations.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Delivery and Operations}
+\setbookpart{Delivery and Operations}

--- a/docs/part_e_organization_leadership.md
+++ b/docs/part_e_organization_leadership.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Organization and Leadership}
+\setbookpart{Organization and Leadership}

--- a/docs/part_f_experience_best_practices.md
+++ b/docs/part_f_experience_best_practices.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Experience and Best Practices}
+\setbookpart{Experience and Best Practices}

--- a/docs/part_g_future_wrap_up.md
+++ b/docs/part_g_future_wrap_up.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Future and Wrap-up}
+\setbookpart{Future and Wrap-up}

--- a/docs/part_h_appendices.md
+++ b/docs/part_h_appendices.md
@@ -1,0 +1,3 @@
+\cleardoublepage
+\part{Appendices and Reference}
+\setbookpart{Appendices and Reference}


### PR DESCRIPTION
## Summary
- insert dedicated LaTeX part marker files before each chapter group so the build has explicit PART sections
- update the Pandoc defaults to configure two-sided fancy headers with part labels and chapter titles and to format part pages as requested
- include the new part markers in the build script and ensure the fallback build also uses two-sided layout

## Testing
- docs/build_book.sh *(fails: missing `xelatex` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e758feb14483309bf92db4ea8f58ba