### PR TITLE
Fix presentation generator dependencies

### DIFF
--- a/.github/workflows/generate-presentations.yml
+++ b/.github/workflows/generate-presentations.yml
@@ -44,21 +44,30 @@ jobs:
           echo "=== Installing Python dependencies ==="
           python3 -m pip install --upgrade pip
           
-          # Install python-pptx library for PowerPoint generation
-          echo "📊 Installing PowerPoint generation dependencies..."
-          if pip install python-pptx>=0.6.21; then
-            echo "✅ python-pptx installed successfully"
+          # Install presentation dependencies
+          echo "📊 Installing PowerPoint and YAML dependencies..."
+          if pip install python-pptx>=0.6.21 PyYAML>=6.0; then
+            echo "✅ python-pptx and PyYAML installed successfully"
           else
-            echo "❌ ERROR: Failed to install python-pptx"
+            echo "❌ ERROR: Failed to install presentation dependencies"
             exit 1
           fi
-          
+
           # Verify python-pptx is available
           echo "🔍 Verifying python-pptx installation..."
           if python3 -c "import pptx; print(f'python-pptx version: {pptx.__version__}')"; then
             echo "✅ python-pptx is available and working"
           else
             echo "❌ ERROR: python-pptx cannot be imported"
+            exit 1
+          fi
+
+          # Verify PyYAML is available
+          echo "🔍 Verifying PyYAML installation..."
+          if python3 -c "import yaml; print(f'PyYAML version: {yaml.__version__}')"; then
+            echo "✅ PyYAML is available and working"
+          else
+            echo "❌ ERROR: PyYAML cannot be imported"
             exit 1
           fi
           

--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -271,7 +271,7 @@ jobs:
         run: |
           echo "=== Installing Python dependencies ==="
           python3 -m pip install --upgrade pip
-          pip install python-pptx>=0.6.21
+          pip install python-pptx>=0.6.21 PyYAML>=6.0
           echo "✅ Python dependencies installed"
 
       - name: 🧪 Test content generation capability

--- a/Dockerfile.book-builder
+++ b/Dockerfile.book-builder
@@ -58,7 +58,7 @@ RUN wget -q https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pa
 RUN npm install -g @mermaid-js/mermaid-cli
 
 # Install Python dependencies
-RUN pip3 install python-pptx>=0.6.21
+RUN pip3 install python-pptx>=0.6.21 PyYAML>=6.0
 
 # Set Chrome executable for Puppeteer with proper sandbox configuration
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable

--- a/generate_presentation.py
+++ b/generate_presentation.py
@@ -39,7 +39,13 @@ import glob
 import re
 from pathlib import Path
 import json
-import yaml
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency check
+    print("❌ Error: PyYAML library not installed")
+    print("   Install with: pip install PyYAML>=6.0")
+    sys.exit(1)
 
 
 def _load_canonical_chapter_filenames(requirements_path=Path("BOOK_REQUIREMENTS.md")):
@@ -903,7 +909,12 @@ def main():
         f.write(pptx_script)
     
     # Create requirements file for presentation generation
-    requirements = "python-pptx>=0.6.21\n"
+    requirements = "\n".join(
+        [
+            "python-pptx>=0.6.21",
+            "PyYAML>=6.0",
+        ]
+    ) + "\n"
     with open(presentations_dir / "requirements.txt", 'w', encoding='utf-8') as f:
         f.write(requirements)
     


### PR DESCRIPTION
## Summary
- ensure the presentation generator gracefully reports when PyYAML is missing
- add the PyYAML dependency to the unified release workflow and Docker image
- update presentation automation to install and verify PyYAML alongside python-pptx

## Testing
- python3 generate_presentation.py --release

------
https://chatgpt.com/codex/tasks/task_e_68e7a566dd908330be134a41929fbba7