### PR TITLE
Revert unified workflow to last successful configuration

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -271,7 +271,7 @@ jobs:
         run: |
           echo "=== Installing Python dependencies ==="
           python3 -m pip install --upgrade pip
-          pip install python-pptx>=0.6.21 PyYAML>=6.0
+          pip install python-pptx>=0.6.21
           echo "✅ Python dependencies installed"
 
       - name: 🧪 Test content generation capability


### PR DESCRIPTION
## Summary
- restore the Unified Build & Release workflow to the version used in run 18359280640 by removing the additional PyYAML dependency from the Python install step

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e80e7e302c83309e195c2ae640cb16