### PR TITLE
Refine CI incident write-up for run 18386920895

### DIFF
--- a/docs/ci_run_18386920895_analysis.md
+++ b/docs/ci_run_18386920895_analysis.md
@@ -1,0 +1,28 @@
+# GitHub Actions Failure Analysis: Run 18386920895
+
+## Incident Overview
+- **Run URL:** [18386920895](https://github.com/Geonitab/architecture_as_code/actions/runs/18386920895)
+- **Trigger:** Pull request `codex/fix-errors-in-build_book.sh`
+- **Failed Jobs:** "🚀 Traditional Complete Build" and "🐳 Docker Optimized Build"
+- **Failing Step:** `docs/build_book.sh --release` (invoked via `build_release.sh`)
+
+## Impact
+- Unified release workflow stopped before producing EPUB and DOCX assets.
+- Both jobs reported a `failure` conclusion, preventing the PR from merging automatically.
+
+## Technical Findings
+### Failing Step Details
+`docs/build_book.sh` prepares a chapter manifest that now includes every part marker (`docs/part_*.md`) before running Pandoc for all formats.【F:docs/build_book.sh†L235-L275】 Each marker contains LaTeX-only commands (`\part{...}`, `\setbookpart{...}`) intended for the PDF output.【F:docs/part_a_foundations.md†L1-L3】
+
+When the script proceeds to `generate_other_formats()` it reuses the same manifest for EPUB and DOCX conversions. Pandoc cannot parse the raw LaTeX in those formats, causing the EPUB command to exit non-zero. The script bubbles up the failure (`return 1`), which stops both CI jobs.【F:docs/build_book.sh†L368-L408】
+
+### Comparison with Run 18359280640
+Run [18359280640](https://github.com/Geonitab/architecture_as_code/actions/runs/18359280640) built commit `97bd9861a457c019d0fd5770e1f697670a7ae0a1` on `main` and succeeded.【fd63a4†L1-L7】 That revision of `docs/build_book.sh` did not add the part marker files to the shared manifest, so EPUB/DOCX steps never encountered the LaTeX directives and the workflow completed successfully.
+
+## Remediation Plan
+1. **Short-term:** Skip or sanitize the part marker files when generating non-LaTeX formats to restore EPUB/DOCX builds while keeping the improved PDF structure.
+2. **Long-term:** Add automated coverage (unit test or smoke step) to ensure future modifications to `CHAPTER_FILES` do not reintroduce incompatible content for alternate targets.
+
+## Validation Strategy
+- After updating `docs/build_book.sh`, rerun `python3 generate_book.py && docs/build_book.sh --release` locally or in CI to confirm all formats succeed.
+- Monitor subsequent GitHub Actions runs for both PRs and `main` pushes to ensure no regression.


### PR DESCRIPTION
## Summary
- refine the CI incident report for run 18386920895 with clearer impact, findings, and remediation steps
- document that the updated build_book.sh now injects LaTeX-only part marker files and that EPUB/DOCX generation needs guards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e81c3116e083308aa68ddb688e507d