### PR TITLE
Skip LaTeX part markers for non-LaTeX book builds

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -274,6 +274,15 @@ CHAPTER_FILES=(
     "31_technical_architecture.md"
 )
 
+# Build a sanitized list that excludes LaTeX-only part markers for non-LaTeX formats
+NON_LATEX_CHAPTER_FILES=()
+for chapter_file in "${CHAPTER_FILES[@]}"; do
+    if [[ $chapter_file == part_*.md ]]; then
+        continue
+    fi
+    NON_LATEX_CHAPTER_FILES+=("$chapter_file")
+done
+
 pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -o "$OUTPUT_PDF" 2>&1
 
 # Check if PDF was actually generated
@@ -370,7 +379,7 @@ generate_other_formats() {
     echo "Generating EPUB format..."
 
     # Generate EPUB with improved metadata
-    if pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" \
+    if pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" \
         -t epub \
         -o "$OUTPUT_EPUB" \
         --metadata date="$(date +'%Y-%m-%d')" \
@@ -406,7 +415,7 @@ generate_other_formats() {
     fi
 
     echo "Generating DOCX format..."
-    pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -t docx -o "$OUTPUT_DOCX"
+    pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" -t docx -o "$OUTPUT_DOCX"
     echo "DOCX generated: $OUTPUT_DOCX"
     cp "$OUTPUT_DOCX" "$RELEASE_DOCX"
     echo "DOCX copied to release directory: $RELEASE_DOCX"


### PR DESCRIPTION
## Summary
- create a sanitized chapter manifest without part marker files for formats that are not rendered with LaTeX
- reuse the sanitized manifest when producing EPUB and DOCX outputs so Pandoc no longer encounters LaTeX-only commands

## Testing
- python3 generate_book.py && docs/build_book.sh --release *(fails: missing `xelatex` in the environment after Pandoc installation)*

------
https://chatgpt.com/codex/tasks/task_e_68e8216c913c8330b45af084f7ef605d