### PR TITLE
Ensure workflows use British English phrasing

### DIFF
--- a/.github/workflows/architect-bot.yml
+++ b/.github/workflows/architect-bot.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - labeled
       - reopened
-  workflow_dispatch:  # Möjliggör manuell körning
+  workflow_dispatch:  # Enables manual execution
 
 permissions:
   contents: write

--- a/.github/workflows/generate-presentations.yml
+++ b/.github/workflows/generate-presentations.yml
@@ -122,7 +122,7 @@ jobs:
           echo "🎯 Enhanced features:"
           echo "   - Word limit: 20 words maximum per slide key point"
           echo "   - Diagram integration: Automatic inclusion of chapter diagrams"
-          echo "   - Swedish theme: Professional blue color scheme"
+          echo "   - Swedish theme: Professional blue colour scheme"
           
           # Run the presentation generation script with --create-pptx flag
           if python3 generate_presentation.py --create-pptx; then


### PR DESCRIPTION
## Summary
- replace the Swedish workflow dispatch comment with a British English explanation in the architect bot workflow
- update the presentation generation messaging to use British English spelling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8939c8fa08330ad3a71192f48f3ac