### PR TITLE
Add issue backlog for chapter modernisation

### DIFF
--- a/issues/001-general-manuscript-modernisation.md
+++ b/issues/001-general-manuscript-modernisation.md
@@ -1,0 +1,22 @@
+# General Manuscript Modernisation
+
+## Summary
+Ensure the entire manuscript aligns with global guidance by removing Swedish-specific content, standardising presentation, and improving explanatory context across diagrams and code samples.
+
+## Tasks
+- [ ] Remove instructions and examples that rely on Swedish-specific assumptions or organisations throughout the manuscript.
+- [ ] Confirm every heading begins with a capital letter and update any that do not.
+- [ ] Verify all diagrams are generated successfully and referenced correctly in the surrounding prose.
+- [ ] Relocate long code listings to the appendix and insert cross-references from the relevant chapters.
+- [ ] Add explanatory paragraphs before and after each code snippet and small diagram to clarify intent and expected outcomes.
+
+## Acceptance Criteria
+- All chapters are free from Sweden-specific references unless explicitly required for universal context.
+- Headings consistently start with capital letters across the book.
+- Each diagram renders correctly and has at least one textual reference in its chapter.
+- Lengthy code blocks reside in appendices with clear forward references in the main chapters.
+- Code snippets and diagrams are framed with descriptive prose that explains their purpose and results.
+
+## Labels
+- documentation
+- design

--- a/issues/006-remove-chapter-6.md
+++ b/issues/006-remove-chapter-6.md
@@ -1,0 +1,17 @@
+# Retire Chapter 6
+
+## Summary
+Remove Chapter 6 from the manuscript to align with the updated table of contents and avoid redundant material.
+
+## Tasks
+- [ ] Delete the Chapter 6 markdown file and associated references in the table of contents or navigation.
+- [ ] Ensure cross-references from other chapters no longer point to Chapter 6.
+- [ ] Update any automation scripts or indices that enumerate chapters so Chapter 6 is excluded.
+
+## Acceptance Criteria
+- Chapter 6 content is no longer present in the repository or generated outputs.
+- No table of contents entries or cross-links refer to Chapter 6.
+- Build scripts and indices reflect the updated chapter numbering without errors.
+
+## Labels
+- documentation

--- a/issues/007-refresh-chapter-7.md
+++ b/issues/007-refresh-chapter-7.md
@@ -1,0 +1,17 @@
+# Refresh Chapter 7
+
+## Summary
+Clean up Chapter 7 by translating remaining Swedish text and ensuring terminology aligns with British English usage.
+
+## Tasks
+- [ ] Translate all Swedish words and phrases in Chapter 7 into British English.
+- [ ] Review examples and scenarios to confirm they are globally applicable.
+- [ ] Proofread the chapter for consistent tone and terminology after translation.
+
+## Acceptance Criteria
+- Chapter 7 contains only British English text.
+- Examples no longer assume Swedish-specific context.
+- Language quality passes editorial review without mixed-language remnants.
+
+## Labels
+- documentation

--- a/issues/008-remove-chapter-8.md
+++ b/issues/008-remove-chapter-8.md
@@ -1,0 +1,17 @@
+# Retire Chapter 8
+
+## Summary
+Remove Chapter 8 entirely to streamline the structure and eliminate outdated guidance.
+
+## Tasks
+- [ ] Delete the Chapter 8 markdown file and related assets.
+- [ ] Update the table of contents, indices, and cross-references to skip Chapter 8.
+- [ ] Ensure chapter numbering or navigation adjusts correctly after removal.
+
+## Acceptance Criteria
+- Chapter 8 content is absent from the repository and generated outputs.
+- No links or references point to the former Chapter 8.
+- Automated builds succeed with the revised chapter list.
+
+## Labels
+- documentation

--- a/issues/009-translate-chapter-9.md
+++ b/issues/009-translate-chapter-9.md
@@ -1,0 +1,17 @@
+# Translate Chapter 9
+
+## Summary
+Convert Chapter 9 to British English while maintaining technical precision and consistent terminology.
+
+## Tasks
+- [ ] Identify and translate all Swedish language segments within Chapter 9.
+- [ ] Validate that terminology aligns with the rest of the English manuscript.
+- [ ] Conduct an editorial pass to ensure flow and clarity after translation.
+
+## Acceptance Criteria
+- Chapter 9 is fully written in British English without residual Swedish words.
+- Technical terms match the glossary or established usage across the book.
+- Editorial review confirms readability and coherence.
+
+## Labels
+- documentation

--- a/issues/010-overhaul-chapter-10.md
+++ b/issues/010-overhaul-chapter-10.md
@@ -1,0 +1,21 @@
+# Overhaul Chapter 10
+
+## Summary
+Refresh Chapter 10 by translating remaining Swedish content, fixing diagram coverage, and restructuring code sections for clarity.
+
+## Tasks
+- [ ] Translate all Swedish terminology and prose in Chapter 10 into British English.
+- [ ] Create any missing diagrams and ensure they render correctly.
+- [ ] Format code snippets using fenced code blocks with appropriate language identifiers.
+- [ ] Move lengthy code listings to the appendix and replace them with succinct summaries and references.
+- [ ] Add in-text references to each diagram and relocated appendix section.
+
+## Acceptance Criteria
+- Chapter 10 is entirely in British English with consistent terminology.
+- All required diagrams appear, render correctly, and are referenced in the text.
+- Code snippets use markdown code fences, and extended listings reside in the appendix with citations.
+- Narrative clearly describes each code example and directs readers to appendix content where applicable.
+
+## Labels
+- documentation
+- design

--- a/issues/011-fix-chapter-11.md
+++ b/issues/011-fix-chapter-11.md
@@ -1,0 +1,18 @@
+# Fix Chapter 11
+
+## Summary
+Revise Chapter 11 by repairing visual assets and converting the outline into coherent prose.
+
+## Tasks
+- [ ] Replace the empty sequence diagram with a complete version that matches the narrative.
+- [ ] Rewrite bullet-point sections as flowing prose paragraphs.
+- [ ] Ensure the new diagram is referenced and explained in the chapter text.
+
+## Acceptance Criteria
+- Chapter 11 contains a populated sequence diagram with accurate content.
+- All sections are written in paragraph form without bullet lists unless absolutely necessary.
+- The diagram is cited in the text with surrounding explanation.
+
+## Labels
+- documentation
+- design

--- a/issues/012-complete-chapter-12-diagrams.md
+++ b/issues/012-complete-chapter-12-diagrams.md
@@ -1,0 +1,18 @@
+# Complete Chapter 12 Diagrams
+
+## Summary
+Add the required diagrams to Chapter 12 and integrate them with explanatory text.
+
+## Tasks
+- [ ] Identify the diagram types needed for Chapter 12 and create them using Mermaid or the approved tooling.
+- [ ] Ensure each diagram renders correctly and is stored with the chapter assets.
+- [ ] Insert descriptive prose that references and explains every diagram.
+
+## Acceptance Criteria
+- All planned diagrams for Chapter 12 exist, render without errors, and are committed to source control.
+- Chapter 12 references each diagram explicitly and describes its key insights.
+- Book builds succeed with the new diagrams included.
+
+## Labels
+- documentation
+- design

--- a/issues/013-restructure-chapter-13.md
+++ b/issues/013-restructure-chapter-13.md
@@ -1,0 +1,21 @@
+# Restructure Chapter 13
+
+## Summary
+Update Chapter 13 by translating remaining Swedish content, completing diagrams, and improving layout for readability.
+
+## Tasks
+- [ ] Translate all Swedish prose in Chapter 13 into British English.
+- [ ] Create the missing diagrams and ensure they use an appropriate layout for clarity.
+- [ ] Move extensive code listings to the appendix and add references in the chapter text.
+- [ ] Reformat Figure 13.2 using a vertical layout to reduce crowding and improve legibility.
+- [ ] Add explanatory paragraphs around each diagram and code reference.
+
+## Acceptance Criteria
+- Chapter 13 is entirely in British English with consistent terminology.
+- All diagrams are present, legible, and referenced in the text, including an updated Figure 13.2 with a vertical layout.
+- Lengthy code samples reside in the appendix with clear references in the main chapter.
+- Narrative context explains each visual and code element before and after presentation.
+
+## Labels
+- documentation
+- design

--- a/issues/014-update-chapter-14.md
+++ b/issues/014-update-chapter-14.md
@@ -1,0 +1,20 @@
+# Update Chapter 14
+
+## Summary
+Revise Chapter 14 to ensure British English terminology, streamlined visuals, and concise code presentation.
+
+## Tasks
+- [ ] Translate all Swedish text in Chapter 14 into British English.
+- [ ] Simplify Figure 14.2 by reducing detail and ensuring the diagram remains legible.
+- [ ] Relocate long code sections to the appendix and add clear references within the chapter.
+- [ ] Provide contextual prose explaining each diagram and code snippet.
+
+## Acceptance Criteria
+- Chapter 14 contains exclusively British English prose with no Swedish terminology.
+- Figure 14.2 uses an appropriate level of detail and remains easy to read.
+- Extended code listings are moved to the appendix and referenced in the chapter narrative.
+- Each visual and code snippet is introduced and summarised within the surrounding text.
+
+## Labels
+- documentation
+- design

--- a/issues/015-enhance-chapter-15.md
+++ b/issues/015-enhance-chapter-15.md
@@ -1,0 +1,18 @@
+# Enhance Chapter 15
+
+## Summary
+Augment Chapter 15 with required diagrams and relocate large code samples to supporting appendices.
+
+## Tasks
+- [ ] Identify and create the missing diagrams for Chapter 15 using the approved tooling.
+- [ ] Ensure each diagram is referenced and explained in the chapter narrative.
+- [ ] Move long code blocks to the appendix and provide cross-references in the chapter.
+
+## Acceptance Criteria
+- Chapter 15 includes all necessary diagrams with clear textual references.
+- Diagrams render correctly and complement the surrounding prose.
+- Lengthy code listings are housed in the appendix with explanatory references in the chapter.
+
+## Labels
+- documentation
+- design

--- a/issues/016-refresh-chapter-16.md
+++ b/issues/016-refresh-chapter-16.md
@@ -1,0 +1,20 @@
+# Refresh Chapter 16
+
+## Summary
+Update Chapter 16 to include required diagrams, British English prose, and streamlined code references.
+
+## Tasks
+- [ ] Translate remaining Swedish content in Chapter 16 into British English.
+- [ ] Create the missing diagrams and ensure they render correctly.
+- [ ] Relocate extensive code sections to the appendix with clear references from the chapter.
+- [ ] Provide explanatory prose surrounding each diagram and code reference.
+
+## Acceptance Criteria
+- Chapter 16 is fully written in British English with no Swedish terminology.
+- All diagrams are present, legible, and referenced in the text.
+- Long code listings live in the appendix with corresponding references in the chapter narrative.
+- Descriptive paragraphs contextualise each diagram and code excerpt.
+
+## Labels
+- documentation
+- design

--- a/issues/017-rework-chapter-17.md
+++ b/issues/017-rework-chapter-17.md
@@ -1,0 +1,22 @@
+# Rework Chapter 17
+
+## Summary
+Bring Chapter 17 up to publication quality by addressing translation gaps, diagram consistency, and code placement.
+
+## Tasks
+- [ ] Translate all Swedish text into British English and remove references to Swedish organisations.
+- [ ] Create missing diagrams and ensure each is referenced within the chapter.
+- [ ] Update Figure 17.2 to use the standard grey Mermaid theme with improved legibility and readable text sizing.
+- [ ] Move long code listings to the appendix and add cross-references in the chapter body.
+- [ ] Provide narrative context before and after each diagram and code reference.
+
+## Acceptance Criteria
+- Chapter 17 contains only British English prose with globally relevant examples.
+- All diagrams are present, rendered with the unified grey theme, and referenced in the text.
+- Figure 17.2 is easy to read with consistent styling and sufficient text size.
+- Extended code samples are relocated to the appendix with clear references in the chapter.
+- Explanatory paragraphs surround each diagram and code snippet to clarify their purpose.
+
+## Labels
+- documentation
+- design

--- a/issues/018-balance-chapter-18.md
+++ b/issues/018-balance-chapter-18.md
@@ -1,0 +1,21 @@
+# Balance Chapter 18
+
+## Summary
+Improve Chapter 18 by translating residual Swedish content, ensuring diagrams are present, and distributing code explanations evenly.
+
+## Tasks
+- [ ] Translate all Swedish prose into British English.
+- [ ] Create the missing diagrams and ensure each is referenced in the text.
+- [ ] Format all code snippets using fenced code blocks with correct language tags.
+- [ ] Add introductory and concluding paragraphs around each code block describing its intent and outcome.
+- [ ] Redistribute code examples so they are evenly spaced throughout the chapter with supporting visuals.
+
+## Acceptance Criteria
+- Chapter 18 is fully in British English and free from Swedish terminology.
+- Each required diagram exists, renders correctly, and is referenced with explanatory prose.
+- Code snippets appear as fenced code blocks and are preceded and followed by descriptive text.
+- Code examples are distributed evenly across the chapter with complementary diagrams explaining their goals.
+
+## Labels
+- documentation
+- design

--- a/issues/019-fix-chapter-19-visuals.md
+++ b/issues/019-fix-chapter-19-visuals.md
@@ -1,0 +1,18 @@
+# Fix Chapter 19 Visuals
+
+## Summary
+Strengthen Chapter 19 by adding an introductory diagram and ensuring Mermaid code renders as graphics.
+
+## Tasks
+- [ ] Design and include an opening diagram that introduces the chapter’s core concept.
+- [ ] Update Mermaid source files so diagrams render as images rather than displaying raw code.
+- [ ] Reference the diagrams within the chapter text and explain their relevance.
+
+## Acceptance Criteria
+- Chapter 19 begins with a clear diagram that frames the chapter’s themes.
+- Mermaid diagrams render as images in generated outputs with no raw code displayed.
+- The chapter text references and explains each diagram.
+
+## Labels
+- documentation
+- design

--- a/issues/020-rewrite-chapter-20.md
+++ b/issues/020-rewrite-chapter-20.md
@@ -1,0 +1,20 @@
+# Rewrite Chapter 20
+
+## Summary
+Revise Chapter 20 to deliver British English prose, cohesive structure, and updated content focusing on AI agent interactions.
+
+## Tasks
+- [ ] Translate the entire chapter into British English and ensure consistent terminology.
+- [ ] Convert bullet-point sections into flowing prose where appropriate.
+- [ ] Redesign Section 20.3 to remove the time dimension and describe how AI agents update cases based on their communications.
+- [ ] Remove Section 20.5 entirely and adjust cross-references accordingly.
+- [ ] Review diagrams and tables to ensure they align with the updated narrative.
+
+## Acceptance Criteria
+- Chapter 20 is written in British English with minimal bullet formatting, using prose instead.
+- Section 20.3 presents an updated table describing AI agent collaboration without time-based columns.
+- Section 20.5 is removed and no references to it remain.
+- Visual elements and text are aligned and mutually reinforcing.
+
+## Labels
+- documentation

--- a/issues/021-reimagine-chapter-21.md
+++ b/issues/021-reimagine-chapter-21.md
@@ -1,0 +1,22 @@
+# Reimagine Chapter 21
+
+## Summary
+Transform Chapter 21 to remove Swedish-specific framing, update diagrams, and streamline the structure for clarity.
+
+## Tasks
+- [ ] Translate Chapter 21 into British English and remove references to Swedish organisations or policies.
+- [ ] Create missing diagrams and ensure they adopt the agreed styling and vertical layout where necessary.
+- [ ] Redesign Figure 21.2 as a vertically oriented mind map with simplified detail and accessible colours.
+- [ ] Remove Sections 21.2.3 and 21.3, updating navigation and references accordingly.
+- [ ] Provide explanatory prose for each diagram and ensure the chapter flows logically after restructuring.
+
+## Acceptance Criteria
+- Chapter 21 is fully in British English with globally relevant examples.
+- All diagrams are present, use the approved styling, and are explicitly referenced in the text.
+- Figure 21.2 appears as a readable vertical mind map with a neutral colour palette.
+- Sections 21.2.3 and 21.3 are removed without leaving dangling references.
+- Chapter narrative flows smoothly with appropriate context around each visual.
+
+## Labels
+- documentation
+- design

--- a/issues/022-remove-chapter-22.md
+++ b/issues/022-remove-chapter-22.md
@@ -1,0 +1,17 @@
+# Retire Chapter 22
+
+## Summary
+Remove Chapter 22 from the manuscript to reflect the updated scope and avoid redundant coverage.
+
+## Tasks
+- [ ] Delete the Chapter 22 markdown file and associated assets.
+- [ ] Update the table of contents and navigation to exclude Chapter 22.
+- [ ] Ensure references from other chapters no longer point to Chapter 22.
+
+## Acceptance Criteria
+- Chapter 22 is removed from the repository and generated outputs.
+- No navigation elements or cross-references mention Chapter 22.
+- Automated builds succeed without Chapter 22 content.
+
+## Labels
+- documentation

--- a/issues/023-revise-chapter-23-mindmap.md
+++ b/issues/023-revise-chapter-23-mindmap.md
@@ -1,0 +1,18 @@
+# Revise Chapter 23 Mind Map
+
+## Summary
+Improve Chapter 23 by fixing the unreadable mind map and ensuring visual accessibility.
+
+## Tasks
+- [ ] Redesign the mind map so that text contrasts clearly against the background.
+- [ ] Apply the standard colour palette and ensure font sizes remain legible.
+- [ ] Reference the updated mind map within the chapter and describe its key takeaways.
+
+## Acceptance Criteria
+- Chapter 23 features a mind map with readable text and compliant colours.
+- The diagram uses the approved styling and is referenced in the chapter narrative.
+- Generated outputs display the mind map without accessibility issues.
+
+## Labels
+- documentation
+- design

--- a/issues/024-modernise-chapter-24.md
+++ b/issues/024-modernise-chapter-24.md
@@ -1,0 +1,22 @@
+# Modernise Chapter 24
+
+## Summary
+Revise Chapter 24 to eliminate Swedish-specific context, translate to British English, and improve supporting visuals.
+
+## Tasks
+- [ ] Translate the entire chapter into British English and remove Swedish organisational references.
+- [ ] Create any missing diagrams and ensure they are referenced in the text.
+- [ ] Redesign Figure 24.2 as a vertically oriented mind map with simplified detail and accessible colours.
+- [ ] Remove Section 24.15.6 and adjust cross-references accordingly.
+- [ ] Provide descriptive prose before and after each diagram and code reference.
+
+## Acceptance Criteria
+- Chapter 24 contains only British English prose with globally relevant examples.
+- All required diagrams exist, follow the approved styling, and are referenced in the narrative.
+- Figure 24.2 is vertically oriented, easy to read, and visually consistent.
+- Section 24.15.6 is removed without leaving broken references.
+- The chapter includes explanatory text framing each diagram and code element.
+
+## Labels
+- documentation
+- design

--- a/issues/025-026-merge-chapters.md
+++ b/issues/025-026-merge-chapters.md
@@ -1,0 +1,21 @@
+# Merge Chapters 25 And 26
+
+## Summary
+Combine Chapters 25 and 26 into a unified chapter with British English prose, complete diagrams, and globally relevant examples.
+
+## Tasks
+- [ ] Remove Swedish organisational focus from the existing Chapter 25 content.
+- [ ] Ensure Chapter 26 content is rewritten as flowing prose instead of bullet lists.
+- [ ] Create any missing diagrams and integrate them with explanatory text.
+- [ ] Merge the two chapters into a single cohesive chapter with updated numbering and navigation.
+- [ ] Review the merged chapter for consistent tone, references, and diagram citations.
+
+## Acceptance Criteria
+- Chapters 25 and 26 are consolidated into a single chapter with updated file names and references.
+- The merged chapter is written in British English, free from Swedish-specific context, and uses paragraph-based prose.
+- All required diagrams are present, rendered correctly, and referenced in the text.
+- Table of contents, indices, and cross-references reflect the merged structure without errors.
+
+## Labels
+- documentation
+- design

--- a/issues/027-refresh-chapter-27.md
+++ b/issues/027-refresh-chapter-27.md
@@ -1,0 +1,20 @@
+# Refresh Chapter 27
+
+## Summary
+Update Chapter 27 to ensure accurate terminology, British English prose, and a streamlined structure without unsupported visuals.
+
+## Tasks
+- [ ] Correct terminology to emphasise "Architecture as Code" rather than "Infrastructure as Code" where applicable.
+- [ ] Translate all remaining content into British English.
+- [ ] Remove Figure 27.1 and adjust surrounding text to reflect its absence.
+- [ ] Delete Section 27.1.2 and update references accordingly.
+- [ ] Fix Section 27.2.1 so that narrative content appears in the body rather than the heading.
+
+## Acceptance Criteria
+- Chapter 27 consistently uses "Architecture as Code" terminology.
+- The chapter is fully written in British English with coherent prose.
+- Figure 27.1 and Section 27.1.2 are removed without leaving broken references.
+- Section 27.2.1 has a clean heading with explanatory text in the body.
+
+## Labels
+- documentation

--- a/issues/028-expand-chapter-28-glossary.md
+++ b/issues/028-expand-chapter-28-glossary.md
@@ -1,0 +1,20 @@
+# Expand Chapter 28 Glossary
+
+## Summary
+Enhance Chapter 28 by completing the relationships diagram and ensuring terminology coverage is inclusive and comprehensive.
+
+## Tasks
+- [ ] Update the relationships diagram to include all key terms with clear connections.
+- [ ] Review the rest of the book to identify missing terms and incorporate them into Chapter 28.
+- [ ] Ensure terminology uses inclusive language and aligns with the updated glossary.
+- [ ] Reference the completed diagram and new terms within the chapter narrative.
+
+## Acceptance Criteria
+- The Chapter 28 relationships diagram covers all major terms with accurate links.
+- Additional important terms from other chapters are included and defined.
+- Language throughout the chapter is inclusive and matches glossary standards.
+- The chapter text references the diagram and highlights newly added terms.
+
+## Labels
+- documentation
+- design

--- a/issues/029-create-new-chapter-29.md
+++ b/issues/029-create-new-chapter-29.md
@@ -1,0 +1,21 @@
+# Create New Chapter 29
+
+## Summary
+Replace the existing Chapter 29 with a new chapter profiling Gunnar Nordqvist, drawing on information from kvadrat.se.
+
+## Tasks
+- [ ] Remove the current Chapter 29 content and associated assets.
+- [ ] Research Gunnar Nordqvist using kvadrat.se as the primary source.
+- [ ] Draft a new Chapter 29 in British English that introduces the author and contextualises the book within his expertise.
+- [ ] Add any supporting visuals or sidebars needed to illustrate key themes, ensuring they follow style guidelines.
+- [ ] Update the table of contents and cross-references to reflect the new chapter focus.
+
+## Acceptance Criteria
+- The old Chapter 29 is fully replaced with a new narrative about Gunnar Nordqvist.
+- Content is sourced from kvadrat.se and written in British English with proper attribution where required.
+- Any diagrams or call-outs comply with styling standards and are referenced in the text.
+- Navigation and references throughout the book acknowledge the new Chapter 29 content.
+
+## Labels
+- documentation
+- design

--- a/issues/031-update-chapter-31.md
+++ b/issues/031-update-chapter-31.md
@@ -1,0 +1,17 @@
+# Update Chapter 31
+
+## Summary
+Translate Chapter 31 into British English and clarify the Markdown example formatting in Section 31.1.2.
+
+## Tasks
+- [ ] Translate all Chapter 31 content into British English.
+- [ ] Format the example in Section 31.1.2 using fenced Markdown code blocks for clarity.
+- [ ] Verify surrounding prose introduces and explains the example.
+
+## Acceptance Criteria
+- Chapter 31 contains only British English text with consistent terminology.
+- Section 31.1.2 displays its example within a fenced code block annotated as Markdown.
+- The narrative clearly explains the purpose of the example before and after the code block.
+
+## Labels
+- documentation


### PR DESCRIPTION
## Summary
- add documentation issues outlining general manuscript modernisation tasks
- create chapter-specific issues covering translation, diagram, and structure updates from chapters 6 through 31
- capture special restructuring requirements, including chapter removals, merges, and new author profile content

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68eb779a1c24833084ad2782af72dfac