### PR TITLE
Rewrite chapter 27 conclusion in English

### DIFF
--- a/docs/27_conclusion.md
+++ b/docs/27_conclusion.md
@@ -1,85 +1,103 @@
 # Conclusion
 
-![Framgångsnycklar for architecture as code](images/diagram_22_slutsats.png)
+Architecture as Code has transformed how organisations design, deliver, and evolve their technology estates. By managing
+architecture artefacts as executable code we gain the same precision, repeatability, and governance controls that software
+engineering teams have relied on for decades. This book has traced that transformation from the
+[fundamental concepts](01_introduction.md) to [forward-looking developments](25_future_trends_development.md), showing how the
+practice underpins modern digital capabilities.
 
-Architecture as Code has transformed how organisationer think about and handles IT-infrastructure. Through treating Architecture as Code has vi enabled same precision, processes and quality controls as long existed within software development. This journey genAbout the Books 25 chapter has shown the way from [Fundamental Concepts](01_introduction.md) to [future advanced technologies](25_future_trends_development.md).
+## Key lessons from our Architecture as Code journey
 
-## Viktiga lessons from vår Architecture as Code-journey
+Sustained success with Architecture as Code depends on the interplay between technical craft and organisational intent. The
+most effective transformations are led by committed sponsors, supported by clear communication, and reinforced through
+structured learning programmes. The change practices explored in [chapter 17 on organisational change](17_organizational_change.md)
+show how leadership, coaching, and incremental adoption reduce disruption while building confidence across teams.
 
-implementation of Architecture as Code requires both technical excellence and organisatorisk change. successful transformations are characterized of strong management commitment, comprehensive training programs and gradual inforandestrategi as minimizes disruptions of existing operations, according to the principles vi explored in [chapter 16 about organizational change](17_organizational_change.md).
+### Technical and organisational alignment
 
-The technical aspect of Architecture as Code requires deep understanding for cloud technologies, Architecture as Code-automation tools and security principles as vi covered from [Fundamental principles](02_fundamental_principles.md) through [advanced policy as code](11_policy_sakerhet.md). simultaneously is organizational factors often crucial for success, including cultural change, competence development and process standardization.
+Architecture as Code asks teams to think about cloud platforms, automation tooling, and security principles as a single
+strategic capability. The technical foundations span [fundamental principles](02_fundamental_principles.md), disciplined
+[version control](03_version_control.md), and [automation through CI/CD](05_automation_devops_cicd.md). These practices must be
+matched by organisational investment in skills, culture, and operating models so that new workflows can flourish.
 
-### Progressionen through technical maturity
+### Building maturity through practice
 
-Vår throughgång började with Fundamental Concepts as declarative code and idempotens in [chapter 2](02_fundamental_principles.md), utvecklades through praktiska Architecture as Code-implementationsaspekter that [version control](03_version_control.md) and [CI/CD-automation](05_automation_devops_cicd.md), and kulminerade in advanced topics that [containerorkestrering](07_containerization.md) and [framtida AI-driven automation](25_future_trends_development.md).
+The journey through this book charts a deliberate increase in sophistication: from declarative blueprints and idempotent
+configuration in [chapter 2](02_fundamental_principles.md), through [container orchestration](07_containerization.md), to
+[future-facing automation patterns](25_future_trends_development.md). Security is treated as an architectural concern from the
+outset, evolving from [policy and security](10_policy_and_security.md) through [governance as code](11_governance_as_code.md) and
+[compliance operations](12_compliance.md). Each capability builds on the previous layer to create a resilient Architecture as
+Code platform.
 
-Säkerhetsaspekterna as introducerades in [chapter 10](10_sakerhet.md) fordjupades through [policy as code](11_policy_sakerhet.md) and [compliance-handling](12_compliance.md), which shows how security must throughsyra entire Architecture as Code-Architecture as Code-implementationen from design to drift.
+## European context and opportunities
 
-### Svenska organisationers unique utmaningar and possibilities
+Many organisations operate within regulatory and sustainability frameworks that shape their Architecture as Code ambitions. The
+[policy and security guidance](10_policy_and_security.md) and [compliance practices](12_compliance.md) demonstrate how European
+legislation such as GDPR influences data residency, encryption, and audit requirements. National sustainability goals, explored
+in [future trends](25_future_trends_development.md), encourage the use of carbon-aware workloads and responsible procurement. The
+wider digital transformation agenda in [chapter 21 on digitalisation](21_digitalization.md) highlights how Architecture as Code
+supports coordinated change across public and private sectors.
 
-GenAbout the Books chapter has vi sett how Swedish organizations stands infor specific Challenges and possibilities:
+## Future developments and technology trends
 
-- **GDPR and data sovereignty**: From [säkerhetskapitlet](10_sakerhet.md) to [policy implementation](11_policy_sakerhet.md) has vi sett how svenska/EU-regulations requires particular attention at dataskydd and compliance
-- **Klimatmål and sustainability**: [Framtidskapitlet](25_future_trends_development.md) belyste how Sveriges klimatneutralitetsmål 2045 driver innovation within carbon-aware computing and sustainable infrastructure
-- **Digitaliseringsstrategi**: [chapter 19 about digitalisering](19_digitalisering.md) visade how Architecture as Code enables The digitala transformation as Swedish organizations undergoes
+Cloud-native services, edge computing, and intelligent automation are accelerating the evolution of Architecture as Code. We
+examined how GitOps pipelines, policy engines, and AI-assisted operations in [chapter 25](25_future_trends_development.md) reduce
+manual effort while improving governance. Platform engineering, discussed in [management as code](19_management_as_code.md),
+illustrates how product-centric platform teams provide paved roads that encapsulate best practice and reduce cognitive load.
 
-## Framtida development and teknologiska trender
+Quantum-ready security planning demands attention today. Organisations with heightened security expectations should begin
+post-quantum preparation, extending the defensive patterns introduced in [policy and security](10_policy_and_security.md) and
+[compliance](12_compliance.md). Hybrid classical–quantum environments will emerge where specialised processors handle targeted
+optimisation tasks while traditional systems provide dependable control planes.
 
-Cloud-native technologies, edge computing and artificiell intelligens driver next generation of Architecture as Code, which vi explored in-depth in [chapter 20 about framtida trender](25_future_trends_development.md). Emerging technologies that GitOps, policy engines and intelligent automation will to ytterligare simplify and improve Architecture as Code-capabilities.
+## Recommendations for organisations
 
-Utvecklingen mot serverless computing and fully managed services forändrar what as needs is managed that Architecture as Code. Framtiden pekar mot higher abstraktion where Developers focuses on business logic with plattformen handles underliggande architecture automatically, which vi saw exemplifierat in diskussionen about [Platform Engineering](19_kapitel18.md).
+Organisations embarking on Architecture as Code initiatives should focus on pilot programmes that demonstrate tangible value
+without jeopardising critical services. Education, shared tooling, and clear ownership models build confidence and set
+expectations. The leadership guidance in [organisational change](17_organizational_change.md) reinforces the importance of
+communication, coaching, and community building.
 
-Machine learning-baserade optimeringar will to enable intelligent resource allocation, kostnadsprediktering and säkerhetshotsdetektion. This creates självläkande systems as kontinuerligt optimerar itself based on usage patterns and performance-metrics, according to the AI-drivna principerna from [framtidskapitlet](19_kapitel18.md).
+### Step-by-step adoption strategy
 
-### Kvantteknologi and säkerhetsutmaningar as vi diskuterade in [chapter 19](19_kapitel18.md), requires kvantdatorers development proaktiv forberedelse for post-quantum cryptography transition. Swedish organizations with critical security requirements must börja planera for quantum-safe transitions nu, which bygger vidare at the security principles as etablerades in [chapter 6](06_kapitel5.md) and [chapter 12](12_kapitel11.md).
+1. **Foundational education**: Establish a common understanding of [Architecture as Code principles](02_fundamental_principles.md)
+   and disciplined [version control practices](03_version_control.md).
+2. **Pilot projects**: Use [automation pipelines](05_automation_devops_cicd.md) to modernise a contained, low-risk service while
+   collecting feedback and metrics.
+3. **Security integration**: Embed [policy and security](10_policy_and_security.md) controls and [compliance processes](12_compliance.md)
+   into every delivery workflow.
+4. **Scaling and automation**: Expand towards [container orchestration](07_containerization.md) and platform capabilities described in
+   [management as code](19_management_as_code.md).
+5. **Future readiness**: Track [emerging trends](25_future_trends_development.md) and sustainability expectations so that the
+   Architecture as Code platform remains adaptable.
 
-Hybrid classical-quantum systems will to emerge where kvantdatorer is used for specific optimerungsproblem with klassiska systems handles general computing workloads. Infrastructure orchestration must support båda paradigmen sömlöst.
+Centres of excellence or platform teams can accelerate adoption by curating reusable modules, publishing reference
+implementations, and providing hands-on support. Governance structures maintain security and compliance without constraining
+innovation, enabling teams to deliver change with confidence.
 
-## Recommendations for organisationer
+## Continuous improvement and measurement
 
-Baserat at vår throughgång from Fundamental principles to advanced implementations, should organisationer påbörja their Architecture as Code-journey with pilot projects as demonstrerar value without to riskera critical systems. Investment in team education and tool standardization is critical for long-term success and adoption across organisationen, according to the strategier as beskrevs in [chapter 10 about organisatorisk change](10_kapitel9.md).
+Continuous improvement is woven into Architecture as Code. Metrics from [automation and DevOps practices](05_automation_devops_cicd.md)
+and insights from [team structure guidance](18_team_structure.md) help identify areas for refinement. Observability patterns, first
+introduced in [security and resilience chapters](09_security.md), support data-driven decisions and proactive optimisation. By
+regularly reviewing feedback loops, teams maintain momentum and prevent regression.
 
-### Stegvis implementationsstrategi
+## Closing reflection
 
-1. **Fundamental utbildning**: Börja with to etablera understanding for [Architecture as Code-principles](02_kapitel1.md) and [version control](03_kapitel2.md)
-2. **Pilotprojekt**: Implementera [CI/CD-pipelines](04_kapitel3.md) for smaller, icke-critical systems
-3. **Säkerhetsintegration**: Etablera [säkerhetspraxis](06_kapitel5.md) and [policy as code](12_kapitel11.md)
-4. **Skalning and automation**: Utöka to [containerorkestrering](11_kapitel10.md) and advanced workflows
-5. **Framtidsberedskap**: Forbereda for [emerging technologies](19_kapitel18.md) and hållbarhetsrequirements
+Architecture as Code is more than a technical milestone; it represents a fundamental shift in how we design and manage digital
+platforms. The journey from [introduction](01_introduction.md) through [technical implementation](14_practical_implementation.md),
+[security strategy](10_policy_and_security.md), and [future-oriented innovation](25_future_trends_development.md) shows that
+Architecture as Code thrives when engineering discipline and organisational stewardship progress together.
 
-Etablering of center of excellence or platform teams can accelerera adoption by tohandahålla standardized tools, Architecture as Code best practices and support for utvecklingsteam. Governance frameworks ensures Security and compliance without to begränsa innovation and agility, which vi saw in [compliance-kapitlet](14_kapitel13.md).
+### The way forward
 
-### Continuous improvement and mätning
-
-Continuous improvement culture is crucial where team regelbundet evaluater and improves sina Architecture as Code-processes. Metrics and monitoring helps to to identify forbättringwhichråden and mäta framsteg mot definierade goals, according to the praktiska examples as visades in [DevOps-kapitlet](07_kapitel6.md) and [organisationskapitlet](10_kapitel9.md).
-
-Investment in observability and monitoring from [säkerhetskapitlet](06_kapitel5.md) and [praktiska implementationen](08_kapitel7.md) enables data-driven decision making and continuous optimering of Architecture as Code-processes.
-
-## Slutord
-
-Architecture as Code represents mer than only technical evolution - the is a fundamental change of how vi think about infrastructure. by embraca Architecture as Code-principles can organisationer achieve increased agility, reliability and scalability while the reduces operational kostnader and risker.
-
-Vår journey through This bok - from [introduktionen to Architecture as Code-konceptet](01_introduction.md), through [technical implementationsdetaljer](02_kapitel1.md) and [praktiska utvecklingsprocesser](03_kapitel2.md), to [advanced security strategies](12_kapitel11.md) and [framtida technologies](19_kapitel18.md) - shows to Architecture as Code is both a technical discipline and a Organizational transformation.
-
-successful implementation requires tålamod, uthållighet and commitment to continuous learning. Organisationer as investerar in to bygga robust Architecture as Code-capabilities position themselves for framtida teknologiska changes and konkurrensfordel at marknaden.
-
-### Avslutande reflektion
-
-the principles as introducerades in bokens forsta chapter - declarative code, idempotens, testbarhet and automation - throughsyrar all aspects of modern infrastructure management. From [Fundamental version control](03_kapitel2.md) to [AI-driven optimization](19_kapitel18.md), These fundamental principles forblir konstanta also when teknologierna is developed.
-
-Swedish organizations has unique possibilities to leda within sustainable and compliant Architecture as Code implementation. by kombinera technical excellence with strong fokus at sustainability, security and regulatory compliance can Swedish companies and offentliga organisationer create competitive advantages as resonerar with nationella values and globala trender.
-
-Bokens progression from teori to praktik, from Fundamental to avancerat, speglar The journey as each organisation must throughgå to lyckas with Architecture as Code. each chapter builds on previous knowledge and forbereder for mer complex Challenges - precis as a verklig Architecture as Code-implementation.
-
-### the way framåt
-
-Architecture as Code is not a destination without a continuous journey of learning, experimentation and improvement. the tools, processes and principles as is described in This bok will to is developed, but the fundamental koncepten about code-driven infrastructure, automation and reproducibility will to forbli relevanta.
-
-Which vi has sett genAbout the Books 23 chapter, from [Fundamental introduction](01_introduction.md) to [framtida visioner](25_future_trends_development.md), represents Architecture as Code framtiden for IT operations. Organisationer as investerar in This journey idag creates foundation for morgondagens digitala success.
+The concepts outlined in this book—declarative intent, idempotence, automated testing, and continuous delivery—remain constants
+even as tooling evolves. By combining technical excellence with attention to sustainability, security, and regulatory
+obligations, organisations can use Architecture as Code to create enduring competitive advantage. The work continues: experiment,
+learn, and refine so that Architecture as Code keeps pace with the ambitions of the business and the expectations of society.
 
 Sources:
 - Industry reports on Architecture as Code adoption trends
-- Expert interviews and case studies  
+- Expert interviews and case studies
 - Research on emerging technologies
-- Best practice documentation from leading organizations
+- Best practice documentation from leading organisations
+


### PR DESCRIPTION
## Summary
- rewrite Chapter 27 to deliver a cohesive British English narrative focused on Architecture as Code concepts
- remove the obsolete Figure 27.1 and restructure the chapter headings to eliminate outdated references
- update cross-references and recommendations to align with current chapter names and emphasise organisational adoption steps

## Testing
- `python3 generate_book.py && docs/build_book.sh` *(fails: xelatex not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebeb060e188330a24bb9d87da6c7c9