### PR TITLE
Refresh Chapter 27 conclusion

### DIFF
--- a/docs/27_conclusion.md
+++ b/docs/27_conclusion.md
@@ -1,35 +1,46 @@
-# Conclusion
+# Chapter 27 – Conclusion
 
 Architecture as Code has transformed how organisations design, deliver, and evolve their technology estates. By managing
-architecture artefacts as executable code we gain the same precision, repeatability, and governance controls that software
+architectural artefacts as executable code we gain the same precision, repeatability, and governance controls that software
 engineering teams have relied on for decades. This book has traced that transformation from the
 [fundamental concepts](01_introduction.md) to [forward-looking developments](25_future_trends_development.md), showing how the
 practice underpins modern digital capabilities.
 
-## Key lessons from our Architecture as Code journey
+## 27.1 Consolidating the Architecture as Code mindset
 
 Sustained success with Architecture as Code depends on the interplay between technical craft and organisational intent. The
 most effective transformations are led by committed sponsors, supported by clear communication, and reinforced through
 structured learning programmes. The change practices explored in [chapter 17 on organisational change](17_organizational_change.md)
 show how leadership, coaching, and incremental adoption reduce disruption while building confidence across teams.
 
-### Technical and organisational alignment
+Architecture as Code stretches beyond infrastructure automation by codifying decision logic, policies, and integration
+patterns that articulate the enterprise blueprint. Maintaining this emphasis ensures that architectural outcomes remain the
+focal point, with infrastructure services treated as one contributor to a broader design system.
+
+### 27.1.1 Technical and organisational alignment
 
 Architecture as Code asks teams to think about cloud platforms, automation tooling, and security principles as a single
 strategic capability. The technical foundations span [fundamental principles](02_fundamental_principles.md), disciplined
 [version control](03_version_control.md), and [automation through CI/CD](05_automation_devops_cicd.md). These practices must be
 matched by organisational investment in skills, culture, and operating models so that new workflows can flourish.
 
-### Building maturity through practice
+## 27.2 Embedding continuous improvement
 
 The journey through this book charts a deliberate increase in sophistication: from declarative blueprints and idempotent
 configuration in [chapter 2](02_fundamental_principles.md), through [container orchestration](07_containerization.md), to
 [future-facing automation patterns](25_future_trends_development.md). Security is treated as an architectural concern from the
-outset, evolving from [policy and security](10_policy_and_security.md) through [governance as code](11_governance_as_code.md) and
-[compliance operations](12_compliance.md). Each capability builds on the previous layer to create a resilient Architecture as
-Code platform.
+outset, evolving from [policy and security](10_policy_and_security.md) through [governance as code](11_governance_as_code.md)
+and [compliance operations](12_compliance.md). Each capability builds on the previous layer to create a resilient Architecture
+as Code platform.
 
-## European context and opportunities
+### 27.2.1 Measuring and refining delivery
+
+Continuous improvement is woven into Architecture as Code. Metrics from [automation and DevOps practices](05_automation_devops_cicd.md)
+and insights from [team structure guidance](18_team_structure.md) help identify areas for refinement. Observability patterns,
+first introduced in [security and resilience chapters](09_security.md), support data-driven decisions and proactive
+optimisation. By regularly reviewing feedback loops, teams maintain momentum and prevent regression.
+
+## 27.3 European context and opportunities
 
 Many organisations operate within regulatory and sustainability frameworks that shape their Architecture as Code ambitions. The
 [policy and security guidance](10_policy_and_security.md) and [compliance practices](12_compliance.md) demonstrate how European
@@ -38,26 +49,14 @@ in [future trends](25_future_trends_development.md), encourage the use of carbon
 wider digital transformation agenda in [chapter 21 on digitalisation](21_digitalization.md) highlights how Architecture as Code
 supports coordinated change across public and private sectors.
 
-## Future developments and technology trends
-
-Cloud-native services, edge computing, and intelligent automation are accelerating the evolution of Architecture as Code. We
-examined how GitOps pipelines, policy engines, and AI-assisted operations in [chapter 25](25_future_trends_development.md) reduce
-manual effort while improving governance. Platform engineering, discussed in [management as code](19_management_as_code.md),
-illustrates how product-centric platform teams provide paved roads that encapsulate best practice and reduce cognitive load.
-
-Quantum-ready security planning demands attention today. Organisations with heightened security expectations should begin
-post-quantum preparation, extending the defensive patterns introduced in [policy and security](10_policy_and_security.md) and
-[compliance](12_compliance.md). Hybrid classical–quantum environments will emerge where specialised processors handle targeted
-optimisation tasks while traditional systems provide dependable control planes.
-
-## Recommendations for organisations
+## 27.4 Recommendations for organisations
 
 Organisations embarking on Architecture as Code initiatives should focus on pilot programmes that demonstrate tangible value
 without jeopardising critical services. Education, shared tooling, and clear ownership models build confidence and set
 expectations. The leadership guidance in [organisational change](17_organizational_change.md) reinforces the importance of
 communication, coaching, and community building.
 
-### Step-by-step adoption strategy
+### 27.4.1 Step-by-step adoption strategy
 
 1. **Foundational education**: Establish a common understanding of [Architecture as Code principles](02_fundamental_principles.md)
    and disciplined [version control practices](03_version_control.md).
@@ -74,21 +73,14 @@ Centres of excellence or platform teams can accelerate adoption by curating reus
 implementations, and providing hands-on support. Governance structures maintain security and compliance without constraining
 innovation, enabling teams to deliver change with confidence.
 
-## Continuous improvement and measurement
-
-Continuous improvement is woven into Architecture as Code. Metrics from [automation and DevOps practices](05_automation_devops_cicd.md)
-and insights from [team structure guidance](18_team_structure.md) help identify areas for refinement. Observability patterns, first
-introduced in [security and resilience chapters](09_security.md), support data-driven decisions and proactive optimisation. By
-regularly reviewing feedback loops, teams maintain momentum and prevent regression.
-
-## Closing reflection
+## 27.5 Closing reflection
 
 Architecture as Code is more than a technical milestone; it represents a fundamental shift in how we design and manage digital
 platforms. The journey from [introduction](01_introduction.md) through [technical implementation](14_practical_implementation.md),
 [security strategy](10_policy_and_security.md), and [future-oriented innovation](25_future_trends_development.md) shows that
 Architecture as Code thrives when engineering discipline and organisational stewardship progress together.
 
-### The way forward
+### 27.5.1 The way forward
 
 The concepts outlined in this book—declarative intent, idempotence, automated testing, and continuous delivery—remain constants
 even as tooling evolves. By combining technical excellence with attention to sustainability, security, and regulatory
@@ -100,4 +92,3 @@ Sources:
 - Expert interviews and case studies
 - Research on emerging technologies
 - Best practice documentation from leading organisations
-


### PR DESCRIPTION
## Summary
- restructure Chapter 27 with numbered sections to reinforce Architecture as Code terminology and British English prose
- emphasise architectural scope over infrastructure automation and update guidance and recommendations accordingly

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: xelatex not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebf20087b483308444f7a090c18eb2