### PR TITLE
Translate book cover assets to English

### DIFF
--- a/templates/book-cover-final.html
+++ b/templates/book-cover-final.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Professional Book Cover</title>
+    <title>Architecture as Code - Professional Book Cover</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -315,27 +315,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                <span class="title-line-1">Arkitektur</span>
-                <span class="title-line-2">som <span class="highlight">kod</span></span>
+                <span class="title-line-1">Architecture</span>
+                <span class="title-line-2">as <span class="highlight">Code</span></span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Kvadrat Expert Team
             </div>
             <div class="edition">
                 <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div>First Edition</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover-light.html
+++ b/templates/book-cover-light.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Light Variation</title>
+    <title>Architecture as Code - Light Variation</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -211,27 +211,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                <span class="title-line-1">Arkitektur</span>
-                <span class="title-line-2">som <span class="highlight">kod</span></span>
+                <span class="title-line-1">Architecture</span>
+                <span class="title-line-2">as <span class="highlight">Code</span></span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Kvadrat Expert Team
             </div>
             <div class="edition">
                 <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div>First Edition</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover-minimal.html
+++ b/templates/book-cover-minimal.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Minimal Variation</title>
+    <title>Architecture as Code - Minimal Variation</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -144,27 +144,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                Arkitektur<br>
-                som <span class="highlight">kod</span>
+                Architecture<br>
+                as <span class="highlight">Code</span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Kvadrat Expert Team
             </div>
             <div class="edition">
                 <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div>First Edition</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover.html
+++ b/templates/book-cover.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Bokframsida</title>
+    <title>Architecture as Code - Book Cover</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -185,27 +185,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                Arkitektur<br>
-                som <span class="highlight">kod</span>
+                Architecture<br>
+                as <span class="highlight">Code</span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Kvadrat Expert Team
             </div>
             <div class="edition">
                 <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div>First Edition</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover.svg
+++ b/templates/book-cover.svg
@@ -187,39 +187,39 @@
             text-anchor="middle" fill="hsl(221, 67%, 32%)">K</text>
       
       <!-- Brand text -->
-      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600" 
-            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLIKATION</text>
+      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600"
+            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLICATION</text>
     </g>
     
     <!-- Main title -->
     <g transform="translate(0, 189)">
-      <!-- Title line 1: "Arkitektur" -->
-      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Arkitektur</text>
-      
-      <!-- Title line 2: "som kod" with highlight -->
-      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">som </text>
-      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">kod</text>
+      <!-- Title line 1: "Architecture" -->
+      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Architecture</text>
+
+      <!-- Title line 2: "as Code" with highlight -->
+      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">as </text>
+      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">Code</text>
     </g>
     
     <!-- Subtitle -->
     <g transform="translate(0, 377)">
       <text font-family="Inter, sans-serif" font-size="22" font-weight="400" 
             fill="rgba(255,255,255,0.92)" line-height="1.5">
-        <tspan x="0" y="26">En omfattande guide till Infrastructure as Code -</tspan>
-        <tspan x="0" y="59">från grundläggande principer till avancerad</tspan>
-        <tspan x="0" y="92">implementation i moderna molnmiljöer</tspan>
-        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">DevOps • CI/CD • Säkerhet • Compliance • Molnarkitektur</tspan>
+        <tspan x="0" y="26">A comprehensive guide to architecture as code—</tspan>
+        <tspan x="0" y="59">from foundational principles to advanced</tspan>
+        <tspan x="0" y="92">implementation in modern cloud environments</tspan>
+        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">DevOps • CI/CD • Security • Compliance • Cloud Architecture</tspan>
       </text>
     </g>
     
     <!-- Footer -->
     <g transform="translate(0, 783)">
       <!-- Authors -->
-      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700" 
-            fill="white">Expertteamet på Kvadrat</text>
+      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700"
+            fill="white">Kvadrat Expert Team</text>
       
       <!-- Edition info -->
       <g transform="translate(450, 0)">
@@ -227,8 +227,8 @@
         <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800" 
               fill="url(#accentGradient)" text-anchor="end">2024</text>
         <!-- Edition text -->
-        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16" 
-              fill="rgba(255,255,255,0.85)" text-anchor="end">Första upplagan</text>
+        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16"
+              fill="rgba(255,255,255,0.85)" text-anchor="end">First Edition</text>
       </g>
     </g>
     
@@ -236,13 +236,13 @@
   
   <!-- Additional metadata for editing -->
   <metadata>
-    <title>Arkitektur som kod - Enhanced Book Cover</title>
+    <title>Architecture as Code - Enhanced Book Cover</title>
     <description>Professional book cover design for Kvadrat's Infrastructure as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
     <author>Kvadrat Design Team</author>
     <created>2024</created>
     <updated>December 2024</updated>
     <brand-guidelines>Kvadrat Brand Guidelines v1.0</brand-guidelines>
-    <themes>Infrastructure as Code, DevOps, CI/CD, Security, Cloud Architecture, Swedish Context</themes>
+    <themes>Infrastructure as Code, DevOps, CI/CD, Security, Cloud Architecture, Global Context</themes>
     <visual-elements>Pipeline patterns, security shields, cloud nodes, microservices, git repositories, containers</visual-elements>
   </metadata>
   

--- a/templates/kvadrat-book-template.latex
+++ b/templates/kvadrat-book-template.latex
@@ -9,7 +9,7 @@
 % Language and encoding
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
-\usepackage[swedish]{babel}
+\usepackage[$if(lang)$$babel-lang$$else$english$endif$]{babel}
 
 % Kvadrat color definitions
 \usepackage{xcolor}
@@ -61,7 +61,7 @@
 \fancyhead[RE]{\textcolor{KvadratGray}{\small\nouppercase{\leftmark}}}
 
 % Footer styling
-\fancyfoot[C]{\textcolor{KvadratGray}{\small Arkitektur som kod - Kvadrat Professional Publication}}
+\fancyfoot[C]{\textcolor{KvadratGray}{\small Architecture as Code - Kvadrat Professional Publication}}
 
 % Remove header rule and add custom styling
 \renewcommand{\headrulewidth}{0pt}
@@ -233,10 +233,10 @@
             \node[anchor=center] at ([yshift=2cm]current page.center) {
                 \begin{minipage}{140mm}
                     \centering
-                    \textcolor{white}{\fontsize{72}{80}\selectfont\textbf{Arkitektur}}\\[5mm]
-                    \textcolor{white}{\fontsize{72}{80}\selectfont som \textcolor{KvadratBlueLight}{\textbf{kod}}}\\[15mm]
-                    \textcolor{white}{\fontsize{24}{32}\selectfont En omfattande guide till Infrastructure as Code}\\[5mm]
-                    \textcolor{white}{\fontsize{18}{24}\selectfont från grundläggande principer till avancerad implementation}
+                    \textcolor{white}{\fontsize{72}{80}\selectfont\textbf{Architecture}}\\[5mm]
+                    \textcolor{white}{\fontsize{72}{80}\selectfont as \textcolor{KvadratBlueLight}{\textbf{Code}}}\\[15mm]
+                    \textcolor{white}{\fontsize{24}{32}\selectfont A comprehensive guide to Architecture as Code}\\[5mm]
+                    \textcolor{white}{\fontsize{18}{24}\selectfont from foundational principles to advanced implementation}
                 \end{minipage}
             };
         \end{tikzpicture}
@@ -244,13 +244,13 @@
         % Footer information
         \begin{tikzpicture}[remember picture,overlay]
             \node[anchor=south west] at ([xshift=40mm,yshift=40mm]current page.south west) {
-                \textcolor{white}{\textbf{\Large Kvadrat Expertteam}}
+                \textcolor{white}{\textbf{\Large Kvadrat Expert Team}}
             };
             \node[anchor=south east] at ([xshift=-40mm,yshift=40mm]current page.south east) {
                 \begin{minipage}[b]{40mm}
                     \raggedleft
                     \textcolor{white}{\textbf{\Large 2024}}\\
-                    \textcolor{white}{Första upplagan}
+                    \textcolor{white}{First Edition}
                 \end{minipage}
             };
         \end{tikzpicture}
@@ -274,7 +274,7 @@
             \fill[KvadratBlue] (0,0) rectangle (15mm,15mm);
             \node[white] at (7.5mm,7.5mm) {\fontsize{24}{24}\selectfont\textbf{\thechapter}};
         \end{tikzpicture}
-    }{20pt}{\Huge\chapteropener{Kapitel \thechapter}}
+    }{20pt}{\Huge\chapteropener{Chapter \thechapter}}
     [
         \vspace{5mm}
         \begin{tikzpicture}
@@ -475,8 +475,8 @@
     filecolor=KvadratBlue,
     urlcolor=KvadratBlueLight,
     citecolor=KvadratBlue,
-    pdfauthor={Kvadrat Expertteam},
-    pdftitle={Arkitektur som kod},
+    pdfauthor={Kvadrat Expert Team},
+    pdftitle={Architecture as Code},
     pdfsubject={Infrastructure as Code},
     pdfkeywords={Infrastructure as Code, DevOps, Cloud, Automation}
 }
@@ -508,12 +508,12 @@
         \vspace{10mm}
         
         {\Large\textbf{\textcolor{KvadratBlue}{Kvadrat Professional Services}}}\\[5mm]
-        {\large\textcolor{KvadratGray}{Expert konsulttjänster inom teknik och arkitektur}}\\[10mm]
-        
+        {\large\textcolor{KvadratGray}{Expert consulting services in technology and architecture}}\\[10mm]
+
         \textcolor{KvadratGray}{
-            \textbf{Kontakt:} info@kvadrat.se | +46 8 123 45 67 | www.kvadrat.se\\
-            \textbf{Adress:} Stockholm, Sverige\\[5mm]
-            © 2024 Kvadrat. Alla rättigheter förbehållna.
+            \textbf{Contact:} info@kvadrat.se | +46 8 123 45 67 | www.kvadrat.se\\
+            \textbf{Address:} Stockholm, Sweden\\[5mm]
+            © 2024 Kvadrat. All rights reserved.
         }
     \end{center}
     


### PR DESCRIPTION
## Summary
- update all book cover HTML variants to use English branding, titles, and edition details
- translate the SVG cover metadata and typography to English terminology
- switch the LaTeX book template to English language settings and cover copy

## Testing
- `python3 generate_book.py`
- `docs/build_book.sh` *(fails: missing xelatex dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0a3fab8c83309d3b1e6ed834a0ed