### PR TITLE
Revise Chapter 11 governance narrative and diagram

### DIFF
--- a/docs/11_governance_as_code.md
+++ b/docs/11_governance_as_code.md
@@ -4,31 +4,29 @@
 
 ![Governance as Code pipeline](images/diagram_29_governance_pipeline.png)
 
-Governance as Code extends the principles of Infrastructure as Code to the policies, approval flows, and organizational guardrails that keep architecture and delivery aligned with strategic intent. By expressing governance artifacts in version-controlled repositories, teams gain transparency, traceability, and automation opportunities while still respecting compliance and risk requirements.
+Figure 11.1 illustrates how policy authors, reviewers, automation, production controls, and the audit portal coordinate through a single repository to evolve governance. Governance as Code extends the principles of Infrastructure as Code to the policies, approval flows, and organizational guardrails that keep architecture and delivery aligned with strategic intent. By expressing governance artifacts in version-controlled repositories, teams gain transparency, traceability, and automation opportunities while still respecting compliance and risk requirements. The shared workflow also keeps an audit trail that shows exactly which checks ran, who approved each change, and when compliance evidence was published.
 
 ## Implementing Approval Processes with Pull Requests
 
-- **Design branching strategies for governance artifacts.** Maintain dedicated branches for policy drafts, review, and production-ready governance definitions. This mirrors software development workflows and keeps governance states explicit.
-- **Use pull requests as approval gates.** Require reviews from architecture leads, security officers, and business stakeholders before merging changes to governance code. Pull-request templates can capture mandatory information such as risk assessments, policy mappings, and rollout plans.
-- **Automate checks in CI pipelines.** Validate governance definitions using policy-as-code tools, schema validations, and automated tests that ensure guardrails remain intact. Only merges that pass automated checks and human approvals reach the main branch.
-- **Leverage GitHub environments and branch protection.** Configure mandatory status checks, signed commits, and review requirements to enforce governance controls directly within the repository.
-- **Document decision context in the repository.** Link pull requests to Architecture Decision Records (ADRs) to capture rationale, business impact, and audit trails in a single system of record.
+Designing branching strategies for governance artifacts keeps each state explicit. Dedicated draft, review, and production branches mirror software development workflows so stakeholders can follow the journey from proposal to adoption. Every merge request becomes a visible checkpoint that shows why a change exists and which controls have already run.
+
+Pull requests then serve as the formal approval gates. Architecture leads, security officers, and business sponsors review the proposal together, using templates that prompt for risk assessments, policy mappings, and rollout plans. Automated status checks enforce the required reviewers, signed commits, and branch protections that ensure only fully vetted changes reach the protected main branch.
+
+Continuous integration pipelines run policy-as-code validations, schema tests, and guardrail verifications the moment a pull request opens. When those checks pass, maintainers link the request to relevant Architecture Decision Records so the business rationale and audit trail live beside the code. The result is an end-to-end approval experience where human judgment complements automated enforcement.
 
 ## Navigating Competency Gaps During Transition
 
-- **Map existing responsibilities to governance roles.** Identify which stakeholders currently approve policies, manage risk, or oversee compliance, and define how those responsibilities translate into code ownership and review rights.
-- **Invest in targeted training.** Offer workshops on Git fundamentals, pull-request etiquette, policy-as-code tooling, and secure coding practices to help traditional governance professionals adapt to code-centric workflows.
-- **Adopt pairing and mentoring structures.** Combine governance experts with experienced developers or platform engineers to co-author governance artifacts, transferring knowledge while maintaining policy fidelity.
-- **Stage the transition.** Begin with low-risk governance components, gather feedback, and iteratively expand to more critical controls as confidence grows. Use retrospectives to capture lessons learned and adjust enablement plans.
-- **Communicate new value streams.** Highlight faster approval cycles, improved auditability, and better collaboration to secure stakeholder buy-in and mitigate resistance stemming from the competency gap.
+Successful adoption begins with mapping existing responsibilities to the new repository roles. Governance owners, risk managers, and compliance leads gain explicit ownership of folders, policies, and review rights so their expertise still anchors decision-making. That foundation makes it easier to tailor enablement activities to each group’s knowledge gaps.
+
+Targeted training accelerates confidence. Workshops that cover Git fundamentals, pull-request etiquette, policy-as-code tooling, and secure coding practices help traditional governance professionals feel comfortable with day-to-day repository work. Pairing or mentoring programmes keep the momentum going by matching domain experts with experienced engineers who can translate policy intent into reliable code implementations.
+
+Teams should stage the transition carefully. Starting with low-risk governance components allows the organisation to gather feedback and fine-tune the approach before scaling to critical controls. Regular retrospectives surface lessons learned, while continual communication reinforces the value of faster approval cycles, stronger auditability, and cross-functional collaboration.
 
 ## Tooling to Enable Non-Developers
 
-- **Low-code policy editors.** Provide graphical interfaces that generate policy code (for example, Rego or Sentinel) so policy specialists can define rules without writing syntax manually.
-- **Template-driven pull requests.** Supply structured templates and form-based inputs that convert stakeholder submissions into well-formed governance updates.
-- **Documentation-as-code portals.** Publish rendered documentation from the repository to user-friendly portals or knowledge bases so non-technical stakeholders can review governance changes without reading raw code.
-- **ChatOps integrations.** Connect collaboration tools like Microsoft Teams or Slack to repository workflows, enabling users to trigger governance checks, receive review notifications, and approve changes from familiar interfaces.
-- **Automated policy explainers.** Integrate tools that translate policy code into natural language summaries, reducing dependency on programming skills while preserving the authoritative source in code.
+Empowering non-developers starts with approachable policy editors that generate Rego, Sentinel, or similar policy languages from guided forms. These low-code experiences keep the code authoritative while lowering the barrier to entry for policy specialists. Template-driven pull requests extend that support by turning stakeholder submissions into structured governance updates that already meet repository standards.
+
+Documentation-as-code portals and ChatOps integrations keep contributors in their preferred environments. Rendered documentation provides a friendly view of pending changes, while Microsoft Teams or Slack integrations surface review notifications, allow approvals, and trigger governance checks without forcing users into the terminal. Automated policy explainers complete the toolkit by translating code into natural language summaries, giving decision makers clarity without diluting the precision of code-based guardrails.
 
 ## Key Takeaways
 

--- a/docs/images/diagram_29_governance_pipeline.mmd
+++ b/docs/images/diagram_29_governance_pipeline.mmd
@@ -16,15 +16,21 @@ sequenceDiagram
     participant CI as CI/CD Checks
     participant Review as Governance Reviewers
     participant Deploy as Production Controls
+    participant Audit as Audit Portal
 
     Author->>Repo: Draft governance update
+    Note right of Author: Branch from<br/>draft workspace
     Repo->>CI: Trigger automated policy tests
     CI-->>Repo: Report compliance status
     Repo->>Review: Open pull request for approval
     Review-->>Repo: Provide review comments
+    Note over Author,Review: Collaborative review
     Author->>Repo: Apply requested changes
-    Repo->>CI: Re-run automated tests
-    CI-->>Review: Confirm guardrails satisfied
+    loop Re-validation
+        Repo->>CI: Re-run automated tests
+        CI-->>Review: Confirm guardrails satisfied
+    end
     Review->>Repo: Approve and merge change
     Repo->>Deploy: Promote policy to production
-    Deploy-->>Author: Publish audit trail
+    Deploy-->>Audit: Capture deployment evidence
+    Audit-->>Author: Publish audit trail


### PR DESCRIPTION
## Summary
- Rewrote Chapter 11 sections as cohesive prose that references the governance pipeline diagram.
- Expanded the overview to highlight audit-trail benefits across the governance workflow.
- Enriched the governance sequence diagram with collaborative review, re-validation, and audit portal steps.

## Testing
- Not run (avoided diagram generation that CI handles automatically).


------
https://chatgpt.com/codex/tasks/task_e_68ec0962c7dc8330889bcf09024a98f8