### PR TITLE
Translate Chapter 7 to British English

### DIFF
--- a/docs/07_containerization.md
+++ b/docs/07_containerization.md
@@ -2,47 +2,47 @@
 
 ![Containerisation and Orchestration](images/diagram_11_kapitel10.png)
 
-The Architecture as Code methodology forms the foundation for container technology and orchestration, representing a paradigm shift in how applications are deployed and scaled. By defining Architecture as Code for containers, teams enable portable, scalable, and reproducible application deployment across environments and cloud providers.
+Architecture as Code underpins modern container platforms by turning deployment practices into repeatable definitions. When infrastructure and runtime configuration are described in version-controlled files, teams gain portable, scalable, and reproducible delivery pipelines that function reliably across data centres and cloud providers.
 
 ## The role of container technology within Architecture as Code
 
-Containers offer application-level virtualisation by packaging applications with all dependencies in isolated, portable units. For Architecture as Code this means application deployment can be standardised and automated through code-based definitions that ensure consistency between development, testing, and production environments.
+Containers package an application together with its libraries and runtime dependencies inside isolated units. Within an Architecture as Code approach, those units are described declaratively so that the same package can be built, tested, and promoted through each stage without configuration drift. The result is predictable application behaviour and simpler collaboration between development, operations, and security teams.
 
-Docker has established itself as the de facto standard for containerisation, with Podman and other alternatives offering daemon-less approaches for enhanced security. Container images are defined through Dockerfiles as executable infrastructure code, enabling version control and automated building of application artefacts.
+Docker popularised this model and remains the industry reference point, while projects such as Podman provide daemon-less alternatives that suit security-conscious environments. Image definitions are written in Dockerfiles (or equivalent build instructions) so that they can be stored in Git, reviewed, and rebuilt automatically as part of the CI/CD process. Linters and automated tests can validate these artefacts in the same way that application code is reviewed.
 
-Container registries function as centralised repositories for image distribution and versioning. Private registries ensure organisational security requirements are met, with image scanning and vulnerability assessment integrated into CI/CD pipelines for automated security validation before deployment.
+Once images are produced they are stored in container registries, which act as central repositories for distribution and version control. Private registries support enterprise governance by enforcing access control, image signing, and vulnerability scanning before any workload reaches production. Registry policies can be expressed as code to guarantee compliance across teams.
 
 ## Kubernetes as an orchestration platform
 
-Kubernetes has emerged as the leading container orchestration platform through its declarative configuration model and extensive ecosystem. YAML-based manifests define the desired state for applications, services, and infrastructure components, aligning perfectly with Architecture as Code principles.
+Kubernetes has become the canonical orchestration layer thanks to its declarative design and expansive ecosystem. YAML manifests capture the desired state for workloads, services, and platform components, meaning the entire runtime can be documented alongside the application source. The Kubernetes control plane continuously reconciles the actual state with those declarations, enforcing Architecture as Code in real time.
 
-Kubernetes objects such as Deployments, Services, ConfigMaps, and Secrets enable comprehensive application lifecycle management through code. Pod specifications, resource quotas, network policies, and persistent volume claims can all be defined declaratively and managed through version control systems.
+Native Kubernetes objects—Deployments, StatefulSets, Services, ConfigMaps, Secrets, and many others—cover the full application lifecycle. Teams describe pod specifications, resource requests, network segmentation, and persistent storage needs directly in code. Version control and peer review help prevent configuration drift while providing a complete audit history for compliance purposes.
 
-Helm charts extend Kubernetes capabilities through templating and package management for complex applications. Chart repositories enable reusable infrastructure patterns and standardised deployment procedures across different environments and organisational units.
+Helm augments Kubernetes with templating and release management features, enabling reusable deployment patterns for complex stacks. Chart repositories encapsulate organisational standards so that teams can provision consistent environments quickly, whether the target is development, staging, or production.
 
 ## Service mesh and advanced networking
 
-Service mesh architectures such as Istio and Linkerd are implemented through Architecture as Code to handle inter-service communication, security policies, and observability. These platforms abstract networking complexity from application developers while providing fine-grained control through configuration files.
+Service meshes such as Istio and Linkerd introduce a programmable data plane that handles inter-service communication, observability, and security concerns. Policy definitions, routing rules, and cryptographic requirements are written as configuration files, allowing networking specialists to iterate safely without touching application code.
 
-Traffic management policies are defined as code for load balancing, circuit breaking, retry mechanisms, and canary deployments. Security policies for mutual TLS, access control, and authentication/authorisation can be version controlled and automatically applied across service topologies.
+Traffic shaping features—including circuit breaking, retries, fault injection, and canary roll-outs—are specified as code and stored alongside the services they protect. Mutual TLS, zero-trust access rules, and identity management policies follow the same pattern, making it straightforward to extend security best practice across microservice estates.
 
-Observability configurations for tracing, metrics collection, and logging integration are managed through declarative specifications. This enables comprehensive monitoring and debugging capabilities while maintaining consistency across distributed service architectures.
+Observability is likewise driven by declaration. Distributed tracing, metrics scraping, and log aggregation are enabled through manifests that describe collectors, exporters, and retention policies. This consistency simplifies root-cause analysis because every cluster exposes telemetry in a standardised format.
 
 ## Infrastructure automation with container platforms
 
-Container-native infrastructure tools such as Crossplane and the Operator Framework extend Kubernetes for complete infrastructure management. These platforms enable provisioning and management of cloud resources through Kubernetes-native APIs and custom resource definitions.
+Kubernetes-native automation frameworks extend the platform to cover underlying infrastructure. Crossplane, the Operator Framework, and similar projects expose cloud resources as custom resource definitions (CRDs), meaning databases, message queues, or networking components can be provisioned through the same API surface as application workloads.
 
-GitOps workflows implement continuous delivery for both applications and infrastructure through Git repositories as the single source of truth. Tools such as Argo CD and Flux automate deployment processes by continuously monitoring Git state and automatically reconciling cluster state.
+GitOps practices complement this model by treating Git repositories as the source of truth. Continuous delivery tools such as Argo CD and Flux reconcile the declared state with the running clusters, applying changes automatically when a pull request is merged. Rollbacks become a matter of reverting commits, and audit trails are preserved for every environment.
 
-Multi-cluster management platforms centralise policy enforcement, resource allocation, and governance across distributed Kubernetes environments. Federation and Cluster API specifications standardise cluster lifecycle management through declarative configurations.
+Large organisations often operate multiple clusters across regions. Multi-cluster management suites provide centralised policy enforcement, workload placement, and governance. Federation APIs and the Cluster API specification capture cluster lifecycle operations in code, standardising creation, upgrades, and decommissioning.
 
 ## Persistent storage and data management
 
-Persistent volume management for containerised applications requires careful consideration of performance, availability, and backup requirements. Storage classes and persistent volume claims are defined as infrastructure code for automated provisioning and lifecycle management.
+Stateful workloads still rely on robust storage. Kubernetes addresses this with persistent volumes, storage classes, and dynamic provisioners, all of which are defined declaratively. Performance, redundancy, and backup requirements can be embedded into these definitions so that new workloads inherit compliant defaults automatically.
 
-Database operators for PostgreSQL, MongoDB, and other systems enable database-as-code deployment patterns. These operators handle complex operations such as backup scheduling, high availability configuration, and automated recovery through custom resource definitions.
+Database operators—for PostgreSQL, MongoDB, MySQL, and many others—take the concept further by managing clustering, backups, failover, and version upgrades. These controllers watch for configuration changes and adjust the database fleet accordingly, providing database-as-code capabilities without extensive manual intervention.
 
-Data protection strategies are implemented through backup operators and disaster recovery procedures defined as code. This ensures consistent data protection policies across environments and automated recovery capabilities during incidents.
+Data protection remains critical. Backup schedules, retention policies, and disaster recovery runbooks can be codified through operators or infrastructure-as-code tooling. Automated tests and scheduled recovery drills verify that restorations meet business continuity objectives.
 
 ## Practical examples
 
@@ -232,7 +232,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
 ## Summary
 
-The modern Architecture as Code methodology provides a global foundation for infrastructure management across industries. Containerisation and orchestration as code transform application deployment from manual, error-prone processes to automated, reliable workflows. Kubernetes and associated tools enable sophisticated application management through declarative configurations, while GitOps patterns ensure consistent and auditable deployment processes. Success requires a thorough understanding of container networking, storage management, and security implications that can be applied in any region.
+Architecture as Code provides a common language for development, operations, and security teams. By expressing container platforms, orchestration logic, networking, and data safeguards as code, organisations can automate delivery, scale confidently, and apply governance consistently. Kubernetes and its surrounding ecosystem offer the building blocks, while GitOps workflows keep every environment aligned with the declared intent. Mastery of these practices delivers resilient platforms that adapt quickly to changing requirements.
 
 ## Sources and references
 


### PR DESCRIPTION
## Summary
- Rewrite Chapter 7 on containerisation and orchestration in British English prose while preserving technical intent and examples.
- Highlight declarative workflows, GitOps practices, and data protection guidance to align with Architecture as Code methodology.

## Testing
- `python3 generate_book.py && docs/build_book.sh` *(fails: Mermaid PNG generation and `xelatex` missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec98a584ac83308741c9f8bdf10f79