### PR TITLE
Fix hardcoded section numbering in AI agent chapter

### DIFF
--- a/docs/20_ai_agent_team.md
+++ b/docs/20_ai_agent_team.md
@@ -2,13 +2,13 @@
 
 The Architecture as Code initiative relies on a cohesive ensemble of AI agents that operate as a digital delivery team. Each agent contributes specialised expertise while adhering to a single backlog, common documentation practices, and shared quality thresholds. This chapter reframes the agent ecosystem in British English, translating previous checklists into narrative guidance that emphasises collaboration, accountability, and the continual refinement of project artefacts.
 
-## 20.1 Multi-Agent Operating Model
+## Multi-Agent Operating Model
 
 ![AI agent collaboration flow](images/diagram_28_agent_team.png)
 
 The operating model begins with the project owner defining priorities and acceptable outcomes. The Project Manager agent transforms those directions into sprint goals, decomposes them into manageable cases, and steers the flow of information between the specialists. Architect, Requirements Analyst, Designer, Developer, Quality Control, Editor, and Graphic Designer agents execute their craft in tight feedback loops, returning insights and artefacts to the Project Manager. The Project Manager consolidates the overall status, flags risks, and recommends decisions back to the project owner at the end of each iteration. *Diagram source: [`images/diagram_28_agent_team.mmd`](images/diagram_28_agent_team.mmd).* 
 
-## 20.2 Role Narratives and Responsibilities
+## Role Narratives and Responsibilities
 
 The Project Manager acts as the coordinating nucleus. They translate strategic directives into prioritised cases, facilitate daily synchronisation, surface blockers early, and prepare a sprint packet that captures completed work, unresolved risks, and suggested trade-offs. Their orchestration ensures that each specialist agent understands the context of their deliverables and the dependencies that bind them.
 
@@ -26,7 +26,7 @@ The Editor safeguards the repository’s written record. They update documentati
 
 The Graphic Designer produces the visual narratives—Mermaid diagrams, illustrative frames, and themed assets—that clarify architectural decisions and team workflows. They maintain a version-controlled library of graphics and iterate alongside the Architect and Editor so that visuals and text reinforce one another.
 
-## 20.3 Collaboration Patterns Without Temporal Gating
+## Collaboration Patterns Without Temporal Gating
 
 The agent collective maintains living cases that accumulate insights whenever two or more specialists exchange information. Rather than tracking activities against a rigid timetable, the focus lies on how communications revise shared artefacts and decisions.
 
@@ -38,7 +38,7 @@ The agent collective maintains living cases that accumulate insights whenever tw
 | Release-readiness review before deployment | Project Manager, Quality Control, Developer | Deployment case annotated with risk mitigations, test evidence attached, and go/no-go decision captured for audit history. |
 | Policy change affecting documentation | Project Manager, Editor, Requirements Analyst | Governance case revised with new policy text, traceability matrix regenerated, and affected chapters scheduled for editorial updates. |
 
-## 20.4 Governance, Reporting, and Onboarding
+## Governance, Reporting, and Onboarding
 
 Sprint rituals anchor collaboration. Fortnightly planning sessions connect the project owner’s objectives with the forthcoming sprint commitment, while brief daily synchronisations allow the Project Manager to redirect attention when blockers emerge. Demonstrations at the end of each sprint showcase artefacts to the project owner, and retrospectives catalogue process improvements that the Project Manager threads into the next iteration.
 


### PR DESCRIPTION
## Summary
- remove manual section numbers from the AI agent team chapter so pandoc numbering is not duplicated

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails in container: Mermaid CLI missing Chrome and TeX engine `xelatex` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ec95f9d7d083309cd36d9f41d35bf1