### PR TITLE
Ensure Pandoc uses English metadata for book outputs

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -379,7 +379,8 @@ generate_other_formats() {
         -t epub \
         -o "$OUTPUT_EPUB" \
         --metadata date="$(date +'%Y-%m-%d')" \
-        --metadata language=sv \
+        --metadata language=en \
+        --metadata lang=en-GB \
         --epub-cover-image="images/book-cover.png" \
         2>&1; then
 

--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -27,7 +27,7 @@ metadata:
   subtitle: "A practical handbook for Infrastructure as Code"
   author: "Architecture as Code Editorial Team"
   date: "2024"
-  language: en
+  language: en-GB
   lang: en-GB
 
 # Variables for better compatibility


### PR DESCRIPTION
## Summary
- update the Pandoc defaults to declare English (en-GB) metadata so generated chapters no longer use Swedish labels
- pass matching English language metadata when producing the EPUB so auxiliary formats stay consistent

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: missing xelatex in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecab9c1b98833099176ae6ba1fb8dc