### PR TITLE
Enlarge Figure 5.2 for readability

### DIFF
--- a/docs/05_automation_devops_cicd.md
+++ b/docs/05_automation_devops_cicd.md
@@ -4,7 +4,7 @@
 
 Continuous integration and continuous deployment (CI/CD) combined with a mature DevOps culture form the backbone of modern software delivery. When Architecture as Code principles are applied, these processes become even more critical. This chapter explores how Swedish organisations can establish robust, secure, and effective CI/CD pipelines that transform infrastructure management from manual, error-prone activities into automated, reliable, and auditable operations while treating the entire system architecture as executable code.
 
-![Architecture as Code implementation timeline](images/diagram_05_gantt_timeline.png)
+![Architecture as Code implementation timeline](images/diagram_05_gantt_timeline.png){ width=100% }
 
 The diagram above illustrates a typical timeline for an Architecture as Code implementation, from initial tool analysis through to a full production rollout.
 


### PR DESCRIPTION
## Summary
- expand the Architecture as Code implementation timeline image in Chapter 5 to fill the text width for improved legibility

## Testing
- `python3 generate_book.py && docs/build_book.sh` *(fails: missing xelatex in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecb7be330c8330beee838ff088dc3e