### PR TITLE
Apply dark background styling to code elements

### DIFF
--- a/docs/stylesheets/code-dark.css
+++ b/docs/stylesheets/code-dark.css
@@ -1,0 +1,33 @@
+/* Custom styling for code elements to ensure dark backgrounds */
+.md-typeset code,
+.md-typeset tt {
+  background-color: #1f1f24;
+  color: #f8f8f2;
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.3rem;
+}
+
+.md-typeset pre {
+  background-color: #1f1f24;
+  color: #f8f8f2;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.md-typeset pre > code {
+  background-color: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+/* Ensure syntax-highlighted code blocks inherit the dark theme */
+.md-typeset .highlight pre,
+.md-typeset .highlight code {
+  background-color: #1f1f24;
+  color: #f8f8f2;
+}
+
+/* Improve readability of inline code links */
+.md-typeset a code {
+  color: #b5c6ff;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,3 +50,5 @@ use_directory_urls: true
 markdown_extensions:
   - toc
   - tables
+extra_css:
+  - stylesheets/code-dark.css


### PR DESCRIPTION
## Summary
- add a custom stylesheet that applies a dark background palette to inline and block code elements
- register the stylesheet in `mkdocs.yml` so the theme picks up the darker code styling

## Testing
- mkdocs serve -a 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68ecb71672b08330b1b5efb6ad3c118f