### PR TITLE
Fix ADR structure figure placement in template section

### DIFF
--- a/docs/04_adr.md
+++ b/docs/04_adr.md
@@ -31,11 +31,11 @@ In the Architecture as Code context, ADRs document decisions about technology ch
 
 ## Structure and Components of ADR
 
-![ADR structure](images/diagram_04_adr_struktur.png)
-
-*Each ADR follows a standardised structure with four main components that ensure consistent and complete documentation of architecture decisions.*
-
 ### Standardised ADR Template
+
+![Figure 4.2 – Standard Architecture Decision Record structure](images/diagram_04_adr_struktur.png)
+
+*Figure 4.2 highlights the four core sections every ADR should capture before the template is populated with project-specific information.*
 
 Each ADR follows a consistent structure that ensures all relevant information is captured systematically:
 


### PR DESCRIPTION
## Summary
- move the ADR structure figure directly under the template subsection to prevent it from rendering inside the code sample
- add an explicit caption referencing Figure 4.2 to explain the diagram before the ADR template example

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ecb74ca8b88330bfa434001e805bae