### PR TITLE
Add dark backgrounds to code elements in generated books

### DIFF
--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -18,7 +18,7 @@ template: eisvogel.latex
 pdf-engine: xelatex
 
 # Syntax highlighting configuration
-highlight-style: tango
+highlight-style: breezedark
 # Alternative highlight styles: pygments, kate, monochrome, espresso, zenburn, haddock, breezedark, tango
 
 # Metadata for document

--- a/docs/stylesheets/code-dark.css
+++ b/docs/stylesheets/code-dark.css
@@ -1,0 +1,25 @@
+/* Dark theme for code elements across the Architecture as Code book */
+
+/* Inline code */
+code {
+  background-color: #1f2933;
+  color: #f5f7fa;
+  padding: 0.1em 0.35em;
+  border-radius: 0.35em;
+  font-size: 0.95em;
+}
+
+/* Code blocks */
+pre,
+pre code {
+  background-color: #1f2933;
+  color: #f5f7fa;
+}
+
+pre {
+  padding: 1.1em;
+  border-radius: 0.5em;
+  overflow: auto;
+  line-height: 1.45;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,3 +50,5 @@ use_directory_urls: true
 markdown_extensions:
   - toc
   - tables
+extra_css:
+  - stylesheets/code-dark.css


### PR DESCRIPTION
## Summary
- add a reusable stylesheet that applies a dark theme to inline and block code snippets across the documentation site
- register the new stylesheet with MkDocs and switch Pandoc to the breezedark highlighting theme so PDF exports use a matching dark background

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: missing xelatex dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecb8e6c1b883309fce03b515f6d136