### PR TITLE
Update book cover templates with English author details

### DIFF
--- a/exports/book-cover/source/book-cover-final.html
+++ b/exports/book-cover/source/book-cover-final.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Professional Book Cover</title>
+    <title>Architecture as Code - Professional Book Cover</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -315,27 +315,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                <span class="title-line-1">Arkitektur</span>
-                <span class="title-line-2">som <span class="highlight">kod</span></span>
+                <span class="title-line-1">Architecture</span>
+                <span class="title-line-2">as <span class="highlight">Code</span></span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/exports/book-cover/source/book-cover.html
+++ b/exports/book-cover/source/book-cover.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="sv">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arkitektur som kod - Bokframsida</title>
+    <title>Architecture as Code - Book Cover</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -185,27 +185,27 @@
         <header class="header">
             <div class="logo-area">
                 <div class="logo">K</div>
-                <div class="brand-text">Kvadrat Publikation</div>
+                <div class="brand-text">Kvadrat Publication</div>
             </div>
         </header>
 
         <main class="main-content">
             <h1 class="title">
-                Arkitektur<br>
-                som <span class="highlight">kod</span>
+                Architecture<br>
+                as <span class="highlight">Code</span>
             </h1>
             <p class="subtitle">
-                En omfattande guide till arkitektur som kod - från grundläggande principer till avancerad implementation i moderna molnmiljöer
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Expertteamet på Kvadrat
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>Första upplagan</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/exports/book-cover/source/book-cover.svg
+++ b/exports/book-cover/source/book-cover.svg
@@ -187,48 +187,48 @@
             text-anchor="middle" fill="hsl(221, 67%, 32%)">K</text>
       
       <!-- Brand text -->
-      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600" 
-            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLIKATION</text>
+      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600"
+            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLICATION</text>
     </g>
     
     <!-- Main title -->
     <g transform="translate(0, 189)">
-      <!-- Title line 1: "Arkitektur" -->
-      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Arkitektur</text>
+      <!-- Title line 1: "Architecture" -->
+      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Architecture</text>
       
-      <!-- Title line 2: "som kod" with highlight -->
-      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">som </text>
-      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">kod</text>
+      <!-- Title line 2: "as Code" with highlight -->
+      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">as </text>
+      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">Code</text>
     </g>
     
     <!-- Subtitle -->
     <g transform="translate(0, 377)">
       <text font-family="Inter, sans-serif" font-size="22" font-weight="400" 
             fill="rgba(255,255,255,0.92)" line-height="1.5">
-        <tspan x="0" y="26">En omfattande guide till Infrastructure as Code -</tspan>
-        <tspan x="0" y="59">från grundläggande principer till avancerad</tspan>
-        <tspan x="0" y="92">implementation i moderna molnmiljöer</tspan>
-        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">DevOps • CI/CD • Säkerhet • Compliance • Molnarkitektur</tspan>
+        <tspan x="0" y="26">A guide to how fully code-based architecture works—</tspan>
+        <tspan x="0" y="59">and the effects it has on design, development, governance,</tspan>
+        <tspan x="0" y="92">testing, and requirements management</tspan>
+        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">Design • Development • Governance • Testing • Requirements</tspan>
       </text>
     </g>
     
     <!-- Footer -->
     <g transform="translate(0, 783)">
       <!-- Authors -->
-      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700" 
-            fill="white">Expertteamet på Kvadrat</text>
+      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700"
+            fill="white">Gunnar Nordqvist</text>
       
       <!-- Edition info -->
       <g transform="translate(450, 0)">
         <!-- Year with gradient -->
-        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800" 
-              fill="url(#accentGradient)" text-anchor="end">2024</text>
+        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800"
+              fill="url(#accentGradient)" text-anchor="end">2025</text>
         <!-- Edition text -->
-        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16" 
-              fill="rgba(255,255,255,0.85)" text-anchor="end">Första upplagan</text>
+        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16"
+              fill="rgba(255,255,255,0.85)" text-anchor="end">Published 2025</text>
       </g>
     </g>
     
@@ -236,13 +236,13 @@
   
   <!-- Additional metadata for editing -->
   <metadata>
-    <title>Arkitektur som kod - Enhanced Book Cover</title>
-    <description>Professional book cover design for Kvadrat's Infrastructure as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
-    <author>Kvadrat Design Team</author>
-    <created>2024</created>
-    <updated>December 2024</updated>
+    <title>Architecture as Code - Enhanced Book Cover</title>
+    <description>Professional book cover design for Kvadrat's Architecture as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
+    <author>Gunnar Nordqvist</author>
+    <created>2025</created>
+    <updated>January 2025</updated>
     <brand-guidelines>Kvadrat Brand Guidelines v1.0</brand-guidelines>
-    <themes>Infrastructure as Code, DevOps, CI/CD, Security, Cloud Architecture, Swedish Context</themes>
+    <themes>Architecture as Code, Design, Development, Governance, Testing, Requirements</themes>
     <visual-elements>Pipeline patterns, security shields, cloud nodes, microservices, git repositories, containers</visual-elements>
   </metadata>
   

--- a/exports/book-cover/svg/book-cover.svg
+++ b/exports/book-cover/svg/book-cover.svg
@@ -187,48 +187,48 @@
             text-anchor="middle" fill="hsl(221, 67%, 32%)">K</text>
       
       <!-- Brand text -->
-      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600" 
-            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLIKATION</text>
+      <text x="72" y="36" font-family="Inter, sans-serif" font-size="16" font-weight="600"
+            fill="white" opacity="0.95" letter-spacing="0.8px">KVADRAT PUBLICATION</text>
     </g>
     
     <!-- Main title -->
     <g transform="translate(0, 189)">
-      <!-- Title line 1: "Arkitektur" -->
-      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Arkitektur</text>
+      <!-- Title line 1: "Architecture" -->
+      <text x="0" y="78" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">Architecture</text>
       
-      <!-- Title line 2: "som kod" with highlight -->
-      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="white" letter-spacing="-3px" filter="url(#textShadow)">som </text>
-      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900" 
-            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">kod</text>
+      <!-- Title line 2: "as Code" with highlight -->
+      <text x="20" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="white" letter-spacing="-3px" filter="url(#textShadow)">as </text>
+      <text x="200" y="156" font-family="Inter, sans-serif" font-size="78" font-weight="900"
+            fill="url(#accentGradient)" letter-spacing="-3px" filter="url(#textShadow)">Code</text>
     </g>
     
     <!-- Subtitle -->
     <g transform="translate(0, 377)">
       <text font-family="Inter, sans-serif" font-size="22" font-weight="400" 
             fill="rgba(255,255,255,0.92)" line-height="1.5">
-        <tspan x="0" y="26">En omfattande guide till Infrastructure as Code -</tspan>
-        <tspan x="0" y="59">från grundläggande principer till avancerad</tspan>
-        <tspan x="0" y="92">implementation i moderna molnmiljöer</tspan>
-        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">DevOps • CI/CD • Säkerhet • Compliance • Molnarkitektur</tspan>
+        <tspan x="0" y="26">A guide to how fully code-based architecture works—</tspan>
+        <tspan x="0" y="59">and the effects it has on design, development, governance,</tspan>
+        <tspan x="0" y="92">testing, and requirements management</tspan>
+        <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">Design • Development • Governance • Testing • Requirements</tspan>
       </text>
     </g>
     
     <!-- Footer -->
     <g transform="translate(0, 783)">
       <!-- Authors -->
-      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700" 
-            fill="white">Expertteamet på Kvadrat</text>
+      <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700"
+            fill="white">Gunnar Nordqvist</text>
       
       <!-- Edition info -->
       <g transform="translate(450, 0)">
         <!-- Year with gradient -->
-        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800" 
-              fill="url(#accentGradient)" text-anchor="end">2024</text>
+        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800"
+              fill="url(#accentGradient)" text-anchor="end">2025</text>
         <!-- Edition text -->
-        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16" 
-              fill="rgba(255,255,255,0.85)" text-anchor="end">Första upplagan</text>
+        <text x="0" y="52" font-family="Inter, sans-serif" font-size="16"
+              fill="rgba(255,255,255,0.85)" text-anchor="end">Published 2025</text>
       </g>
     </g>
     
@@ -236,13 +236,13 @@
   
   <!-- Additional metadata for editing -->
   <metadata>
-    <title>Arkitektur som kod - Enhanced Book Cover</title>
-    <description>Professional book cover design for Kvadrat's Infrastructure as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
-    <author>Kvadrat Design Team</author>
-    <created>2024</created>
-    <updated>December 2024</updated>
+    <title>Architecture as Code - Enhanced Book Cover</title>
+    <description>Professional book cover design for Kvadrat's Architecture as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
+    <author>Gunnar Nordqvist</author>
+    <created>2025</created>
+    <updated>January 2025</updated>
     <brand-guidelines>Kvadrat Brand Guidelines v1.0</brand-guidelines>
-    <themes>Infrastructure as Code, DevOps, CI/CD, Security, Cloud Architecture, Swedish Context</themes>
+    <themes>Architecture as Code, Design, Development, Governance, Testing, Requirements</themes>
     <visual-elements>Pipeline patterns, security shields, cloud nodes, microservices, git repositories, containers</visual-elements>
   </metadata>
   

--- a/templates/book-cover-final.html
+++ b/templates/book-cover-final.html
@@ -325,17 +325,17 @@
                 <span class="title-line-2">as <span class="highlight">Code</span></span>
             </h1>
             <p class="subtitle">
-                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Kvadrat Expert Team
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>First Edition</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover-light.html
+++ b/templates/book-cover-light.html
@@ -221,17 +221,17 @@
                 <span class="title-line-2">as <span class="highlight">Code</span></span>
             </h1>
             <p class="subtitle">
-                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Kvadrat Expert Team
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>First Edition</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover-minimal.html
+++ b/templates/book-cover-minimal.html
@@ -154,17 +154,17 @@
                 as <span class="highlight">Code</span>
             </h1>
             <p class="subtitle">
-                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Kvadrat Expert Team
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>First Edition</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover.html
+++ b/templates/book-cover.html
@@ -195,17 +195,17 @@
                 as <span class="highlight">Code</span>
             </h1>
             <p class="subtitle">
-                A comprehensive guide to architecture as code—from foundational principles to advanced implementation in modern cloud environments
+                A guide to how fully code-based architecture works—and the effects it has on adjacent disciplines such as design, development, governance, testing, and requirements management
             </p>
         </main>
 
         <footer class="footer">
             <div class="authors">
-                Kvadrat Expert Team
+                Gunnar Nordqvist
             </div>
             <div class="edition">
-                <div class="edition-year">2024</div>
-                <div>First Edition</div>
+                <div class="edition-year">2025</div>
+                <div>Published 2025</div>
             </div>
         </footer>
     </div>

--- a/templates/book-cover.svg
+++ b/templates/book-cover.svg
@@ -208,9 +208,9 @@
     <g transform="translate(0, 377)">
       <text font-family="Inter, sans-serif" font-size="22" font-weight="400" 
             fill="rgba(255,255,255,0.92)" line-height="1.5">
-        <tspan x="0" y="26">A comprehensive guide to architecture as code—</tspan>
-        <tspan x="0" y="59">from foundational principles to advanced</tspan>
-        <tspan x="0" y="92">implementation in modern cloud environments</tspan>
+        <tspan x="0" y="26">A guide to how fully code-based architecture works—</tspan>
+        <tspan x="0" y="59">and the effects it has on design, development, governance,</tspan>
+        <tspan x="0" y="92">testing, and requirements management</tspan>
         <tspan x="0" y="125" font-size="18" fill="rgba(5,150,105,0.8)">DevOps • CI/CD • Security • Compliance • Cloud Architecture</tspan>
       </text>
     </g>
@@ -219,16 +219,16 @@
     <g transform="translate(0, 783)">
       <!-- Authors -->
       <text x="0" y="20" font-family="Inter, sans-serif" font-size="20" font-weight="700"
-            fill="white">Kvadrat Expert Team</text>
+            fill="white">Gunnar Nordqvist</text>
       
       <!-- Edition info -->
       <g transform="translate(450, 0)">
         <!-- Year with gradient -->
-        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800" 
-              fill="url(#accentGradient)" text-anchor="end">2024</text>
+        <text x="0" y="28" font-family="Inter, sans-serif" font-size="28" font-weight="800"
+              fill="url(#accentGradient)" text-anchor="end">2025</text>
         <!-- Edition text -->
         <text x="0" y="52" font-family="Inter, sans-serif" font-size="16"
-              fill="rgba(255,255,255,0.85)" text-anchor="end">First Edition</text>
+              fill="rgba(255,255,255,0.85)" text-anchor="end">Published 2025</text>
       </g>
     </g>
     
@@ -237,12 +237,12 @@
   <!-- Additional metadata for editing -->
   <metadata>
     <title>Architecture as Code - Enhanced Book Cover</title>
-    <description>Professional book cover design for Kvadrat's Infrastructure as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
-    <author>Kvadrat Design Team</author>
-    <created>2024</created>
-    <updated>December 2024</updated>
+    <description>Professional book cover design for Kvadrat's Architecture as Code publication featuring DevOps, CI/CD, security, and cloud architecture themes</description>
+    <author>Gunnar Nordqvist</author>
+    <created>2025</created>
+    <updated>January 2025</updated>
     <brand-guidelines>Kvadrat Brand Guidelines v1.0</brand-guidelines>
-    <themes>Infrastructure as Code, DevOps, CI/CD, Security, Cloud Architecture, Global Context</themes>
+      <themes>Architecture as Code, Design, Development, Governance, Testing, Requirements</themes>
     <visual-elements>Pipeline patterns, security shields, cloud nodes, microservices, git repositories, containers</visual-elements>
   </metadata>
   


### PR DESCRIPTION
## Summary
- translate the exported and template book cover variants to English
- highlight the new subtitle describing code-based architecture impacts and credit Gunnar Nordqvist as 2025 author
- refresh SVG metadata to reflect the updated publication focus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecbf31f70083308ca06cefefd96b28