### PR TITLE
Rename release artifacts to British English names

### DIFF
--- a/.github/workflows/generate-presentations.yml
+++ b/.github/workflows/generate-presentations.yml
@@ -180,14 +180,14 @@ jobs:
           fi
           
           echo "🔍 Checking for PowerPoint presentation file..."
-          if [ -f "presentations/arkitektur_som_kod_presentation.pptx" ]; then
-            file_size=$(ls -lh presentations/arkitektur_som_kod_presentation.pptx | awk '{print $5}')
+          if [ -f "presentations/architecture_as_code_presentation.pptx" ]; then
+            file_size=$(ls -lh presentations/architecture_as_code_presentation.pptx | awk '{print $5}')
             echo "✅ PowerPoint presentation file created successfully"
             echo "   📄 File size: $file_size"
-            echo "   📄 File type: $(file presentations/arkitektur_som_kod_presentation.pptx)"
+            echo "   📄 File type: $(file presentations/architecture_as_code_presentation.pptx)"
           else
-            echo "❌ VALIDATION ERROR: arkitektur_som_kod_presentation.pptx is missing"
-            echo "   Expected location: presentations/arkitektur_som_kod_presentation.pptx"
+            echo "❌ VALIDATION ERROR: architecture_as_code_presentation.pptx is missing"
+            echo "   Expected location: presentations/architecture_as_code_presentation.pptx"
             validation_failed=true
           fi
           
@@ -218,8 +218,8 @@ jobs:
             echo "📝 PowerPoint script lines: $script_lines"
           fi
           
-          if [ -f "presentations/arkitektur_som_kod_presentation.pptx" ]; then
-            pptx_size=$(ls -lh presentations/arkitektur_som_kod_presentation.pptx | awk '{print $5}')
+          if [ -f "presentations/architecture_as_code_presentation.pptx" ]; then
+            pptx_size=$(ls -lh presentations/architecture_as_code_presentation.pptx | awk '{print $5}')
             echo "📊 PowerPoint file size: $pptx_size"
           fi
           
@@ -236,7 +236,7 @@ jobs:
             presentations/presentation_outline.md
             presentations/generate_pptx.py
             presentations/requirements.txt
-            presentations/arkitektur_som_kod_presentation.pptx
+            presentations/architecture_as_code_presentation.pptx
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
       - name: 📝 Create presentation summary (PR only)
@@ -271,8 +271,8 @@ jobs:
             }
             
             try {
-              if (fs.existsSync('presentations/arkitektur_som_kod_presentation.pptx')) {
-                const stats = fs.statSync('presentations/arkitektur_som_kod_presentation.pptx');
+              if (fs.existsSync('presentations/architecture_as_code_presentation.pptx')) {
+                const stats = fs.statSync('presentations/architecture_as_code_presentation.pptx');
                 const fileSize = (stats.size / 1024).toFixed(1); // Size in KB
                 summary += `- ✅ **PowerPoint File**: ${fileSize} KB presentation ready for download\n`;
               }

--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -299,8 +299,8 @@ jobs:
           echo "🔍 Checking for expected key files:"
           
           # Check for book files
-          if [ -f "releases/book/arkitektur_som_kod.pdf" ]; then
-            echo "✅ Book PDF found ($(ls -lh releases/book/arkitektur_som_kod.pdf | awk '{print $5}'))"
+          if [ -f "releases/book/architecture_as_code.pdf" ]; then
+            echo "✅ Book PDF found ($(ls -lh releases/book/architecture_as_code.pdf | awk '{print $5}'))"
           else
             echo "❌ Book PDF not found"
           fi
@@ -336,8 +336,8 @@ jobs:
           echo "📚 Book formats:"
           if [ -d "releases/book" ]; then
             ls -la releases/book/ || echo "   No book files found"
-            if [ -f "releases/book/arkitektur_som_kod.pdf" ]; then
-              echo "   📖 PDF size: $(ls -lh releases/book/arkitektur_som_kod.pdf | awk '{print $5}')"
+            if [ -f "releases/book/architecture_as_code.pdf" ]; then
+              echo "   📖 PDF size: $(ls -lh releases/book/architecture_as_code.pdf | awk '{print $5}')"
             fi
           fi
 
@@ -514,12 +514,12 @@ jobs:
             ### 📦 Complete Release Package Contents:
 
             #### 📖 Book Formats
-            - `arkitektur_som_kod.pdf` - Complete PDF book
-            - `arkitektur_som_kod.epub` - EPUB format for e-readers
-            - `arkitektur_som_kod.docx` - Microsoft Word format
+            - `architecture_as_code.pdf` - Complete PDF book
+            - `architecture_as_code.epub` - EPUB format for e-readers
+            - `architecture_as_code.docx` - Microsoft Word format
 
             #### 🎤 Presentation Materials
-            - `arkitektur_som_kod_presentation.pptx` - PowerPoint presentation
+            - `architecture_as_code_presentation.pptx` - PowerPoint presentation
             - Presentation outline and generation scripts
 
             #### 📄 Whitepapers
@@ -540,10 +540,10 @@ jobs:
 
             🎯 **This unified release includes ALL project deliverables with optimized build performance!**
           files: |
-            final-release/book/arkitektur_som_kod.pdf
-            final-release/book/arkitektur_som_kod.epub
-            final-release/book/arkitektur_som_kod.docx
-            final-release/presentation/arkitektur_som_kod_presentation.pptx
+            final-release/book/architecture_as_code.pdf
+            final-release/book/architecture_as_code.epub
+            final-release/book/architecture_as_code.docx
+            final-release/presentation/architecture_as_code_presentation.pptx
             final-release/whitepapers/whitepapers_combined.pdf
             unified-release-archive.zip
           draft: false

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,9 @@ link-verification-report.html
 link-verification-report.json
 
 # Generated book files in docs/ (should be in releases/book/)
-docs/arkitektur_som_kod.pdf
-docs/arkitektur_som_kod.epub
-docs/arkitektur_som_kod.docx
+docs/architecture_as_code.pdf
+docs/architecture_as_code.epub
+docs/architecture_as_code.docx
 
 # MkDocs build output
 site/

--- a/AUTOMATION_WORKFLOWS.md
+++ b/AUTOMATION_WORKFLOWS.md
@@ -42,7 +42,7 @@ The workflow runs when:
 - **`presentation_outline.md`** - Structured outline with key points from each chapter
 - **`generate_pptx.py`** - Python script to create PowerPoint presentations
 - **`requirements.txt`** - Dependencies needed for PowerPoint generation
-- **`arkitektur_which_kod_presentation.pptx`** - Complete PowerPoint presentation file (ready to use)
+- **`architecture_as_code_presentation.pptx`** - Complete PowerPoint presentation file (ready to use)
 
 ### Workflow Steps
 1. **Setup Environment** - Python 3.12 with required dependencies
@@ -56,7 +56,7 @@ The workflow runs when:
 After the workflow completes, the PowerPoint presentation is ready for imwithiate use!
 
 **Download from GitHub Actions artifacts:**
-- `arkitektur_which_kod_presentation.pptx` - Complete presentation (28 slides)
+- `architecture_as_code_presentation.pptx` - Complete presentation (28 slides)
 - `presentation_outline.md` - Structured outline for reference
 - `generate_pptx.py` - Script for local customization
 - `requirements.txt` - Dependencies list
@@ -121,7 +121,7 @@ presentations/                   # Generated presentation materials (ignored in 
 ├── presentation_outline.md      # Chapter outlines and key points
 ├── generate_pptx.py             # PowerPoint generation script
 ├── requirements.txt             # Python dependencies
-└── arkitektur_som_kod_presentation.pptx  # Generated PowerPoint file (ready to use)
+└── architecture_as_code_presentation.pptx  # Generated PowerPoint file (ready to use)
 
 whitepapers/                     # Generated whitepaper documents (ignored in git)
 ├── 01_inledning_whitepaper.html # Introduction whitepaper

--- a/CODEBASE_ANALYSIS.md
+++ b/CODEBASE_ANALYSIS.md
@@ -306,9 +306,9 @@ export default defineConfig({
 
 **Good**: The following are properly ignored:
 ```gitignore
-docs/arkitektur_som_kod.pdf
-docs/arkitektur_som_kod.epub
-docs/arkitektur_som_kod.docx
+docs/architecture_as_code.pdf
+docs/architecture_as_code.epub
+docs/architecture_as_code.docx
 ```
 
 **Issue**: Pandoc .deb package in repository root

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ docs/                     # Manuscript chapters, diagrams, and publishing assets
 └── pandoc.yaml           # Shared Pandoc configuration
 
 releases/                 # Git-ignored distribution bundles populated by build scripts
-├── book/                 # arkitektur_som_kod.{pdf,epub,docx}
-├── presentation/         # arkitektur_som_kod_presentation.pptx and supporting files
+├── book/                 # architecture_as_code.{pdf,epub,docx}
+├── presentation/         # architecture_as_code_presentation.pptx and supporting files
 ├── whitepapers/          # Per-chapter HTML exports
 └── website/              # Static site build output
 
@@ -90,8 +90,8 @@ mkdocs build   # render static site into the site/ directory
 Continuous integration enforces successful builds through the `Build MkDocs Site` workflow, which runs whenever `docs/` sources or the MkDocs configuration change.【F:mkdocs.yml†L1-L53】【F:.github/workflows/build-mkdocs.yml†L1-L35】
 
 ## 📦 Release Deliverables
-- **Book formats:** `arkitektur_som_kod.pdf`, `.epub`, and `.docx` generated via Pandoc with the Eisvogel template.
-- **Presentation materials:** `arkitektur_som_kod_presentation.pptx` containing chapter summaries and speaker notes.
+- **Book formats:** `architecture_as_code.pdf`, `.epub`, and `.docx` generated via Pandoc with the Eisvogel template.
+- **Presentation materials:** `architecture_as_code_presentation.pptx` containing chapter summaries and speaker notes.
 - **Whitepapers:** HTML exports for each chapter designed for responsive reading.
 - **Static website:** Production-ready site mirroring the manuscript for web distribution.【F:releases/README.md†L1-L48】
 

--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -230,7 +230,7 @@ def main() -> int:
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     )
     
-    epub_path = Path("docs/arkitektur_som_kod.epub")
+    epub_path = Path("docs/architecture_as_code.epub")
     
     if not epub_path.exists():
         logger.info("No EPUB file found to validate")

--- a/SOLUTION_SUMMARY.md
+++ b/SOLUTION_SUMMARY.md
@@ -28,7 +28,7 @@ Instead of modifying the source book content, this solution demonstrates the pro
 - `generate_pptx.py` - PowerPoint generator script
 - `requirements.txt` - Python dependencies for presentation creation
 - `README.md` - Complete documentation for the presentations feature
-- `arkitektur_which_kod_presentation.pptx` - Generated PowerPoint file (excluded from git)
+- `architecture_as_code_presentation.pptx` - Generated PowerPoint file (excluded from git)
 
 #### 3. **Protection Guidelines and Tools**
 
@@ -148,7 +148,7 @@ presentations/
 ├── presentation_outline.md
 ├── generate_pptx.py
 ├── requirements.txt
-└── arkitektur_som_kod_presentation.pptx (generated, git-ignored)
+└── architecture_as_code_presentation.pptx (generated, git-ignored)
 
 scripts/
 └── validate_docs_protection.py

--- a/SYNTAX_HIGHLIGHTING.md
+++ b/SYNTAX_HIGHLIGHTING.md
@@ -156,7 +156,7 @@ To verify syntax highlighting works:
 2. **Book Formats**: Generate book and check PDF
    ```bash
    python3 generate_book.py && cd docs && ./build_book.sh --release
-   # Check releases/book/arkitektur_som_kod.pdf for colored code blocks
+   # Check releases/book/architecture_as_code.pdf for colored code blocks
    ```
 
 3. **Presentations**: Generate presentations

--- a/TRANSLATION_COMPLETION_SUMMARY.md
+++ b/TRANSLATION_COMPLETION_SUMMARY.md
@@ -70,7 +70,7 @@ This document summarizes the completion of the English translation project for t
 4. **releases/README_en.md**
    - Releases folder documentation
    - Translated from Swedish original
-   - Fixed filename references (arkitektur_som_kod)
+   - Fixed filename references (architecture_as_code)
 
 5. **tests/README_en.md**
    - Test suite documentation
@@ -80,7 +80,7 @@ This document summarizes the completion of the English translation project for t
 ### Translation Artifacts Fixed
 
 During automated translation, some errors were introduced and corrected:
-- ❌ "arkitektur_which_kod" → ✅ "arkitektur_som_kod"
+- ❌ "arkitektur_which_kod" → ✅ "architecture_as_code"
 - ❌ "Kwhatrat" → ✅ "Kvadrat"
 - ❌ "Withium-resolution" → ✅ "Medium-resolution"
 - ❌ "social withia" → ✅ "social media"

--- a/TRANSLATION_PROJECT.md
+++ b/TRANSLATION_PROJECT.md
@@ -197,7 +197,7 @@ To fully support English book generation:
 2. **Update `docs/build_book.sh`:**
    - Add English PDF build target
    - Configure Pandoc for English metadata
-   - Generate `arkitektur_which_kod_en.pdf`
+   - Generate `architecture_as_code_en.pdf`
    - Support bilingual builds with single command
 
 3. **Update GitHub Actions:**
@@ -214,7 +214,7 @@ if [ "$LANG" = "a" ]; then
     OUTPUT_PDF="architecture_as_code_en.pdf"
 else
     CHAPTER_FILES=("01_introduction.md" "02_fundamental_principles.md" ...)
-    OUTPUT_PDF="arkitektur_som_kod.pdf"
+    OUTPUT_PDF="architecture_as_code.pdf"
 fi
 ```
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -166,10 +166,10 @@ Omit optional fields to fall back on the default guidance defined in the workflo
 **Unified Releases** include:
 ```
 Assets:
-├── arkitektur_som_kod.pdf (PDF book)
-├── arkitektur_som_kod.epub (EPUB book)  
-├── arkitektur_som_kod.docx (Word book)
-├── arkitektur_som_kod_presentation.pptx (PowerPoint)
+├── architecture_as_code.pdf (PDF book)
+├── architecture_as_code.epub (EPUB book)  
+├── architecture_as_code.docx (Word book)
+├── architecture_as_code_presentation.pptx (PowerPoint)
 ├── whitepapers_combined.pdf (All whitepapers)
 └── unified-release-archive.zip (Everything)
 ```

--- a/build_release.sh
+++ b/build_release.sh
@@ -122,9 +122,9 @@ if [ -f "docs/build_book.sh" ]; then
         # Return to original directory before verification
         cd "$current_dir"
         # Verify book files were created
-        verify_file "releases/book/arkitektur_som_kod.pdf" "Book PDF"
-        verify_file "releases/book/arkitektur_som_kod.epub" "Book EPUB" || true
-        verify_file "releases/book/arkitektur_som_kod.docx" "Book DOCX" || true
+        verify_file "releases/book/architecture_as_code.pdf" "Book PDF"
+        verify_file "releases/book/architecture_as_code.epub" "Book EPUB" || true
+        verify_file "releases/book/architecture_as_code.docx" "Book DOCX" || true
     else
         log "❌ Failed to build book formats"
         cd "$current_dir"
@@ -207,7 +207,7 @@ fi
 
 # 7. Generate presentation PDF (if PPTX exists)
 log "🎥 Step 7: Attempting to generate presentation PDF..."
-if [ -f "releases/presentation/arkitektur_som_kod_presentation.pptx" ]; then
+if [ -f "releases/presentation/architecture_as_code_presentation.pptx" ]; then
     log "⚠️  PowerPoint to PDF conversion requires additional tools (LibreOffice or similar)"
     log "   Manual conversion recommended for presentation PDF"
 else

--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -121,9 +121,9 @@ fi
 
 # Determine the release directory path (relative to docs directory)
 RELEASE_DIR="../releases/book"
-OUTPUT_PDF="arkitektur_som_kod.pdf"
-OUTPUT_EPUB="arkitektur_som_kod.epub"
-OUTPUT_DOCX="arkitektur_som_kod.docx"
+OUTPUT_PDF="architecture_as_code.pdf"
+OUTPUT_EPUB="architecture_as_code.epub"
+OUTPUT_DOCX="architecture_as_code.docx"
 RELEASE_PDF="$RELEASE_DIR/$OUTPUT_PDF"
 RELEASE_EPUB="$RELEASE_DIR/$OUTPUT_EPUB"
 RELEASE_DOCX="$RELEASE_DIR/$OUTPUT_DOCX"

--- a/docs/images/diagram_27_technical_structure.mmd
+++ b/docs/images/diagram_27_technical_structure.mmd
@@ -33,7 +33,7 @@ graph TB
 
     %% Output Formats
     subgraph "Utdataformat"
-        PDF[📕 PDF-bok<br/>arkitektur_som_kod.pdf]
+        PDF[📕 PDF-bok<br/>architecture_as_code.pdf]
         EPUB[📱 EPUB-format<br/>E-läsare]
         DOCX[📄 Word-dokument<br/>Redigering]
         HTML[🌐 HTML-sidor<br/>Whitepapers]

--- a/generate_book.py
+++ b/generate_book.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
     # generate_iac_book_content()
     
     # EPUB validation is still active
-    epub_path = "docs/arkitektur_som_kod.epub"
+    epub_path = "docs/architecture_as_code.epub"
     if os.path.exists(epub_path):
         print("📖 Checking existing EPUB file...")
         success, log_output = validate_epub_file(epub_path)

--- a/generate_presentation.py
+++ b/generate_presentation.py
@@ -255,7 +255,7 @@ def validate_chapter_diagrams():
             if chapter_name.startswith('part_'):
                 continue
 
-        if chapter_name in ['README.md', 'arkitektur_som_kod.md']:
+        if chapter_name in ['README.md', 'architecture_as_code.md']:
             continue
 
         validation_results['total_chapters'] += 1
@@ -549,7 +549,7 @@ def generate_presentation_outline():
     presentation_data = []
     
     for chapter_file in chapter_files:
-        if Path(chapter_file).name in ['README.md', 'arkitektur_som_kod.md']:
+        if Path(chapter_file).name in ['README.md', 'architecture_as_code.md']:
             continue  # Skip non-chapter files
             
         chapter_data = read_chapter_content(chapter_file)
@@ -698,7 +698,7 @@ def create_presentation():
     script_content += '''
     
     # Save presentation
-    output_path = "arkitektur_som_kod_presentation.pptx"
+    output_path = "architecture_as_code_presentation.pptx"
     prs.save(output_path)
     print(f"✅ Presentation saved to {output_path}")
     print(f"📊 Total slides created: {len(prs.slides)}")
@@ -714,7 +714,7 @@ if __name__ == "__main__":
     
     return script_content
 
-def create_presentation_directly(presentation_data, output_path="arkitektur_som_kod_presentation.pptx"):
+def create_presentation_directly(presentation_data, output_path="architecture_as_code_presentation.pptx"):
     """Create PowerPoint presentation directly without generating a script."""
     try:
         from pptx import Presentation
@@ -827,7 +827,7 @@ def main():
     parser = argparse.ArgumentParser(description="Generate PowerPoint presentation from book chapters")
     parser.add_argument("--create-pptx", action="store_true", 
                        help="Create PowerPoint file directly (requires python-pptx)")
-    parser.add_argument("--output", default="arkitektur_som_kod_presentation.pptx",
+    parser.add_argument("--output", default="architecture_as_code_presentation.pptx",
                        help="Output filename for PowerPoint file")
     parser.add_argument("--validate-diagrams", action="store_true",
                        help="Validate that all chapters have diagrams and check diagram type coverage")

--- a/releases/README.md
+++ b/releases/README.md
@@ -6,13 +6,13 @@ This folder contains all deliverables generated during the build process, organi
 
 ### `/book/`
 Contains book formats generated from the markdown source:
-- `arkitektur_som_kod.pdf` - Complete book in PDF format
-- `arkitektur_som_kod.epub` - EPUB format for e-readers
-- `arkitektur_som_kod.docx` - Microsoft Word format
+- `architecture_as_code.pdf` - Complete book in PDF format
+- `architecture_as_code.epub` - EPUB format for e-readers
+- `architecture_as_code.docx` - Microsoft Word format
 
 ### `/presentation/`
 Contains presentation materials:
-- `arkitektur_som_kod_presentation.pptx` - PowerPoint presentation
+- `architecture_as_code_presentation.pptx` - PowerPoint presentation
 - `presentation_outline.md` - Presentation content outline
 - `generate_pptx.py` - Script to regenerate presentation
 - `requirements.txt` - Python dependencies for presentation generation

--- a/tests/test_epub_validation.py
+++ b/tests/test_epub_validation.py
@@ -21,12 +21,12 @@ class TestEPUBValidation:
     @pytest.fixture 
     def epub_file(self, docs_directory):
         """Get path to EPUB file."""
-        return docs_directory / "arkitektur_som_kod.epub"
+        return docs_directory / "architecture_as_code.epub"
     
     @pytest.fixture
     def release_epub_file(self):
         """Get path to release EPUB file."""
-        return Path(__file__).parent.parent / "releases" / "book" / "arkitektur_som_kod.epub"
+        return Path(__file__).parent.parent / "releases" / "book" / "architecture_as_code.epub"
     
     def test_epubcheck_available(self):
         """Test that EPUBCheck tool is available."""


### PR DESCRIPTION
## Summary
- rename all book output filenames to `architecture_as_code` variants across build scripts and automation workflows
- update presentation workflow, scripts, and documentation to expect `architecture_as_code_presentation.pptx`
- refresh tests and repository docs to reference the British English artifact names

## Testing
- pytest tests/test_epub_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68ecd741f14483308f893c91eec809aa