### PR TITLE
Adjust odd-page header to show part information

### DIFF
--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -90,9 +90,10 @@ variables:
     \newcommand{\setbookpart}[1]{%
       \renewcommand{\currentpartletter}{\thepart}%
       \renewcommand{\currentparttitle}{#1}%
-      \renewcommand{\currentpartformat}{PART~\thepart\space--\space #1}%
+      \renewcommand{\currentpartformat}{PART~\thepart\space-\space #1}%
     }
     \renewcommand{\chaptermark}[1]{\markboth{\thechapter.\ #1}{}}
+    \fancyhead[LO]{\small\bfseries \currentpartformat}
     \fancyhead[LE]{\small\bfseries \currentpartformat}
     \fancyhead[RO]{\small\bfseries \leftmark}
     \fancyfoot[C]{\thepage}


### PR DESCRIPTION
## Summary
- show the current part format on the left header of odd pages in the PDF output
- align the part header formatting with a single hyphen separator to match the desired text

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: missing xelatex in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecd83a17dc8330a13c8f662080ac0c