### PR TITLE
Ensure gh-pages deployment preserves custom domain

### DIFF
--- a/.github/workflows/build-mkdocs.yml
+++ b/.github/workflows/build-mkdocs.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Build MkDocs site
         run: mkdocs build
 
+      - name: Prepare static site artifacts
+        run: |
+          if [ -f CNAME ]; then
+            cp CNAME site/CNAME
+          fi
+          touch site/.nojekyll
+
       - name: Deploy MkDocs site to GitHub Pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +52,12 @@ jobs:
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
           git fetch
           git switch -C gh-pages
-          cp -r site/* .
+          git rm -rf . || true
+          cp -r site/. .
           git add .
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+            exit 0
+          fi
           git commit -m "Deploy MkDocs site"
           git push origin gh-pages --force


### PR DESCRIPTION
## Summary
- copy the repository CNAME into the generated site and add a .nojekyll marker
- reset the gh-pages branch before copying the freshly built MkDocs output
- avoid pushing when no site changes are detected to keep the workflow idempotent

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68ecd8d50a908330b18d6da2cfd5a229