### PR TITLE
Align tests with current book pipeline

### DIFF
--- a/generate_whitepapers.py
+++ b/generate_whitepapers.py
@@ -122,19 +122,21 @@ def read_chapter_content(chapter_file):
 
 def get_book_overview():
     """Return the book overview and purpose description."""
+    chapter_total = len(get_chapter_mapping())
+
     return {
         'title': 'Arkitektur som kod',
         'subtitle': 'Infrastructure as Code för svenska organisationer',
         'description': '''
-Infrastructure as Code representerar en fundamental förändring i hur vi hanterar och utvecklar IT-infrastruktur. 
-Denna bok ger svenska organisationer praktisk vägledning för att implementera IaC-principer samtidigt som de 
+Infrastructure as Code representerar en fundamental förändring i hur vi hanterar och utvecklar IT-infrastruktur.
+Denna bok ger svenska organisationer praktisk vägledning för att implementera IaC-principer samtidigt som de
 uppfyller lokala compliance-krav och optimerar kostnader.
 
-Boken täcker allt från grundläggande principer och verktyg till avancerade implementationsstrategier, 
+Boken täcker allt från grundläggande principer och verktyg till avancerade implementationsstrategier,
 säkerhetsaspekter och organisatoriska förändringar som krävs för framgångsrik IaC-adoption.
         '''.strip(),
         'target_audience': 'IT-arkitekter, DevOps-team, utvecklare och beslutsfattare inom svenska organisationer',
-        'chapters_count': 31
+        'chapters_count': chapter_total
     }
 
 def get_chapter_mapping():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 """
-Test suite for "Arkitektur som Kod" book content validation.
+Test suite for the "Architecture as Code" book.
 
 This package contains modular tests to validate:
 - Completeness: All required sections and chapters
-- Consistency: Uniform tone, style, and formatting  
+- Consistency: Uniform tone, style, and formatting
 - Clarity: Content quality and readability
 - Technical Accuracy: Code snippets, diagrams, and examples
 """

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Content validation test runner for "Arkitektur som Kod" book.
+Content validation test runner for the "Architecture as Code" book.
 
 This script runs the complete test suite and generates reports.
 """
@@ -128,7 +128,7 @@ def run_tests(test_type="all", verbose=True, generate_report=True):
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
-        description="Content validation test runner for Arkitektur som Kod book"
+        description="Content validation test runner for the Architecture as Code book"
     )
     parser.add_argument(
         "--type", 


### PR DESCRIPTION
## Summary
- update the whitepaper test suite to derive chapter counts from the current docs layout and keep the book overview in sync
- extend EPUB validation coverage with build pipeline checks and refresh test suite messaging to reference Architecture as Code
- make the whitepaper overview dynamically report the number of mapped chapters

## Testing
- pytest tests/test_whitepaper_generation.py::TestWhitepaperGeneration::test_chapter_mapping_complete -q
- pytest tests/test_epub_validation.py::TestBuildPipelineConfiguration::test_build_script_defines_expected_outputs -q
- pytest tests/test_epub_validation.py::TestBuildPipelineConfiguration::test_build_script_invokes_pandoc -q

------
https://chatgpt.com/codex/tasks/task_e_68ecd94147448330a437719830056e84