### PR TITLE
Adjust PDF headers to show chapter titles

### DIFF
--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -79,9 +79,12 @@ variables:
       \renewcommand{\currentpartformat}{PART~\thepart\space-\space #1}%
     }
     \renewcommand{\chaptermark}[1]{\markboth{\thechapter.\ #1}{}}
-    \fancyhead[LO]{\small\bfseries \currentpartformat}
-    \fancyhead[LE]{\small\bfseries \currentpartformat}
-    \fancyhead[RO]{\small\bfseries \leftmark}
+    % Show only the current chapter title in the running header to avoid
+    % duplicating the part name alongside the chapter label.
+    \fancyhead[LO]{\small\bfseries \leftmark}
+    \fancyhead[LE]{\small\bfseries \leftmark}
+    \fancyhead[RO]{}
+    \fancyhead[RE]{}
     \fancyfoot[C]{\thepage}
     \renewcommand{\headrulewidth}{0pt}
     \renewcommand{\partname}{Part}


### PR DESCRIPTION
## Summary
- update the Pandoc header configuration so the running header only prints the current chapter title
- clear the part name from the header to avoid showing both the part and chapter simultaneously

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: missing xelatex in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecef482e388330af44a8f3d6812dd2