### PR TITLE
Make chapter 10 diagrams vertical

### DIFF
--- a/docs/images/diagram_12_chapter10.mmd
+++ b/docs/images/diagram_12_chapter10.mmd
@@ -1,4 +1,4 @@
-graph LR
+graph TB
     A[Container Images]:::kv-primary --> B[Kubernetes Cluster]:::kv-highlight
     B --> C[Service Mesh]:::kv-accent
     C --> D[Application Services]:::kv-accent

--- a/docs/images/mindmap_10_security.mmd
+++ b/docs/images/mindmap_10_security.mmd
@@ -1,4 +1,5 @@
 mindmap
+  direction TB
   root((Security in Architecture as Code))
     Threat Modeling
       Threat Landscape


### PR DESCRIPTION
## Summary
- switch the chapter 10 lifecycle diagram to a top-to-bottom layout for easier vertical reading
- orient the security mind map vertically so branches flow downward from the root

## Testing
- `python3 generate_book.py`
- `docs/build_book.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ecf0c399088330af2911a5f6a27462