### PR TITLE
Fix English text in Chapter 2 diagram

### DIFF
--- a/docs/images/diagram_02_fundamental_principles.mmd
+++ b/docs/images/diagram_02_fundamental_principles.mmd
@@ -1,5 +1,5 @@
 Diagram LR
-A[Deklarativ kod] --&gt; B[Versionskontroll]
-B --&gt; C[Automatisering]
-C --&gt; D[reproducerbarhet]
-D --&gt; E[Skalbarhet]
+A[Declarative Code] --> B[Version Control]
+B --> C[Automation]
+C --> D[Reproducibility]
+D --> E[Scalability]


### PR DESCRIPTION
## Summary
- update the Chapter 2 fundamental principles Mermaid diagram to use English labels for each node

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: Mermaid CLI image conversion and XeLaTeX dependencies not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed2a9202fc8330a0dd9398fc546db1