### PR TITLE
Fix MkDocs image rendering for chapter 1

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,5 +50,9 @@ use_directory_urls: true
 markdown_extensions:
   - toc
   - tables
+  - pymdownx.pathconverter:
+      base_path: docs
+      relative_path: ''
+      absolute: true
 extra_css:
   - stylesheets/code-dark.css


### PR DESCRIPTION
## Summary
- add the pymdownx path converter extension so MkDocs rewrites relative asset links to absolute paths
- ensure chapter 1 image references resolve correctly when browsing the documentation site

## Testing
- mkdocs build *(fails: mkdocs not installed in the execution environment)*
- python3 generate_book.py && docs/build_book.sh *(interrupted after hanging without producing output)*

------
https://chatgpt.com/codex/tasks/task_e_68ed2aa4cc588330bb55bbde2458f363