### PR TITLE
Fix appendix numbering for appendix B

### DIFF
--- a/docs/30_appendix_code_examples.md
+++ b/docs/30_appendix_code_examples.md
@@ -1,6 +1,8 @@
-# Appendix A: Kodexempel and technical architecture as code-implementations
+\appendix
 
-This appendix contains all kodexamples, konfigurationsfiler and technical implementeringar as refereras to in bokens huvudkapitel. Kodexemplen is organiserade efter typ and användningwhichråde to do the enkelt to hitta specific implementations.
+# Code examples and technical architecture as code implementations
+
+Appendix A contains all kodexamples, konfigurationsfiler and technical implementeringar as refereras to in bokens huvudkapitel. Kodexemplen is organiserade efter typ and användningwhichråde to do the enkelt to hitta specific implementations.
 
 ![Kodexempel appendix](images/diagram_26_appendix.png)
 

--- a/docs/31_technical_architecture.md
+++ b/docs/31_technical_architecture.md
@@ -10,9 +10,9 @@ This chapter describes the technical infrastructure and workflow that produce, b
 
 The entity relationship diagram above shows the logical data structure that connects organisations, projects, infrastructure, and deployments in an Architecture as Code implementation.
 
-## 31.1 Markdown Files: Structure and Purpose
+## Markdown Files: Structure and Purpose
 
-### 31.1.1 File Organisation and Naming Conventions
+### File Organisation and Naming Conventions
 
 Book content is organised in 31 Markdown files within the `docs/` directory, where each file represents a chapter:
 
@@ -33,7 +33,7 @@ docs/
 └── 31_technical_architecture.md    # This chapter
 ```
 
-### 31.1.2 Markdown Structure and Semantics
+### Markdown Structure and Semantics
 
 Each chapter follows a consistent structure that optimises both readability and automated processing. The template below demonstrates how headings, diagrams, lists, and code samples are arranged.
 
@@ -57,7 +57,7 @@ Introductory text with a short description of the chapter’s contents.
 
 This layout ensures that readers can skim the content quickly, while the build pipeline can reliably transform every chapter into the desired publication formats.
 
-### 31.1.3 Automated Content Generation
+### Automated Content Generation
 
 The system uses `generate_book.py` to generate and update chapter content automatically:
 
@@ -66,9 +66,9 @@ The system uses `generate_book.py` to generate and update chapter content automa
 - **Consistency management**: Keeps structure uniform across all chapters.
 - **Version control**: Tracks every change through Git.
 
-## 31.2 Pandoc: Conversion and Formatting
+## Pandoc: Conversion and Formatting
 
-### 31.2.1 Configuration System
+### Configuration System
 
 Pandoc conversion is governed by `pandoc.yaml`, which defines all format-specific settings:
 
@@ -91,7 +91,7 @@ metadata:
   author: "Code Architecture Book Workshop"
 ```
 
-### 31.2.2 Build Process and Architecture as Code Automation
+### Build Process and Architecture as Code Automation
 
 `build_book.sh` orchestrates the entire build process:
 
@@ -113,16 +113,16 @@ done
 pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -o architecture_as_code.pdf
 ```
 
-### 31.2.3 Quality Assurance and Validation
+### Quality Assurance and Validation
 
 - **Template validation**: Automatically checks the Eisvogel template.
 - **Configuration control**: Verifies Pandoc settings in `pandoc.yaml`.
 - **Image handling**: Ensures every diagram reference resolves correctly.
 - **Output verification**: Confirms the generated files meet expectations.
 
-## 31.3 GitHub Actions: CI/CD Pipeline
+## GitHub Actions: CI/CD Pipeline
 
-### 31.3.1 Primary Workflow for Book Production
+### Primary Workflow for Book Production
 
 `build-book.yml` automates the entire publication process:
 
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 90
 ```
 
-### 31.3.2 Workflow Steps and Optimisations
+### Workflow Steps and Optimisations
 
 1. **Environment setup (15 minutes)**:
    - Install Python 3.12.
@@ -167,15 +167,15 @@ jobs:
    - Store build artefacts for 30 days.
    - Distribute the PDF through GitHub Releases.
 
-### 31.3.3 Complementary Workflows
+### Complementary Workflows
 
 - **Content Validation** (`content-validation.yml`): Markdown syntax checks, link validation, and language quality control.
 - **Presentation Generation** (`generate-presentations.yml`): Creates PowerPoint-ready outlines with Kvadrat branding.
 - **Whitepaper Generation** (`generate-whitepapers.yml`): Builds standalone HTML documents optimised for search engines and printing.
 
-## 31.4 Presentation Materials: Preparation and Generation
+## Presentation Materials: Preparation and Generation
 
-### 31.4.1 Automated Outline Generation
+### Automated Outline Generation
 
 `generate_presentation.py` creates presentation materials from the book’s content:
 
@@ -197,7 +197,7 @@ def generate_presentation_outline():
     return presentation_data
 ```
 
-### 31.4.2 PowerPoint Integration
+### PowerPoint Integration
 
 The system delivers:
 
@@ -206,7 +206,7 @@ The system delivers:
 - **Kvadrat branding**: Consistent visual identity.
 - **Content optimisation**: Arranged for confident verbal delivery.
 
-### 31.4.3 Distribution and Use
+### Distribution and Use
 
 ```bash
 # Download artefacts from GitHub Actions
@@ -217,9 +217,9 @@ python generate_pptx.py
 
 The result is a set of professional PowerPoint presentations tailored for conferences, workshops, training sessions, marketing activities, and technical seminars.
 
-## 31.5 Cover and Whitepapers: Design and Integration
+## Cover and Whitepapers: Design and Integration
 
-### 31.5.1 Cover Design System
+### Cover Design System
 
 The book cover is produced through an HTML/CSS design system:
 
@@ -235,7 +235,7 @@ exports/book-cover/
     └── generate_book_cover_exports.py
 ```
 
-### 31.5.2 Kvadrat Brand Integration
+### Kvadrat Brand Integration
 
 The design system implements Kvadrat’s visual identity:
 
@@ -255,7 +255,7 @@ The design system implements Kvadrat’s visual identity:
 }
 ```
 
-### 31.5.3 Whitepaper Generation
+### Whitepaper Generation
 
 `generate_whitepapers.py` creates standalone HTML documents:
 
@@ -265,9 +265,9 @@ The design system implements Kvadrat’s visual identity:
 - **Search optimisation**: Accurate metadata and structure.
 - **Distribution ready**: Suitable for email, web, or print.
 
-## 31.6 Technical Architecture and System Integration
+## Technical Architecture and System Integration
 
-### 31.6.1 Holistic View of the Architecture
+### Holistic View of the Architecture
 
 The system demonstrates Architecture as Code through:
 
@@ -277,14 +277,14 @@ The system demonstrates Architecture as Code through:
 4. **Reproducibility**: Identical builds from the same source code.
 5. **Scalability**: Simple to add new chapters and formats.
 
-### 31.6.2 Quality Assurance and Testing
+### Quality Assurance and Testing
 
 - **Automated validation**: Continuous checks of content and formatting.
 - **Build verification**: Ensures every format is generated correctly.
 - **Performance monitoring**: Tracks build times and resource usage.
 - **Error handling**: Provides clear messages and recovery options.
 
-### 31.6.3 Future Development
+### Future Development
 
 The system is designed for continuous improvement:
 


### PR DESCRIPTION
## Summary
- start the appendices with a LaTeX `\appendix` directive so Pandoc switches from numeric to lettered headings
- remove hard-coded numeric prefixes from the technical architecture appendix so section numbers follow the appendix format

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: missing `xelatex` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed42c6377c8330a9c41f202c24e78c