### PR TITLE
Remove Appendix A Figure 26.1

### DIFF
--- a/docs/30_appendix_code_examples.md
+++ b/docs/30_appendix_code_examples.md
@@ -2,8 +2,6 @@
 
 This appendix contains all kodexamples, konfigurationsfiler and technical implementeringar as refereras to in bokens huvudkapitel. Kodexemplen is organiserade efter typ and användningwhichråde to do the enkelt to hitta specific implementations.
 
-![Kodexempel appendix](images/diagram_26_appendix.png)
-
 *This appendix functions as a praktisk referenssamling for all technical implementations as demonstreras genAbout the Book. each kodexamples is kategoriserat and märkt with References tobaka to relevanta chapter.*
 
 ## Navigering in appendix


### PR DESCRIPTION
## Summary
- remove the Figure 26.1 image block from Appendix A so the content opens with the introductory text

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: missing xelatex in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed42cec9148330ae32beef6f939d1a