### PR TITLE
Fix competency loop paragraph line break

### DIFF
--- a/docs/18_team_structure.md
+++ b/docs/18_team_structure.md
@@ -14,7 +14,9 @@ Platform teams act as internal service providers. They own the common toolchains
 
 ![Competency development loop illustrating assessment, planning, learning, application, knowledge sharing, and measurement](images/diagram_18_competency_cycle.png)
 
-Architecture as Code specialists blend system engineering, software craftsmanship, and cloud fluency. Core skills include modern programming languages for automation (such as Python, Go, or PowerShell), multi-cloud familiarity spanning AWS, Azure, and Google Cloud, and disciplined software engineering practices like version control, testing, and peer review. The competency development loop depicted above highlights how continuous assessment, learning, and knowledge sharing reinforce professional growth.
+Architecture as Code specialists blend system engineering, software craftsmanship, and cloud fluency.
+Core skills include modern programming languages for automation (such as Python, Go, or PowerShell), multi-cloud familiarity spanning AWS, Azure, and Google Cloud, and disciplined software engineering practices like version control, testing, and peer review.
+The competency development loop depicted above highlights how continuous assessment, learning, and knowledge sharing reinforce professional growth.
 
 Soft skills are equally significant. Practitioners must communicate design intent, negotiate trade-offs with stakeholders, and mentor peers adopting new tooling. These interpersonal abilities ensure technical decisions are understood and adopted across the organisation.
 


### PR DESCRIPTION
## Summary
- reflow the competency development paragraph in chapter 18 to eliminate the forced line break before "sharing reinforce professional growth"

## Testing
- `python3 generate_book.py && docs/build_book.sh` *(fails: missing xelatex in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed42dda7e483309d193d10eb0f0507