### PR TITLE
Rename technical architecture chapter as Appendix B

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The book explores how to treat architecture and infrastructure work as software 
 - **Chapter 28 – Glossary:** Key terminology for Architecture as Code initiatives.
 - **Chapter 29 – About the Author:** Profile of Gunnar Nordqvist and the expertise behind the book.
 - **Chapter 30 – Appendix A: Code Examples:** Reference implementations and automation templates.
-- **Chapter 31 – Technical Structure for Book Production:** Tooling overview for the publishing platform.【F:docs/book_structure.md†L97-L139】
+- **Appendix B – Technical Architecture for Book Production:** Tooling overview for the publishing platform.【F:docs/book_structure.md†L97-L139】
 
 ### Archived Drafts
 - **Former Chapter 32 – Advantages and Disadvantages of Working in a Code-Oriented Organisation:** Preserved in `docs/archive/32_code_oriented_organisations.md` for optional background reading and future revisions.【F:docs/book_structure.md†L81-L108】【F:docs/archive/README.md†L1-L9】

--- a/docs/31_technical_architecture.md
+++ b/docs/31_technical_architecture.md
@@ -1,6 +1,6 @@
-# Technical Architecture for Book Production
+# Appendix B: Technical Architecture for Book Production
 
-This chapter describes the technical infrastructure and workflow that produce, build, and publish "Architecture as Code". The system is a practical demonstration of Architecture as Code principles, showing how code defines and automates the entire book production process.
+This appendix describes the technical infrastructure and workflow that produce, build, and publish "Architecture as Code". The system is a practical demonstration of Architecture as Code principles, showing how code defines and automates the entire book production process.
 
 ![Technical architecture for book production](images/diagram_27_technical_structure.png)
 
@@ -30,7 +30,7 @@ docs/
 ├── 28_glossary.md                  # Terminology
 ├── 29_about_the_authors.md         # Author information
 ├── 30_appendix_code_examples.md    # Technical examples
-└── 31_technical_architecture.md    # This chapter
+└── 31_technical_architecture.md    # This appendix
 ```
 
 ### 31.1.2 Markdown Structure and Semantics

--- a/docs/book_structure.md
+++ b/docs/book_structure.md
@@ -104,14 +104,14 @@ Reference material, author information, and technical enablers
 | 25 | `25_future_trends_development.md` | Future Trends and Development in Architecture as Code | Development trends, technological future, and long-term perspectives |
 | 27 | `27_conclusion.md` | Conclusion | Concluding reflections |
 
-### Appendices (Chapters 28-31)
+### Appendices
 
-| Chapter | File | Title | Description |
-|---------|------|-------|-------------|
+| Chapter / Appendix | File | Title | Description |
+|--------------------|------|-------|-------------|
 | 28 | `28_glossary.md` | Glossary | Glossary and definitions |
 | 29 | `29_about_the_authors.md` | About the Author | Profile of Gunnar Nordqvist and context for the book's expertise |
 | 30 | `30_appendix_code_examples.md` | Appendix A: Code Examples and Technical Implementations | Technical architecture code implementations |
-| 31 | `31_technical_architecture.md` | Technical Structure for Book Production | Technical book production infrastructure |
+| Appendix B | `31_technical_architecture.md` | Appendix B: Technical Architecture for Book Production | Technical book production infrastructure |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ nav:
       - Glossary: 28_glossary.md
       - About the Author: 29_about_the_authors.md
       - Appendix A – Code Examples and Technical Implementations: 30_appendix_code_examples.md
-      - Technical Structure for Book Production: 31_technical_architecture.md
+      - Appendix B – Technical Architecture for Book Production: 31_technical_architecture.md
 docs_dir: docs
 use_directory_urls: true
 markdown_extensions:


### PR DESCRIPTION
## Summary
- rename the technical architecture chapter heading to "Appendix B" to match the intended appendix naming
- update the MkDocs navigation and book structure table so the technical architecture content is grouped with the appendices
- refresh the README appendix list to reference Appendix B and the updated chapter metadata

## Testing
- python3 generate_book.py
- ./build_book.sh *(fails: missing xelatex and Mermaid conversions in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed42f565f88330abf7f9740fdda075