### PR TITLE
Configure MkDocs to use Bootswatch Slate theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
       - Appendix B – Technical Architecture for Book Production: 31_technical_architecture.md
 docs_dir: docs
 use_directory_urls: true
+theme:
+  name: bootswatch
+  bootswatch_theme: slate
 markdown_extensions:
   - toc
   - tables


### PR DESCRIPTION
## Summary
- configure MkDocs to use the Bootswatch theme with the Slate variant for the documentation site

## Testing
- not run (mkdocs command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed5b3fff148330843e883aa492c660