### PR TITLE
Update MkDocs configuration to use built-in theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,7 @@ nav:
 docs_dir: docs
 use_directory_urls: true
 theme:
-  name: bootswatch
-  bootswatch_theme: slate
+  name: readthedocs
 markdown_extensions:
   - toc
   - tables


### PR DESCRIPTION
## Summary
- replace the Bootswatch theme configuration with the built-in Read the Docs theme so MkDocs can build with the available themes

## Testing
- mkdocs build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5c3fa68883308e6dd3b770e409d9