### PR TITLE
fix: capitalise Figure 14.4 caption

### DIFF
--- a/docs/14_practical_implementation.md
+++ b/docs/14_practical_implementation.md
@@ -16,6 +16,11 @@ The adoption journey in Figure 14.2 breaks down these stages into the minimum se
 ![Figure 14.2 – Iterative journey for Architecture as Code adoption](images/diagram_13_user_journey.png)
 *Figure 14.2 – A simplified adoption journey that balances architectural guardrails with iterative delivery milestones.*
 
+Figure 14.4 captures the enablement flywheel that keeps Architecture as Code programmes sustainable by moving teams from shared delivery into lasting communities of practice.
+
+![Figure 14.4 – Enablement flywheel for sustained Architecture as Code capabilities](images/diagram_16_chapter14.png)
+*Figure 14.4 – Enablement flywheel connecting cross-functional teams, skill development, knowledge sharing, communities of practice, and career progression.*
+
 | Implementation Stage | Key Activities | Success Criteria | Deliverables |
 |---------------------|----------------|------------------|--------------|
 | Aligning stakeholders early | Current-state assessment, cross-functional working group formation, vocabulary and SLO agreement | Platform, security, finance, and architecture alignment on priorities | Technical baseline documentation, regulatory obligations map, shared vocabulary guide |


### PR DESCRIPTION
## Summary
- add the missing narrative and image block for Figure 14.4 with a capitalised caption to match the chapter’s style guide
- ensure the new figure description reinforces the enablement flywheel context for Chapter 14

## Testing
- python3 generate_book.py
- docs/build_book.sh (fails: xelatex unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ed5bc64f8483308b912094596105ca