### PR TITLE
Move chapter 22 Mermaid example into dedicated diagram file

### DIFF
--- a/docs/22_documentation_vs_architecture.md
+++ b/docs/22_documentation_vs_architecture.md
@@ -126,12 +126,9 @@ Mermaid is a JavaScript-based diagramming tool that uses simple text syntax to c
 
 Example Mermaid diagram:
 
-```mermaid
-graph LR
-    User[Customer] --> API[Payment API]
-    API --> DB[(Payment Database)]
-    API --> Queue[Message Queue]
-```
+![Mermaid example highlighting the flow between a customer, payment API, database, and queue](images/diagram_22_mermaid_example.png)
+
+*Figure 22.2 shows a simple customer-to-payment flow using the Mermaid syntax. The source definition is maintained in `docs/images/diagram_22_mermaid_example.mmd` to keep the diagram version-controlled alongside the manuscript.*
 
 Mermaid excels at quickly creating visual explanations within documentation. Its lightweight syntax makes it accessible to non-technical contributors, and its widespread integration means diagrams can be embedded directly in Markdown files without external tools.
 

--- a/docs/images/diagram_22_mermaid_example.mmd
+++ b/docs/images/diagram_22_mermaid_example.mmd
@@ -1,0 +1,5 @@
+%% Example Mermaid diagram referenced in Chapter 22
+graph LR
+    User[Customer]:::kv-primary --> API[Payment API]:::kv-accent
+    API --> DB[(Payment Database)]:::kv-highlight
+    API --> Queue[Message Queue]:::kv-highlight


### PR DESCRIPTION
## Summary
- replace the inline Mermaid example in chapter 22 with an image reference
- add the corresponding Mermaid source to docs/images so it is version-controlled with other diagrams

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef9b0529f483308f8dd57d24b36f4a