### PR TITLE
Add feedback loop diagram to documentation vs architecture chapter

### DIFF
--- a/docs/22_documentation_vs_architecture.md
+++ b/docs/22_documentation_vs_architecture.md
@@ -161,7 +161,11 @@ While diagram tools are excellent for Documentation as Code, they have significa
 
 4. **Manual synchronisation**: When using diagram tools, keeping diagrams synchronised with actual implementation requires manual effort. There is no automatic bidirectional synchronisation between the diagram and the running system.
 
-This book uses Mermaid for creating illustrative diagrams because its primary purpose is **documentation**—communicating concepts to readers. The diagrams are not intended to be executable architectural models but rather visual aids that support the narrative.
+This book uses Mermaid for creating illustrative diagrams because its primary purpose is **documentation**—communicating concepts to readers. The diagrams are not intended to be executable architectural models but rather visual aids that support the narrative. Figure 22.3 summarises how documentation insights and architectural automation stay aligned through reciprocal feedback loops.
+
+![Feedback loop between Documentation as Code and Architecture as Code workflows](images/diagram_22_tool_alignment.png)
+
+*Figure 22.3 shows how Documentation as Code outputs and Architecture as Code automation reinforce one another through shared feedback loops. The Mermaid source is maintained in `docs/images/diagram_22_tool_alignment.mmd` to keep the definition version-controlled alongside the manuscript.*
 
 ## Key Differences: A Comparative Framework
 

--- a/docs/images/diagram_22_tool_alignment.mmd
+++ b/docs/images/diagram_22_tool_alignment.mmd
@@ -1,0 +1,20 @@
+flowchart LR
+    subgraph Documentation_as_Code[Documentation as Code]
+        Docs[Markdown Source<br/>Repositories]:::kv-primary --> Reviews[Pull Request Reviews<br/>and Style Checks]:::kv-highlight
+        Reviews --> Publish[Static Site & PDF<br/>Publication]:::kv-accent
+        Publish --> Feedback[Reader Feedback<br/>and Issue Tracking]:::kv-muted
+    end
+
+    subgraph Architecture_as_Code[Architecture as Code]
+        Models[Executable Architecture<br/>Models (CALM/DSL)]:::kv-primary --> Policies[Automated Policy Checks]:::kv-highlight
+        Policies --> Provision[Provisioning & Governance<br/>Automation]:::kv-accent
+        Provision --> Telemetry[Runtime Telemetry<br/>and Drift Detection]:::kv-muted
+    end
+
+    Feedback -.Context Updates.-> Models
+    Telemetry -.Implementation Evidence.-> Docs
+    Docs -.Guidance & Intent.-> Models
+    Publish -.Stakeholder Visibility.-> Telemetry
+
+    classDef kv-connector stroke-dasharray:4 2,stroke:#1E3A8A,color:#0F172A,font-weight:bold;
+    class Feedback,Telemetry kv-connector;


### PR DESCRIPTION
## Summary
- add a feedback loop diagram to the Documentation vs Architecture chapter and reference the generated PNG
- document the figure with a caption that notes the Mermaid source location
- store the Mermaid definition in `docs/images/diagram_22_tool_alignment.mmd`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef9eb7df008330ab4410961bd261c2