### PR TITLE
Limit finalize job artifact download

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -390,10 +390,11 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v5
 
-      - name: 📦 Download artifacts
+      - name: 📦 Download build artifacts
         uses: actions/download-artifact@v5
         with:
-          path: artifacts/
+          name: unified-docker-build
+          path: artifacts/unified-docker-build
 
       - name: 🔄 Merge build results
         run: |


### PR DESCRIPTION
## Summary
- restrict the finalize stage to download only the build artifact generated by the Docker job
- ensure the artifact is extracted into the expected directory for the release merge step

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68efe1929b148330b834affc813a9022