### PR TITLE
Fix dispatch input handling in unified workflow

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -94,9 +94,38 @@ jobs:
         run: |
           echo "=== Determining Build Strategy ==="
 
-          # Determine build type
-          BUILD_TYPE="${{ github.event.inputs.build_type || 'both' }}"
-          DELIVERABLES="${{ github.event.inputs.deliverables || 'all' }}"
+          # Extract workflow_dispatch inputs when available, otherwise fall back to defaults
+          BUILD_TYPE=$(python3 - <<'PY'
+import json
+import os
+
+event_path = os.environ.get('GITHUB_EVENT_PATH')
+default = 'both'
+
+try:
+    with open(event_path, 'r', encoding='utf-8') as handle:
+        payload = json.load(handle)
+    print(payload.get('inputs', {}).get('build_type') or default)
+except Exception:
+    print(default)
+PY
+          )
+
+          DELIVERABLES=$(python3 - <<'PY'
+import json
+import os
+
+event_path = os.environ.get('GITHUB_EVENT_PATH')
+default = 'all'
+
+try:
+    with open(event_path, 'r', encoding='utf-8') as handle:
+        payload = json.load(handle)
+    print(payload.get('inputs', {}).get('deliverables') or default)
+except Exception:
+    print(default)
+PY
+          )
 
           case $BUILD_TYPE in
             "traditional")


### PR DESCRIPTION
## Summary
- read workflow_dispatch inputs by parsing the GitHub event payload
- default build strategy inputs to sensible values when the fields are absent
- keep existing logging and output handling intact

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68efe1dd33288330b4d8ac38b1585082