### PR TITLE
Document checkout v5 runner requirement

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -45,10 +45,13 @@ This repository uses a unified GitHub Actions workflow to handle all aspects of 
 
 **GitHub Release**: Creates comprehensive release with all files attached (tag: `v{run_number}-unified`)
 
-**Duration**: 
+**Duration**:
 - Traditional only: ~90 minutes
-- Docker only: ~60 minutes  
+- Docker only: ~60 minutes
 - Both strategies: ~90 minutes (runs in parallel)
+
+> [!IMPORTANT]
+> The workflow currently uses `actions/checkout@v5` in both the Docker build and finalize jobs. This release of the checkout action runs on the Node.js 24 runtime and therefore requires Actions runners version 2.327.1 or newer. Older runners fail before any of the build steps run, so keep environments on v4 until runners are updated.
 
 ---
 

--- a/reports/unified_checkout_investigation.md
+++ b/reports/unified_checkout_investigation.md
@@ -1,0 +1,14 @@
+# Unified Build & Release checkout failure analysis
+
+## Summary
+- The unified workflow started failing immediately after upgrading `actions/checkout` from v4 to v5.
+- Both the Docker build job and the finalize job invoke `actions/checkout@v5`, so the regression blocks the workflow before any build steps execute.
+- Checkout v5 runs on the Node.js 24 runtime and requires Actions runner version 2.327.1 or newer; older runners abort with a runtime version error. This requirement was introduced with the v5 release and is absent in v4.
+
+## Evidence
+- Workflow definition showing the upgrade to `actions/checkout@v5` in the Docker build job and the finalize job.
+- Official checkout documentation noting the Node.js 24 runtime requirement and the minimum runner version (2.327.1) for v5 ([actions/checkout README](https://github.com/actions/checkout/tree/main#whats-new)).
+
+## Recommendation
+- Update the self-hosted runners that execute this workflow to Actions runner >= 2.327.1 so they support Node.js 24.
+- If updating the runner fleet is not immediately possible, pin the workflow back to `actions/checkout@v4` until compatible infrastructure is available.


### PR DESCRIPTION
## Summary
- Explain in `WORKFLOWS.md` why the unified workflow fails when `actions/checkout` is bumped to v5.
- Add a dedicated investigation report that records the Node.js 24 runtime requirement and recommended mitigations.

## Testing
- Not run (documentation-only change).

------
https://chatgpt.com/codex/tasks/task_e_68efe47cad9c83309ec38148b2245b77