### PR TITLE
Add issues for British English consistency and onboarding consolidation

### DIFF
--- a/Issues/011-standardise-british-english.md
+++ b/Issues/011-standardise-british-english.md
@@ -1,0 +1,16 @@
+# Standardise Documentation on British English Spelling and Grammar
+
+## Summary
+Repository guidelines require British English across all reader-facing content, but numerous markdown chapters and supporting documents still contain American spellings and idioms. Examples include "organized" in `docs/06_structurizr.md`, "color" references within Structurizr snippets, and "digitalization" phrasing in `README.md`. The inconsistency weakens the editorial tone and contradicts the documented language standard.
+
+## Tasks
+- Audit every file under `docs/` and the root documentation set (e.g., `README.md`, `BOOK_REQUIREMENTS.md`, `VISUAL_ELEMENTS_GUIDE.md`) for American spellings, idioms, and grammar patterns.
+- Replace each instance with the Oxford-standard British equivalent (e.g., organise, colour, digitalisation) while ensuring technical keywords that are intentionally American remain unchanged.
+- Update diagrams or code snippets embedded in markdown where text output is affected to keep rendered artefacts consistent.
+- Create `docs/STYLE_GUIDE.md` capturing the British English standard, examples of approved spellings, and guidance for future contributions.
+- Run the existing build scripts to ensure the language updates do not break automated exports.
+
+## Acceptance Criteria
+- All markdown and rendered text assets in the repository read naturally in British English with no lingering American spellings.
+- The new `docs/STYLE_GUIDE.md` exists, documents the British English requirements, and is referenced from the contributing section of `README.md`.
+- Automated builds (`python3 generate_book.py && docs/build_book.sh`) complete without content regressions after the language updates.

--- a/Issues/012-consolidate-onboarding-docs.md
+++ b/Issues/012-consolidate-onboarding-docs.md
@@ -1,0 +1,17 @@
+# Consolidate Introductory and Onboarding Documentation
+
+## Summary
+Essential onboarding guidance is fragmented across multiple markdown files (`README.md`, `WORKFLOWS.md`, `AUTOMATION_WORKFLOWS.md`, `TEST_WORKFLOW.md`, and various docs/* chapters). New contributors must cross-reference several long-form documents to understand the project's purpose, required tooling, and validation steps. This creates avoidable friction for first-time collaborators.
+
+## Tasks
+- Inventory the current onboarding touchpoints (repository root files plus introductory chapters such as `docs/01_introduction.md` and `docs/book_structure.md`) to map overlapping information.
+- Draft a unified `docs/getting-started.md` that walks readers through project context, prerequisite installations, core commands, and validation expectations in a concise, sequential format.
+- Refactor `README.md` so the opening section remains a high-level overview and links prominently to the new getting started guide, book structure, and workflow documentation.
+- Update supporting files (e.g., `WORKFLOWS.md`, `AUTOMATION_WORKFLOWS.md`) to remove duplicated narrative and point to the single source of truth for onboarding instructions.
+- Ensure MkDocs navigation includes the new guide so it appears in published documentation, and verify build pipelines succeed with the updated structure.
+
+## Acceptance Criteria
+- A clearly scoped `docs/getting-started.md` exists, covering context, setup, key commands, and validation checks without requiring readers to consult multiple files.
+- `README.md` links to the getting started guide and other foundational references while avoiding duplicated setup content.
+- Automation documentation references the new guide for onboarding steps, with redundant text removed or summarised.
+- MkDocs site navigation reflects the new guide and all automated builds succeed after the documentation restructuring.


### PR DESCRIPTION
## Summary
- add an issue request to audit the repository for British English usage and document the language standard
- document a follow-up issue to consolidate onboarding materials into a single getting started guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f005bfae448330b388ef8f53033f08