### PR TITLE
Localise Structurizr styling terminology and navigation labels

### DIFF
--- a/docs/06_structurizr.md
+++ b/docs/06_structurizr.md
@@ -219,7 +219,7 @@ views {
 
 ### Styling and Themes
 
-Structurizr allows customization of diagram appearance:
+Structurizr allows customisation of diagram appearance:
 
 ```structurizr
 views {
@@ -227,27 +227,27 @@ views {
         element "Person" {
             shape person
             background #08427b
-            color #ffffff
+            colour #ffffff
         }
         
         element "Software System" {
             background #1168bd
-            color #ffffff
+            colour #ffffff
         }
         
         element "External System" {
             background #999999
-            color #ffffff
+            colour #ffffff
         }
         
         element "Container" {
             background #438dd5
-            color #ffffff
+            colour #ffffff
         }
         
         element "Component" {
             background #85bbf0
-            color #000000
+            colour #000000
         }
         
         element "Database" {
@@ -867,7 +867,7 @@ def verify_architecture_coverage():
 | Large-scale system architecture | **Structurizr** | Model consistency, C4 hierarchy, architecture focus |
 | Quick diagrams in README | **Mermaid** | GitHub native support, simple syntax |
 | Detailed sequence diagrams | **PlantUML** | Rich sequence diagram features |
-| Non-technical stakeholder presentations | **Lucidchart/Draw.io** | Familiar interface, easy customization |
+| Non-technical stakeholder presentations | **Lucidchart/Draw.io** | Familiar interface, easy customisation |
 | Architecture as Code practice | **Structurizr** | Native version control, automation support |
 
 ## Common Challenges and Solutions
@@ -1013,13 +1013,13 @@ views {
         element "Person" {
             shape person
             background #FF6B35  # Brand colour
-            color #FFFFFF
+            colour #FFFFFF
             fontSize 24
         }
         
         element "Container" {
             background #004E89  # Brand colour
-            color #FFFFFF
+            colour #FFFFFF
             fontSize 18
             shape roundedbox
         }
@@ -1031,7 +1031,7 @@ views {
         
         relationship "Relationship" {
             thickness 3
-            color #004E89
+            colour #004E89
             routing curved  # or: orthogonal, direct
             fontSize 14
         }
@@ -1360,30 +1360,30 @@ workspace "E-Commerce Platform" "Complete architecture for online retail" {
             element "Person" {
                 shape person
                 background #08427b
-                color #ffffff
+                colour #ffffff
                 fontSize 22
             }
             
             element "Software System" {
                 background #1168bd
-                color #ffffff
+                colour #ffffff
                 shape roundedbox
             }
             
             element "External System" {
                 background #999999
-                color #ffffff
+                colour #ffffff
             }
             
             element "Container" {
                 background #438dd5
-                color #ffffff
+                colour #ffffff
                 shape roundedbox
             }
             
             element "Component" {
                 background #85bbf0
-                color #000000
+                colour #000000
                 shape component
             }
             
@@ -1411,7 +1411,7 @@ workspace "E-Commerce Platform" "Complete architecture for online retail" {
             
             relationship "Relationship" {
                 thickness 2
-                color #707070
+                colour #707070
                 routing orthogonal
                 fontSize 12
             }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,8 +27,8 @@ nav:
       - Architecture as Code in Practice: 14_practical_implementation.md
       - Cost Optimization and Resource Management: 15_cost_optimization.md
       - Migration from Traditional Infrastructure: 16_migration.md
-  - Part 5 – Organization & Leadership:
-      - Organizational Change and Team Structures: 17_organizational_change.md
+  - Part 5 – Organisation & Leadership:
+      - Organisational Change and Team Structures: 17_organizational_change.md
       - Management as Code: 19_management_as_code.md
       - AI Agent Team for Architecture as Code Initiatives: 20_ai_agent_team.md
       - Digitalization through Code-based Infrastructure: 21_digitalization.md


### PR DESCRIPTION
## Summary
- update Structurizr styling guidance to use British English phrasing for colour customisation
- adjust MkDocs navigation for Part 5 to use Organisation terminology consistently

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: missing `xelatex` after attempting dependency installation)*

Closes #574
Closes #575

------
https://chatgpt.com/codex/tasks/task_e_68f024bb2eb4833087eb742299801d4f