### PR TITLE
Add workflow to close pull requests with merge conflicts

### DIFF
--- a/.github/workflows/close-conflicted-pull-requests.yml
+++ b/.github/workflows/close-conflicted-pull-requests.yml
@@ -1,0 +1,109 @@
+name: Close conflicted pull requests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  close-conflicts:
+    if: github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Await mergeability assessment
+        id: mergeability
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const prNumber = context.payload.pull_request.number;
+            let pr;
+
+            for (let attempt = 0; attempt < 6; attempt += 1) {
+              ({ data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              }));
+
+              if (pr.mergeable !== null) {
+                break;
+              }
+
+              core.info('Mergeability is currently unknown, waiting before retrying.');
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+
+            const hasConflicts = pr.mergeable === false && pr.mergeable_state === 'dirty';
+            core.setOutput('mergeable', pr.mergeable === null ? 'unknown' : String(pr.mergeable));
+            core.setOutput('mergeable_state', pr.mergeable_state ?? 'unknown');
+            core.setOutput('has_conflicts', hasConflicts ? 'true' : 'false');
+
+      - name: Raise merge conflict issue
+        id: issue
+        if: steps.mergeability.outputs.has_conflicts == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_ISSUE }}
+          script: |
+            const pr = context.payload.pull_request;
+            const title = `Resolve merge conflicts for PR #${pr.number}`;
+            const body = [
+              `This issue was created automatically because pull request #${pr.number} has merge conflicts and was closed.`,
+              '',
+              `Conflicted pull request: ${pr.html_url}`,
+              '',
+              'Please resolve the conflicts locally and submit a fresh pull request once the branch is up to date.'
+            ].join('\n');
+
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              assignees: ['copilot'],
+            });
+
+            return { issue_number: issue.number, issue_url: issue.html_url };
+
+      - name: Close pull request with merge conflicts
+        if: steps.mergeability.outputs.has_conflicts == 'true'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueReference = process.env.ISSUE_NUMBER
+              ? `issue #${process.env.ISSUE_NUMBER}`
+              : 'the linked issue';
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                'This pull request has been closed automatically because it contains merge conflicts.',
+                process.env.ISSUE_URL
+                  ? `Further updates will be tracked in ${issueReference}: ${process.env.ISSUE_URL}.`
+                  : 'Further updates will be tracked in the follow-up issue.',
+              ].join('\n\n'),
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'closed',
+            });
+


### PR DESCRIPTION
## Summary
- add an automated workflow that monitors pull requests for merge conflicts
- raise a follow-up issue assigned to copilot and close the conflicted pull request with a contextual comment

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f08bfe27b08330a795020109d139e3