### PR TITLE
Add British English localisation issues for identified sections

### DIFF
--- a/Issues/localise-content-advanced-threat-detection.md
+++ b/Issues/localise-content-advanced-threat-detection.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Advanced Threat Detection Platform
+
+**Section:** 09b_security_patterns/#advanced-threat-detection-platform  
+**Summary:** The threat detection pattern is anchored to Swedish organisational contexts, conflicting with British English localisation.
+
+## Observed Non-British Usage
+- Describes solutions for "Swedish organisations" directly within code comments.
+- Uses geographic assumptions that do not translate to British readers.
+- Lacks British equivalents or generalised wording.
+
+## Proposed Corrections
+- Update examples to reference British sectors or use neutral terminology applicable in the UK.
+- Ensure comments and docstrings adopt British English spellings and references.
+- Add British-centric threat intelligence sources where relevant.
+
+## Tasks
+- [ ] Replace Swedish locale references with British or neutral alternatives.
+- [ ] Audit associated comments for spelling and terminology alignment.
+- [ ] Provide contextual notes referencing UK threat intelligence guidance.
+```

--- a/Issues/localise-content-ai-augmented-infrastructure-optimisation.md
+++ b/Issues/localise-content-ai-augmented-infrastructure-optimisation.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – AI-Augmented Infrastructure Optimisation
+
+**Section:** 12_compliance/#ai-augmented-infrastructure-optimisation  
+**Summary:** The optimisation narrative mixes spellings and hints at American variants, risking inconsistency within British English sections.
+
+## Observed Non-British Usage
+- Contextual commentary mentions "optimize" whilst the code uses `optimise`.
+- Supporting text references American spelling in surrounding prose or comments.
+- Inconsistent terminology may confuse readers about the preferred British spelling.
+
+## Proposed Corrections
+- Standardise all surrounding prose, comments, and variable names to British spellings (`optimise`, `optimisation`).
+- Verify that any imported modules or helper functions follow the same convention.
+- Provide an editorial note emphasising British English spelling for automation terminology.
+
+## Tasks
+- [ ] Review the section for stray American spellings of "optimise/optimisation" and correct them.
+- [ ] Align docstrings and comments with British English usage.
+- [ ] Confirm glossary entries reinforce British terminology for optimisation routines.
+```

--- a/Issues/localise-content-compliance-quality-standards.md
+++ b/Issues/localise-content-compliance-quality-standards.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Compliance and Quality Standards
+
+**Section:** 04_adr/#compliance-and-quality-standards  
+**Summary:** The compliance narrative promotes EU and US regulations without framing British obligations, diluting the localisation mandate.
+
+## Observed Non-British Usage
+- Highlights GDPR and PCI-DSS without acknowledging British regulatory schemes or standards.
+- Implies an international context inconsistent with the book's British English orientation.
+- Uses terminology that may lead readers to prioritise non-UK compliance frameworks.
+
+## Proposed Corrections
+- Rebalance the section to foreground British regulations such as the UK GDPR, Data Protection Act 2018, and FCA requirements.
+- Clarify when international standards remain relevant whilst maintaining British English spelling and context.
+- Provide examples showcasing documentation practices tailored for British organisations.
+
+## Tasks
+- [ ] Update regulatory references to highlight British legislation and guidance.
+- [ ] Ensure terminology and spellings follow British English conventions throughout the section.
+- [ ] Add cross-references to British standards or government resources where applicable.
+```

--- a/Issues/localise-content-comprehensive-security-foundation.md
+++ b/Issues/localise-content-comprehensive-security-foundation.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Comprehensive Security Foundation Module
+
+**Section:** 09b_security_patterns/#comprehensive-security-foundation-module  
+**Summary:** Commentary within the module references Swedish security expectations, undermining British localisation.
+
+## Observed Non-British Usage
+- Inline comments cite "Swedish security expectations".
+- Suggests compliance targets unique to Sweden.
+- Omits British or neutral framing for rotation policies.
+
+## Proposed Corrections
+- Reword comments to focus on British operational expectations or general best practice.
+- Align supporting text with British English spellings and regulatory references.
+- Introduce UK-centric rotation standards where available.
+
+## Tasks
+- [ ] Replace Swedish references with British or universally applicable terminology.
+- [ ] Ensure documentation uses British spelling and context.
+- [ ] Validate that code examples demonstrate suitability for British organisations.
+```

--- a/Issues/localise-content-container-based-testing.md
+++ b/Issues/localise-content-container-based-testing.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Container-Based Testing with Compliance
+
+**Section:** 05_automation_devops_cicd/#container-based-testing-with-compliance  
+**Summary:** The Docker configuration enforces an American locale, undermining British English consistency across the automation chapter.
+
+## Observed Non-British Usage
+- Dockerfile snippet sets `en_US.UTF-8` for `LANG`, `LANGUAGE`, and `LC_ALL`.
+- Commentary references US-centric locale assumptions for compliance pipelines.
+- Reinforces American spelling defaults during build processes.
+
+## Proposed Corrections
+- Replace locale generation and environment variables with `en_GB.UTF-8`.
+- Update explanatory text to confirm British English locale enforcement.
+- Validate that downstream scripts and templates inherit the British locale settings.
+
+## Tasks
+- [ ] Adjust the Docker example to generate and export `en_GB.UTF-8`.
+- [ ] Review surrounding guidance to ensure British spelling and terminology.
+- [ ] Document any compatibility considerations when adopting British locales in CI pipelines.
+```

--- a/Issues/localise-content-cost-optimisation-resource-management.md
+++ b/Issues/localise-content-cost-optimisation-resource-management.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Cost Optimisation and Resource Management
+
+**Chapter:** 15_cost_optimization/  
+**Summary:** The chapter title and content retain American spellings of "optimisation", clashing with British English requirements.
+
+## Observed Non-British Usage
+- Directory name and headings use "Optimization" instead of "Optimisation".
+- Narrative and diagrams echo American spelling choices.
+- Potential downstream references inherit the American variant.
+
+## Proposed Corrections
+- Rename chapter headings and internal references to "Optimisation".
+- Update textual content to British spellings and verify cross-references within the book.
+- Consider renaming files if technically feasible, documenting any build implications.
+
+## Tasks
+- [ ] Replace occurrences of "Optimization" with "Optimisation" across the chapter.
+- [ ] Review associated assets (figures, diagrams, links) for consistent spelling.
+- [ ] Adjust navigation metadata or configuration to reflect the British spelling.
+```

--- a/Issues/localise-content-migration-traditional-infrastructure.md
+++ b/Issues/localise-content-migration-traditional-infrastructure.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Migration from Traditional Infrastructure
+
+**Chapter:** 16_migration/  
+**Summary:** The migration guidance includes Swedish terminology, conflicting with the British English localisation directive.
+
+## Observed Non-British Usage
+- Terms such as "planering", "stegvis", and "Structureerade" appear in the prose.
+- Narrative tone suggests Swedish localisation rather than British orientation.
+- Potential mistranslations hinder clarity for British readers.
+
+## Proposed Corrections
+- Translate Swedish words into precise British English equivalents.
+- Ensure all sentences flow naturally for a British audience without residual Swedish structure.
+- Cross-check any Swedish-influenced examples to confirm cultural neutrality or British relevance.
+
+## Tasks
+- [ ] Replace Swedish terminology with British English wording throughout the chapter.
+- [ ] Review sentence structure for lingering translation artefacts.
+- [ ] Verify references and examples resonate with British practitioners.
+```

--- a/Issues/localise-content-monitoring-alerting.md
+++ b/Issues/localise-content-monitoring-alerting.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Monitoring and Alerting
+
+**Section:** 05_automation_devops_cicd/#monitoring-and-alerting  
+**Summary:** Monitoring guidance inherits American locale assumptions from preceding pipeline configuration, risking inconsistent British English coverage.
+
+## Observed Non-British Usage
+- Prometheus configuration references pipelines configured with `en_US` locales.
+- Commentary assumes American default metrics naming conventions.
+- Lack of explicit British English terminology in explanatory notes.
+
+## Proposed Corrections
+- Clarify that monitoring jobs operate within an `en_GB`-configured environment following updates to the Docker pipeline.
+- Adjust narrative to use British spelling and cite British operational tooling where helpful.
+- Ensure metric labels and documentation align with British English phrasing.
+
+## Tasks
+- [ ] Update prose to reference British locale settings applied earlier in the chapter.
+- [ ] Review metric descriptions and comments for American spellings.
+- [ ] Add guidance on aligning monitoring terminology with British standards.
+```

--- a/Issues/localise-content-practical-example-opa.md
+++ b/Issues/localise-content-practical-example-opa.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Practical Example with Open Policy Agent (OPA)
+
+**Section:** 02_fundamental_principles/#practical-example-with-open-policy-agent-opa  
+**Summary:** The practical example relies on pan-European terminology and references EU agencies, drifting from the book's British English positioning.
+
+## Observed Non-British Usage
+- Mentions "pan-European" metadata tied to ENISA and the European Data Protection Board (EDPB).
+- Incorporates EU-specific acronyms without British English context, leading to a Swedish-leaning locale.
+- Reinforces continental terminology that may confuse readers expecting British regulatory framing.
+
+## Proposed Corrections
+- Rephrase narrative to emphasise applicability for British organisations whilst acknowledging wider European relevance in supporting notes.
+- Replace or contextualise ENISA and EDPB references with British equivalents such as the National Cyber Security Centre (NCSC) where appropriate.
+- Audit metadata examples to ensure British English spellings and locale identifiers.
+
+## Tasks
+- [ ] Update the narrative within the section to centre on British regulatory expectations.
+- [ ] Review tables or code snippets for locale-sensitive terminology and adjust to British English.
+- [ ] Provide editorial notes clarifying any remaining EU agency references.
+```

--- a/Issues/localise-content-scope-goals.md
+++ b/Issues/localise-content-scope-goals.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Scope and Goals of the Chapter
+
+**Section:** 09a_security_fundamentals/#scope-and-goals-of-the-chapter  
+**Summary:** The scope statement lists EU regulations and directives, eroding British localisation fidelity.
+
+## Observed Non-British Usage
+- Enumerates GDPR, EDPB, and NIS2 Directive requirements.
+- Presents compliance goals from an EU regulatory perspective.
+- Uses terminology that implies a continental policy environment.
+
+## Proposed Corrections
+- Reframe objectives to align with UK GDPR, the Data Protection Act 2018, and NCSC directives.
+- Provide British English explanations for any retained references to EU frameworks.
+- Ensure the section signposts British regulatory resources for readers.
+
+## Tasks
+- [ ] Edit the section narrative to emphasise British legal drivers.
+- [ ] Replace or annotate EU acronyms with UK-specific counterparts.
+- [ ] Validate that referenced policies match the UK's post-Brexit regulatory landscape.
+```

--- a/Issues/localise-content-security-fundamentals.md
+++ b/Issues/localise-content-security-fundamentals.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Security Fundamentals for Architecture as Code
+
+**Chapter:** 09a_security_fundamentals/  
+**Summary:** The chapter leans heavily on US-centric frameworks such as NIST, diluting British localisation aims.
+
+## Observed Non-British Usage
+- Prominent references to the NIST Cybersecurity Framework without British context.
+- American spellings and terminology when citing US publications.
+- Absence of equivalent British standards, leaving a transatlantic emphasis.
+
+## Proposed Corrections
+- Introduce British frameworks and agencies (e.g., NCSC, Cyber Assessment Framework) alongside or in place of NIST references.
+- Ensure all descriptive text uses British English spellings.
+- Add commentary explaining international references only when necessary for comparison.
+
+## Tasks
+- [ ] Replace or contextualise US agency citations with British alternatives.
+- [ ] Review the entire chapter for American spellings and adjust to British English.
+- [ ] Provide updated references pointing to UK government or industry publications.
+```

--- a/Issues/localise-content-serverless-infrastructure-definition.md
+++ b/Issues/localise-content-serverless-infrastructure-definition.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Serverless Infrastructure Definition
+
+**Section:** 12_compliance/#serverless-infrastructure-definition  
+**Summary:** The serverless configuration mixes British and American spellings, notably around optimisation terminology.
+
+## Observed Non-British Usage
+- Environment variables reference `OPTIMISATION` whilst surrounding comments imply "optimization".
+- Inconsistent spelling across YAML keys and narrative guidance.
+- Potential confusion for readers adopting British English standards.
+
+## Proposed Corrections
+- Ensure all references to optimisation within the section adopt the British spelling consistently.
+- Align environment variable naming and descriptive text with British English conventions.
+- Provide clarification if legacy naming requires dual spelling, offering migration advice.
+
+## Tasks
+- [ ] Harmonise YAML keys, environment variables, and prose to use "optimisation".
+- [ ] Update commentary to reinforce British English spelling expectations.
+- [ ] Document any compatibility considerations when renaming configuration values.
+```

--- a/Issues/localise-content-validation-test-automation.md
+++ b/Issues/localise-content-validation-test-automation.md
@@ -1,0 +1,21 @@
+```markdown
+# Issue: Localise Content to British English – Validation and Test Automation
+
+**Section:** 02_fundamental_principles/#validation-and-test-automation  
+**Summary:** The validation automation example is anchored to EU supervisory bodies, embedding non-British terminology and locale codes.
+
+## Observed Non-British Usage
+- Hard-coded references to GDPR, EDPB guidance, and ENISA baselines.
+- Uses American-style capitalisation in constants alongside EU agency names.
+- Positions regulatory validation from an EU authority perspective rather than a British frame.
+
+## Proposed Corrections
+- Reorient the example towards British regulators such as the Information Commissioner's Office (ICO) and the National Cyber Security Centre (NCSC).
+- Replace locale constants and comments with British English spellings and local regulatory references.
+- Provide contextual notes if retaining any EU-wide terminology is essential for comparative reasons.
+
+## Tasks
+- [ ] Revise code snippets to use British agency names and British English spellings.
+- [ ] Update accompanying prose to describe validation expectations for the United Kingdom.
+- [ ] Confirm glossary entries for regulatory terms align with British English conventions.
+```


### PR DESCRIPTION
## Summary
- add new issue snippets under `Issues/` covering localisation fixes across security, compliance, and automation chapters
- capture specific non-British terminology, locales, and spellings that require anglicisation
- outline actionable tasks to align each section with British English conventions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1c86d28908330ab4cf325430f7a30