### PR TITLE
Add issues addressing verbosity concerns in documentation

### DIFF
--- a/Issues/README.md
+++ b/Issues/README.md
@@ -58,6 +58,26 @@ These issues capture verification work to ensure the manuscript accurately repre
     - Labels: `documentation`, `security`
     - Focus: IaC state management security guidance verification
 
+11. **[issue_11_remove_redundant_qualifiers_and_hedging_language.md](./issue_11_remove_redundant_qualifiers_and_hedging_language.md)**
+    - Labels: `documentation`
+    - Focus: Remove redundant qualifiers and hedging language throughout the documentation
+
+12. **[issue_12_replace_nominalisations_with_active_verbs.md](./issue_12_replace_nominalisations_with_active_verbs.md)**
+    - Labels: `documentation`
+    - Focus: Replace nominalisations with active verbs to improve clarity and ownership
+
+13. **[issue_13_reduce_prepositional_phrase_stacking.md](./issue_13_reduce_prepositional_phrase_stacking.md)**
+    - Labels: `documentation`
+    - Focus: Reduce stacked prepositional phrases to streamline sentence structure
+
+14. **[issue_14_shift_passive_voice_to_active_construction.md](./issue_14_shift_passive_voice_to_active_construction.md)**
+    - Labels: `documentation`
+    - Focus: Convert passive voice constructions into active statements with clear actors
+
+15. **[issue_15_split_long_compound_sentences.md](./issue_15_split_long_compound_sentences.md)**
+    - Labels: `documentation`
+    - Focus: Split long compound sentences to improve readability and pacing
+
 ## Structure
 
 Each issue file follows a consistent format:

--- a/Issues/issue_11_remove_redundant_qualifiers_and_hedging_language.md
+++ b/Issues/issue_11_remove_redundant_qualifiers_and_hedging_language.md
@@ -1,0 +1,25 @@
+# Issue 11: Remove Redundant Qualifiers and Hedging Language
+
+## Relevant Documentation Sections
+Architecture as Code manuscript chapters, README content, and supporting documentation files.
+
+## Problem Statement
+The documentation repeatedly uses hedging adverbs such as "often", "typically", and "particularly". These words weaken otherwise factual statements without adding verifiable nuance. The resulting prose sounds tentative, inflates the word count, and slows reading speed.
+
+## Impact
+- Readers perceive the guidance as uncertain or non-committal.
+- Important statements become verbose, reducing clarity and engagement.
+- Increased word count creates friction for teams attempting to reference the material quickly.
+
+## Recommended Remediation
+- Remove hedging qualifiers unless they convey measurable frequency or confidence levels.
+- Recast sentences to deliver direct statements (for example, "Systems drift" instead of "Systems typically tend to drift").
+- Review headings, bullet lists, and explanatory paragraphs for redundant qualifiers.
+
+## Acceptance Criteria
+- Qualifiers remain only where they communicate data-backed frequency or probability.
+- Updated passages read in clear, direct British English without unnecessary repetition.
+- Editorial review confirms improved readability in at least the cited examples and other high-traffic sections.
+
+## Recommended Labels
+`documentation`

--- a/Issues/issue_12_replace_nominalisations_with_active_verbs.md
+++ b/Issues/issue_12_replace_nominalisations_with_active_verbs.md
@@ -1,0 +1,25 @@
+# Issue 12: Replace Nominalisations with Active Verbs
+
+## Relevant Documentation Sections
+Architecture as Code manuscript, especially chapters covering ADR practices, governance mechanisms, and tooling discussions.
+
+## Problem Statement
+The narrative frequently converts verbs into nouns (for example, "facilitates knowledge transfer"), creating distant, formal prose that obscures the actor. This nominalisation-heavy style makes it harder for readers to identify who performs an action and adds unnecessary complexity to simple statements.
+
+## Impact
+- Readers struggle to trace accountability for activities.
+- Sentences become longer and more bureaucratic in tone.
+- Excess formality erodes the accessible, practitioner-focused voice we target for the book.
+
+## Recommended Remediation
+- Rewrite affected sentences with strong verbs and explicit subjects (for example, "teams transfer knowledge").
+- Audit ADR and governance sections where process descriptions are dense and convert nominalisations to active voice.
+- Ensure resulting sentences remain concise and aligned with British English phrasing conventions.
+
+## Acceptance Criteria
+- Affected sections use active verbs with clear subjects instead of abstract nouns.
+- Updated copy reads more directly while preserving the intended meaning.
+- Editorial spot-checks confirm improved clarity in all highlighted examples and analogous passages.
+
+## Recommended Labels
+`documentation`

--- a/Issues/issue_13_reduce_prepositional_phrase_stacking.md
+++ b/Issues/issue_13_reduce_prepositional_phrase_stacking.md
@@ -1,0 +1,25 @@
+# Issue 13: Reduce Prepositional Phrase Stacking
+
+## Relevant Documentation Sections
+Architecture as Code manuscript narrative chapters and supporting documentation describing workflows and governance.
+
+## Problem Statement
+Many sentences layer three or more prepositional phrases (for example, "practice of describing, version-controlling, and automating the entire system architecture through machine-readable code"). This stacking bloats sentences, forcing readers to parse long strings of modifiers before reaching the main clause.
+
+## Impact
+- Readers need to re-read sentences to grasp the core idea.
+- The prose feels bureaucratic and detached.
+- Dense constructions reduce accessibility for practitioners scanning for practical guidance.
+
+## Recommended Remediation
+- Limit sentences to two prepositional phrases wherever feasible.
+- Convert prepositional phrases into adjectives or adverbs when the meaning stays intact.
+- Prioritise strong subjects and verbs early in each sentence to anchor the reader.
+
+## Acceptance Criteria
+- Revised sections present core ideas within two prepositional phrases or fewer per sentence.
+- Key examples highlighted in the issue description read cleanly with minimal structural repetition.
+- Editorial sampling across documentation confirms improved flow without information loss.
+
+## Recommended Labels
+`documentation`

--- a/Issues/issue_14_shift_passive_voice_to_active_construction.md
+++ b/Issues/issue_14_shift_passive_voice_to_active_construction.md
@@ -1,0 +1,25 @@
+# Issue 14: Shift Passive Voice to Active Construction
+
+## Relevant Documentation Sections
+Architecture as Code manuscript, ADR workflow explanations, and tooling guidance sections.
+
+## Problem Statement
+Extensive passive voice (for example, "Versioning is managed through the Git history") hides the responsible actor and adds unnecessary words. Passive constructions can be harder to parse and dilute the authoritative tone required for prescriptive technical guidance.
+
+## Impact
+- Readers expend more effort to understand who performs critical actions.
+- Sentences lengthen, reducing pace and engagement.
+- Passive voice undermines clear ownership in governance and process descriptions.
+
+## Recommended Remediation
+- Identify passive constructions across documentation and rewrite them in active voice with explicit subjects (for example, "Git history manages versioning").
+- Prioritise sections discussing ADR lifecycle, governance checkpoints, and version control responsibilities.
+- Ensure edits maintain technical accuracy while improving readability.
+
+## Acceptance Criteria
+- Passive constructions are replaced by active voice statements except where passive voice is necessary (for instance, when the actor is unknown).
+- Updated passages clearly state the responsible actor for key activities.
+- Editorial review verifies improved clarity in the cited examples and representative sections.
+
+## Recommended Labels
+`documentation`

--- a/Issues/issue_15_split_long_compound_sentences.md
+++ b/Issues/issue_15_split_long_compound_sentences.md
@@ -1,0 +1,25 @@
+# Issue 15: Split Long Compound Sentences
+
+## Relevant Documentation Sections
+Architecture as Code manuscript chapters, especially sections that describe workflows, tooling integrations, and governance frameworks.
+
+## Problem Statement
+Numerous passages use long compound sentences exceeding 60 words, packing multiple clauses into a single line. These constructions overwhelm readers and obscure the main message.
+
+## Impact
+- Readers must re-read sentences to extract key information.
+- Dense wording reduces accessibility for practitioners seeking quick guidance.
+- Overly long sentences diminish the authoritative, confident tone of the book.
+
+## Recommended Remediation
+- Limit sentences to 20–25 words where possible, with one core idea per sentence.
+- Split lengthy sentences at natural breakpoints, introducing connective sentences to preserve flow.
+- Ensure resulting prose maintains British English spelling and consistent terminology.
+
+## Acceptance Criteria
+- Highlighted examples are rewritten into shorter sequences of sentences without losing meaning.
+- Editorial sampling across documentation confirms improved readability and pacing.
+- Readability tooling (for example, Flesch-Kincaid) shows measurable improvement in affected sections.
+
+## Recommended Labels
+`documentation`


### PR DESCRIPTION
## Summary
- add five new GitHub issue drafts detailing documentation verbosity problems
- update the Issues README to index the new verbosity-focused drafts

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f23813b29c8330925a6541b1b7a7fd