### PR TITLE
Add repetition cleanup issue drafts

### DIFF
--- a/Issues/issue_11_reduce_aac_definition_redundancy.md
+++ b/Issues/issue_11_reduce_aac_definition_redundancy.md
@@ -1,0 +1,38 @@
+# Issue 11: Reduce Architecture as Code Definition Redundancy
+
+## Priority
+High
+
+## Type
+Content duplication
+
+## Component
+Core definitions across multiple chapters
+
+## Problem Statement
+The core definition of Architecture as Code is repeated with near-identical wording across Chapters 1 and 2. The duplicated passages emphasise the same holistic scope (application architecture or logic, data flows, security policies, compliance rules, organisational structures) without introducing new insight, which bloats the manuscript and forces future edits to be applied in several places.
+
+## Evidence of Repetition
+- Chapter 1 – Introduction: “Architecture as Code represents a paradigm shift in system development where the entire system architecture is defined, version-controlled, and managed through code… applies the same methodologies across the whole technical landscape.”
+- Chapter 1 – Evolution towards Architecture as Code: “Traditional methods… Architecture as Code builds on established principles… applies them to the complete system landscape… infrastructure, application architecture, data flows, security policies, compliance rules, organisational structures.”
+- Chapter 2 – Fundamental Principles: “Architecture as Code is founded on core principles that enable successful implementation… span the entire system landscape… holistic view.”
+- Chapter 2 – Holistic perspective on codification: “Architecture as Code embraces the full system ecosystem… includes application logic, data flows, security policies, compliance rules, organisational structures.”
+
+## Impact
+- Inflates chapter length without delivering new information.
+- Increases maintenance overhead when terminology or scope changes.
+- Creates reader fatigue by restating identical concepts.
+
+## Recommended Actions
+1. Consolidate a single authoritative definition within Chapter 1.
+2. Replace later repetitions with concise cross-references (for example, “As defined in Chapter 1, Architecture as Code…”).
+3. Introduce fresh insights in subsequent sections instead of restating the definition.
+4. Consider adding a glossary entry to centralise recurring terminology.
+
+## Acceptance Criteria
+- [ ] Chapter 1 contains one comprehensive definition that is referenced elsewhere.
+- [ ] Repeated paragraphs in Chapters 1 and 2 are replaced with cross-references or unique context.
+- [ ] Editorial review confirms no redundant copies of the definition remain.
+
+## Recommended Labels
+`documentation`, `editor`

--- a/Issues/issue_12_consolidate_iac_tool_references.md
+++ b/Issues/issue_12_consolidate_iac_tool_references.md
@@ -1,0 +1,36 @@
+# Issue 12: Consolidate Infrastructure as Code Tool References
+
+## Priority
+Medium
+
+## Type
+Technical reference duplication
+
+## Component
+Tool references across chapters
+
+## Problem Statement
+Terraform, Pulumi, CloudFormation, and Ansible are cited repeatedly across Chapters 2, 4, and 5 with minimal additional context. The repetition frames the tooling ecosystem as narrow and duplicates explanations of the same capabilities rather than expanding the reader’s understanding.
+
+## Evidence of Repetition
+- Chapter 2 – Drift Detection and Remediation: lists Terraform, Pulumi, CloudFormation for infrastructure state management.
+- Chapter 4 – Example 1: Architecture as Code Tool Choice: reiterates Terraform’s role for all cloud environments.
+- Chapter 5 – Multiple sections: repeats Terraform and Ansible as accelerants for Architecture as Code adoption.
+
+## Impact
+- Signals a limited vendor perspective.
+- Misses opportunities to introduce tooling diversity or comparative insights.
+- Adds unnecessary length to chapters without advancing the argument.
+
+## Recommended Actions
+1. Create a single appendix or reference section cataloguing the primary tooling options and their strengths.
+2. Replace duplicate paragraphs with short references back to the consolidated list.
+3. Introduce context-specific tooling only when adding new analysis (for example, unique Terraform capabilities relevant to a case study).
+
+## Acceptance Criteria
+- [ ] Appendix or tooling reference section created with comparative detail.
+- [ ] Chapters 2, 4, and 5 reference the consolidated list instead of repeating identical tool descriptions.
+- [ ] Each remaining tooling mention adds chapter-specific insight or rationale.
+
+## Recommended Labels
+`documentation`, `architecture`

--- a/Issues/issue_13_streamline_gdpr_article_25_guidance.md
+++ b/Issues/issue_13_streamline_gdpr_article_25_guidance.md
@@ -1,0 +1,38 @@
+# Issue 13: Streamline GDPR Article 25 Guidance
+
+## Priority
+High
+
+## Type
+Regulatory content duplication
+
+## Component
+Compliance guidance across chapters
+
+## Problem Statement
+Chapter 5 repeats GDPR Article 25 requirements (“data protection by design and by default”) in multiple sections with almost identical phrasing. The recurrence emphasises GDPR at the expense of other regulations and provides limited actionable guidance beyond the repeated quote.
+
+## Evidence of Repetition
+- Regulatory complexity and automation: cites Article 25 and mandates automated validation.
+- GDPR-compliant pipeline design: restates Article 25 obligations verbatim.
+- Additional references: multiple mentions of “GDPR validation, data-residency enforcement, audit-trail generation” without differentiating context.
+
+## Impact
+- Creates the impression that GDPR is the sole compliance focus.
+- Diminishes credibility by repeating the same legal text without new interpretation.
+- Wastes space that could highlight other regulatory frameworks (NIS2, DORA, sector-specific obligations).
+
+## Recommended Actions
+1. Establish a dedicated compliance chapter or appendix that fully covers GDPR obligations once.
+2. Reference Article 25 via cross-references in later sections rather than repeating the full quotation.
+3. Diversify regulatory examples elsewhere (for example, NIS2 for operational resilience, HIPAA for healthcare).
+4. Provide actionable guidance tailored to each chapter’s theme (pipelines, automation, architecture governance).
+
+## Acceptance Criteria
+- [ ] GDPR Article 25 content consolidated into a single authoritative location.
+- [ ] Later chapters reference the consolidated material instead of duplicating the quotation.
+- [ ] Additional regulations are introduced to balance the compliance narrative.
+- [ ] Editorial review confirms varied, chapter-specific compliance insights.
+
+## Recommended Labels
+`documentation`, `requirements`

--- a/Issues/issue_14_align_five_foundational_pillars.md
+++ b/Issues/issue_14_align_five_foundational_pillars.md
@@ -1,0 +1,37 @@
+# Issue 14: Align the Five Foundational Pillars Narrative
+
+## Priority
+Medium
+
+## Type
+Structural inconsistency
+
+## Component
+Core principles definition
+
+## Problem Statement
+Chapter 2 references “five foundational pillars” twice, but the introductory list (declarative code, version control, automation, reproducibility, scalability) does not match the subsequent section headings (declarative definition, holistic perspective, immutable patterns, testability, documentation as code). The mismatch leaves readers unsure which constructs are canonical.
+
+## Evidence of Inconsistency
+- Opening description ties the pillars to declarative code → version control → automation → reproducibility → scalability.
+- Section breakdown covers different topics, omitting version control and scalability while adding holistic perspective and documentation as code.
+
+## Impact
+- Erodes trust in the manuscript’s core framework.
+- Makes it difficult to reference “the five pillars” consistently.
+- Introduces ambiguity for diagrams, summaries, or cross-references relying on the pillar concept.
+
+## Recommended Actions
+1. Define a single authoritative list of the five pillars, with unambiguous names.
+2. Update Chapter 2 structure so each section corresponds to one pillar.
+3. Ensure diagrams, summaries, and subsequent chapters reference the same pillar names.
+4. Provide brief rationale for each pillar to reinforce their distinct contribution.
+
+## Acceptance Criteria
+- [ ] Canonical pillar list documented and agreed by the editorial team.
+- [ ] Chapter 2 headings revised to match the canonical list.
+- [ ] Supporting diagrams or call-outs updated for consistency.
+- [ ] Cross-references audited to confirm they align with the revised pillar names.
+
+## Recommended Labels
+`documentation`, `architecture`

--- a/Issues/issue_15_condense_version_control_benefits.md
+++ b/Issues/issue_15_condense_version_control_benefits.md
@@ -1,0 +1,36 @@
+# Issue 15: Condense Version Control Benefit Narratives
+
+## Priority
+Low
+
+## Type
+Conceptual repetition
+
+## Component
+Version control chapter
+
+## Problem Statement
+Chapter 3 describes the benefits of Git-based workflows three times with overlapping language about commit history, documentation of change intent, and collaboration. The repeated passages fail to add new perspectives or examples, leaving the reader with redundant prose rather than practical guidance.
+
+## Evidence of Repetition
+- Git-based workflow section: emphasises distributed collaboration and commit messages explaining what and why.
+- Transparency through version control: reiterates commit messages and audit trail benefits.
+- Commit history: once again highlights traceability of architectural evolution and decision context.
+
+## Impact
+- Reduces information density within Chapter 3.
+- Suggests there are limited additional insights into version control usage.
+- Risks reader disengagement due to repetitive phrasing.
+
+## Recommended Actions
+1. Merge the overlapping paragraphs into a single, comprehensive explanation of Git benefits.
+2. Introduce new value-add material, such as workflow diagrams, branching strategies, or tooling integrations, to replace removed text.
+3. Provide concrete examples (for example, sample commit message, pull request template) to diversify the discussion.
+
+## Acceptance Criteria
+- [ ] Chapter 3 contains one consolidated section covering commit history, audit trails, and collaboration benefits.
+- [ ] Additional content demonstrates practical application of version control beyond the consolidated summary.
+- [ ] Editorial review confirms the removal of redundant paragraphs.
+
+## Recommended Labels
+`documentation`, `editor`

--- a/Issues/issue_16_reduce_adr_template_duplication.md
+++ b/Issues/issue_16_reduce_adr_template_duplication.md
@@ -1,0 +1,36 @@
+# Issue 16: Reduce ADR Template Duplication
+
+## Priority
+Medium
+
+## Type
+Example duplication
+
+## Component
+ADR chapter
+
+## Problem Statement
+Chapter 4 repeats the four-part ADR structure (Status, Context, Decision, Consequences) in the introductory explanation, the standard template, and two full examples. The repetition focuses on formatting rather than demonstrating diverse decision outcomes, making the chapter feel formulaic.
+
+## Evidence of Repetition
+- “What Are Architecture Decision Records?” section: table presenting Status, Context, Decision, Consequences.
+- “Standardised ADR Template” section: Markdown template repeating the same headings.
+- Example 1 (Terraform selection) and Example 2 (PostgreSQL selection): both restate the identical structure before delivering content.
+
+## Impact
+- Consumes space that could showcase varied ADR scenarios (rejected, superseded, escalated decisions).
+- Reduces reader engagement by reiterating structure instead of insight.
+- Suggests limited creativity in applying ADRs beyond the standard format.
+
+## Recommended Actions
+1. Present the ADR structure once with detailed guidance on populating each section.
+2. Replace duplicate structural descriptions in examples with brief reminders or annotations focusing on content quality.
+3. Introduce varied ADR states (for example, superseded, rejected) to demonstrate lifecycle management.
+
+## Acceptance Criteria
+- [ ] Chapter 4 contains a single authoritative description of the ADR template.
+- [ ] Examples focus on decision rationale and outcomes without reprinting the full template each time.
+- [ ] At least one example showcases a non-“Accepted” ADR status to illustrate lifecycle variety.
+
+## Recommended Labels
+`documentation`, `editor`

--- a/Issues/issue_17_expand_holistic_architecture_testing_guidance.md
+++ b/Issues/issue_17_expand_holistic_architecture_testing_guidance.md
@@ -1,0 +1,35 @@
+# Issue 17: Expand Holistic Architecture Testing Guidance
+
+## Priority
+Medium
+
+## Type
+Conceptual repetition
+
+## Component
+Testing strategies chapter
+
+## Problem Statement
+Chapter 5 introduces holistic Architecture as Code testing twice in succession—first as a conceptual overview, then as a list of unit, integration, system, and acceptance tests—without providing examples, tooling, or execution guidance. The duplicated framing feels aspirational rather than actionable.
+
+## Evidence of Repetition
+- Architecture as Code testing strategies: outlines the need for cross-domain validation.
+- Holistic architecture testing: immediately restates the concept and enumerates four test levels without further depth.
+
+## Impact
+- Leaves readers without practical steps for implementing the stated test levels.
+- Reinforces a perception that Architecture as Code testing lacks clarity or maturity.
+- Consumes space that could host concrete examples or case studies.
+
+## Recommended Actions
+1. Retain a single introductory paragraph explaining the holistic testing intent.
+2. Provide detailed examples, tools, or pipelines for each test level (unit, integration, system, acceptance).
+3. Include illustrative code snippets, automation workflows, or case studies to demonstrate execution.
+
+## Acceptance Criteria
+- [ ] Only one conceptual introduction to holistic testing remains.
+- [ ] Each test level is backed by practical implementation detail (tooling, scripts, scenarios).
+- [ ] Editorial review confirms the removal of redundant text and addition of actionable guidance.
+
+## Recommended Labels
+`documentation`, `qa`

--- a/Issues/issue_18_diversify_referenced_sources.md
+++ b/Issues/issue_18_diversify_referenced_sources.md
@@ -1,0 +1,35 @@
+# Issue 18: Diversify Referenced Sources Across Chapters
+
+## Priority
+Low
+
+## Type
+Reference duplication
+
+## Component
+Source citations
+
+## Problem Statement
+ThoughtWorks’ “Architecture as Code: The Next Evolution” and Robert Martin’s “Clean Architecture” are cited in multiple chapters as generic support. The repeated use suggests a limited research base and fails to connect citations with chapter-specific arguments.
+
+## Evidence of Repetition
+- Chapter 1 cites both sources for foundational claims.
+- Chapter 2 reuses the same sources alongside additional references, without clarifying their unique contribution to the new material.
+
+## Impact
+- Creates the impression of shallow or placeholder referencing.
+- Undermines the credibility of claims that require specialised evidence (for example, compliance or DevOps metrics).
+- Misses opportunities to showcase broader industry research.
+
+## Recommended Actions
+1. Audit each chapter to ensure citations directly support the surrounding assertions.
+2. Limit reuse of foundational sources to contexts where they provide unique value.
+3. Introduce domain-specific references (for example, GDPR guidance, DORA regulations, DORA metrics research) when discussing specialised topics.
+
+## Acceptance Criteria
+- [ ] Citation audit completed with a mapping of sources to specific claims.
+- [ ] Redundant references removed or replaced with more relevant sources.
+- [ ] Chapters highlight diverse, topic-appropriate references beyond the two repeated works.
+
+## Recommended Labels
+`documentation`, `requirements`

--- a/Issues/issue_19_streamline_pipeline_validation_layers.md
+++ b/Issues/issue_19_streamline_pipeline_validation_layers.md
@@ -1,0 +1,35 @@
+# Issue 19: Streamline Pipeline Validation Layer Coverage
+
+## Priority
+Low
+
+## Type
+Content structure duplication
+
+## Component
+CI/CD chapter
+
+## Problem Statement
+Chapter 5 explains fail-fast, multilayer validation in prose and then repeats the same information in a validation-layer table. The duplicated explanations provide minimal new insight and could be condensed to emphasise why the layers matter rather than what they are.
+
+## Evidence of Repetition
+- Fail-fast feedback introduction: narrative description of multilayer validation from syntax checks to security scanning.
+- Validation layer table: reiterates the same layers with columns for purpose, tools, detection capabilities.
+
+## Impact
+- Reduces the impact of the table by pre-empting its content in prose form.
+- Limits space for discussing trade-offs, metrics, or real-world outcomes of validation layers.
+- Creates repetitive reading flow within the CI/CD chapter.
+
+## Recommended Actions
+1. Keep the structured table as the authoritative reference for validation layers.
+2. Replace the introductory prose with context on why fail-fast validation delivers business value (speed, cost avoidance, risk mitigation).
+3. Add examples or metrics demonstrating tangible benefits of early failure detection.
+
+## Acceptance Criteria
+- [ ] Prose section rewritten to focus on rationale and outcomes rather than enumerating the same layers.
+- [ ] Validation layer table retained as the primary enumeration.
+- [ ] Additional examples or metrics illustrate the effectiveness of early validation.
+
+## Recommended Labels
+`documentation`, `qa`

--- a/Issues/issue_20_replace_devops_cultural_transformation_buzzwords.md
+++ b/Issues/issue_20_replace_devops_cultural_transformation_buzzwords.md
@@ -1,0 +1,36 @@
+# Issue 20: Replace DevOps Cultural Transformation Buzzwords with Actionable Detail
+
+## Priority
+Medium
+
+## Type
+Linguistic repetition
+
+## Component
+CI/CD and organisational chapters
+
+## Problem Statement
+Chapter 5 repeatedly references “cultural transformation”, “DevOps culture”, and similar phrases without clarifying the concrete behaviours or practices that define the desired culture. The buzzword-heavy narrative lacks actionable guidance for readers seeking implementation steps.
+
+## Evidence of Repetition
+- Organisational implications: “Cultural transformation: Building trust in automation…”
+- Critical success factors: “Cultural transformation with a holistic perspective…”
+- DevOps culture for Architecture as Code: “Architecture as Code requires a mature DevOps culture…”
+
+## Impact
+- Dilutes credibility through vague, abstract language.
+- Fails to equip readers with actionable practices or measurable cultural indicators.
+- Creates a perception of theoretical guidance rather than practical instruction.
+
+## Recommended Actions
+1. Replace generic “cultural transformation” statements with concrete examples (for example, cross-functional architecture reviews, shared on-call, ADR reviews in pull requests).
+2. Introduce case studies or anecdotes illustrating successful cultural change.
+3. Provide measurable outcomes or indicators (for example, mean time to recovery improvements, joint KPIs) to demonstrate progress.
+
+## Acceptance Criteria
+- [ ] Abstract references to “cultural transformation” are rewritten with specific practices or behaviours.
+- [ ] At least one case study or scenario is added to ground the narrative.
+- [ ] Cultural outcomes are linked to measurable indicators or observed behaviours.
+
+## Recommended Labels
+`documentation`, `editor`

--- a/Issues/issue_21_vary_architecture_as_code_sentence_structures.md
+++ b/Issues/issue_21_vary_architecture_as_code_sentence_structures.md
@@ -1,0 +1,39 @@
+# Issue 21: Vary “Architecture as Code…” Sentence Structures
+
+## Priority
+Low
+
+## Type
+Stylistic repetition
+
+## Component
+Manuscript narrative
+
+## Problem Statement
+Across multiple chapters, sentences frequently begin with “Architecture as Code is…”, “Architecture as Code enables…”, or “Architecture as Code requires…”. The repetitive construction produces monotonous prose and obscures the subject performing the action.
+
+## Evidence of Repetition
+Examples include:
+1. “Architecture as Code represents a paradigm shift…”
+2. “Architecture as Code is founded on core principles…”
+3. “Architecture as Code enables testing of the entire system…”
+4. “Architecture as Code requires testing strategies…”
+5. “Architecture as Code represents the future…”
+
+## Impact
+- Reduces narrative variety and reader engagement.
+- Masks opportunities to highlight actors (teams, architects, pipelines) performing the work.
+- Makes the text feel formulaic and less persuasive.
+
+## Recommended Actions
+1. Rewrite repetitive sentences using pronouns, abbreviations (AaC), or alternative subjects where appropriate.
+2. Introduce active voice with clear actors (for example, “Teams adopting AaC can test…”).
+3. Limit full “Architecture as Code…” phrases to first mention per section, using “AaC” thereafter for flow.
+
+## Acceptance Criteria
+- [ ] Audit of chapters identifies and rewrites repetitive sentence openings.
+- [ ] Revised prose demonstrates varied sentence structure and active voice.
+- [ ] Editorial review confirms improved narrative flow without loss of clarity.
+
+## Recommended Labels
+`documentation`, `editor`

--- a/Issues/issue_22_expand_compliance_requirement_examples.md
+++ b/Issues/issue_22_expand_compliance_requirement_examples.md
@@ -1,0 +1,36 @@
+# Issue 22: Expand Compliance Requirement Examples Beyond Repeated Lists
+
+## Priority
+Medium
+
+## Type
+List repetition
+
+## Component
+Compliance sections across chapters
+
+## Problem Statement
+Compliance lists featuring “GDPR, PCI-DSS, and industry-specific regulations” recur across Chapters 2, 4, and 5, occasionally swapping in ISO27001 or SOC2. The repetition overemphasises a narrow subset of regulations and neglects sector-specific obligations.
+
+## Evidence of Repetition
+- Chapter 2 – Requirements as Code example: YAML snippet `compliance: ["GDPR", "ISO27001"]`.
+- Chapter 4 – Compliance and Quality Standards: reiterates “GDPR, PCI-DSS, and industry-specific regulations”.
+- Chapter 5 – Multiple references embedding the same trio of regulations into narrative passages.
+
+## Impact
+- Signals a limited understanding of broader regulatory landscapes (for example, NIS2, DORA, HIPAA, energy-sector rules).
+- Reduces the perceived relevance of the book for organisations outside GDPR-focused contexts.
+- Creates monotonous lists instead of targeted, scenario-specific guidance.
+
+## Recommended Actions
+1. Develop a compliance matrix or appendix mapping regulations to architectural concerns and industries.
+2. Vary examples in each chapter to highlight different regulatory drivers (for example, DORA for financial services, NERC CIP for energy).
+3. Reference the consolidated matrix instead of repeating the same short list in prose.
+
+## Acceptance Criteria
+- [ ] Compliance matrix or appendix created with cross-industry coverage.
+- [ ] Chapters 2, 4, and 5 updated to reference the matrix and showcase diverse regulatory examples.
+- [ ] Editorial review confirms elimination of repetitive regulation lists.
+
+## Recommended Labels
+`documentation`, `requirements`


### PR DESCRIPTION
## Summary
- add twelve new issue drafts covering repeated content, lists, and stylistic redundancies in the Architecture as Code manuscript
- capture priority, impact, evidence, and acceptance criteria for each repetition clean-up activity to guide editorial work

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f238f88af48330a4ad26fa60e82a8a