### PR TITLE
Refactor: centralise OpenAI workflow helper

### DIFF
--- a/.github/scripts/openai_responses.sh
+++ b/.github/scripts/openai_responses.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shared helper for invoking the OpenAI Responses API from GitHub Actions workflows.
+# Expects PROMPT and OPENAI_API_KEY to be present in the environment.
+set -euo pipefail
+
+FORMAT="${1:-text}"
+PROMPT="${PROMPT:-}"
+API_KEY="${OPENAI_API_KEY:-}"
+
+if [[ -z "$PROMPT" ]]; then
+  echo "PROMPT environment variable is required." >&2
+  exit 1
+fi
+
+if [[ -z "$API_KEY" ]]; then
+  echo "OPENAI_API_KEY environment variable is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  sudo apt-get update >/dev/null
+  sudo apt-get install -y jq >/dev/null
+fi
+
+REQUEST=$(jq -n --arg prompt "$PROMPT" '{
+  model: "gpt-4o-mini",
+  input: [{role: "user", content: $prompt}]
+}')
+
+RAW=$(curl -sS https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$REQUEST")
+
+if [[ "${FORMAT}" == "raw" ]]; then
+  printf '%s' "$RAW"
+  exit 0
+fi
+
+TEXT=$(echo "$RAW" | jq -r '.output_text // .output[0].content[0].text // empty')
+
+if [[ -z "$TEXT" ]]; then
+  ERROR_MESSAGE=$(echo "$RAW" | jq -r '.error.message // empty')
+  if [[ -n "$ERROR_MESSAGE" ]]; then
+    echo "OpenAI error: ${ERROR_MESSAGE}" >&2
+  else
+    echo "OpenAI response did not contain any text." >&2
+  fi
+  exit 2
+fi
+
+case "$FORMAT" in
+  text)
+    printf '%s' "$TEXT"
+    ;;
+  json)
+    JSON_BODY=$(printf '%s' "$TEXT" | awk 'BEGIN{capture=0}{if(index($0,"{"))capture=1;if(capture)print}')
+    if [[ -z "$JSON_BODY" ]]; then
+      echo "OpenAI response did not include a JSON payload." >&2
+      exit 3
+    fi
+    echo "$JSON_BODY" | jq -c .
+    ;;
+  *)
+    echo "Unsupported format: ${FORMAT}. Use text, json, or raw." >&2
+    exit 4
+    ;;
+esac

--- a/.github/workflows/assistant-new-issue.yml
+++ b/.github/workflows/assistant-new-issue.yml
@@ -86,31 +86,16 @@ jobs:
                       {"pr_title":"Fix: X","pr_body":"Why + what changed","patch":"diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ ..."}
         run: |
           set -euo pipefail
-          sudo apt-get update >/dev/null && sudo apt-get install -y jq >/dev/null
-
-          REQUEST=$(jq -n --arg prompt "$PROMPT" '{
-            model: "gpt-4o-mini",
-            input: [{role:"user", content: $prompt}]
-          }')
-
-          RAW=$(curl -sS https://api.openai.com/v1/responses \
-            -H "Authorization: Bearer '"$OPENAI_API_KEY"'" \
-            -H "Content-Type: application/json" \
-            -d "$REQUEST")
-
-          TEXT=$(echo "$RAW" | jq -r '.output_text // .output[0].content[0].text // empty')
-          [ -z "$TEXT" ] && { echo "No text in OpenAI response."; exit 1; }
-
-          # Extract JSON even if any stray prose was returned
-          JSON=$(printf "%s" "$TEXT" | awk 'BEGIN{p=0}{if(index($0,"{"))p=1;if(p)print}')
-          echo "$JSON" | jq . >/dev/null
+          JSON="$(.github/scripts/openai_responses.sh json)"
 
           PR_TITLE=$(echo "$JSON" | jq -r '.pr_title // "Proposed changes from OpenAI"')
           PR_BODY=$(echo "$JSON" | jq -r '.pr_body // ""')
           PATCH=$(echo "$JSON" | jq -r '.patch // ""')
 
           if [ -z "$PATCH" ] || ! printf "%s" "$PATCH" | grep -q '^diff --git '; then
-            echo "Model did not return a valid unified diff."; echo "$TEXT"; exit 1
+            echo "Model did not return a valid unified diff.";
+            echo "$JSON";
+            exit 1
           fi
 
           printf "%s" "$PATCH" > patch.diff

--- a/.github/workflows/assistant.yml
+++ b/.github/workflows/assistant.yml
@@ -36,29 +36,15 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y jq
-
-          # Build JSON with jq to avoid quoting/escaping issues
-          REQUEST=$(jq -n --arg prompt "$PROMPT" '{
-            model: "gpt-4o-mini",
-            input: [{role:"user", content: $prompt}]
-          }')
-
-          RESPONSE=$(curl -sS https://api.openai.com/v1/responses \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$REQUEST")
-
-          # Prefer the convenience field if present; fall back to nested structure
-          TEXT=$(echo "$RESPONSE" | jq -r '.output_text // .output[0].content[0].text // empty')
+          TEXT="$(.github/scripts/openai_responses.sh text)"
 
           echo "Assistant said:"
-          echo "$TEXT"
+          printf '%s\n' "$TEXT"
 
           # Expose TEXT for later steps
           {
             echo "ASSISTANT_TEXT<<EOF"
-            echo "${TEXT:-}"
+            printf '%s\n' "${TEXT:-}"
             echo "EOF"
           } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- add a shared `.github/scripts/openai_responses.sh` helper to call the OpenAI Responses API with consistent error handling
- update `assistant.yml` to reuse the helper script instead of inlining curl and jq logic
- update `assistant-new-issue.yml` to consume the helper, ensuring consistent parsing and diagnostics for generated patches

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f4e8a4a1b48330b5fb60e5208c444c