### PR TITLE
Add backlog issues aligning Git workflows with book guidance

### DIFF
--- a/issues/audit-git-workflow.md
+++ b/issues/audit-git-workflow.md
@@ -1,0 +1,51 @@
+# Issue: Audit and expand our Git-based workflow for infrastructure
+
+**Summary**
+Chapter 3 (“Version Control and Code Structure”) describes a Git-based workflow for Architecture as Code (AaC) with clear commit history, PR-based review, and transparent branching strategies. We should align our repositories with these practices, decide on the default branching model (trunk vs GitFlow), and document contribution rules.
+
+**Why**
+- Ensure architectural guardrails are enforced via Git.
+- Improve traceability, review quality, and onboarding.
+- Make PR checks and governance explicit.
+
+**Scope**
+- Revisit branch strategy, PR templates, CODEOWNERS, and mandatory checks.
+- Define commit message conventions and cross-linking to ADRs/Issues.
+- Clarify separation of AaC vs IaC repositories.
+
+**References**
+- Site: “Version Control and Code Structure” (includes “Git-based workflow for infrastructure”, “Transparency through version control”).
+
+**Acceptance Criteria**
+- [ ] A documented branching strategy with examples.
+- [ ] Standard PR template (review checklist for governance/policy).
+- [ ] CODEOWNERS with required reviewers for sensitive areas.
+- [ ] Commit message convention documented; link to ADR policy.
+- [ ] Example “happy path” PR from feature to main with checks.
+
+**Tasks**
+- [ ] Decide and document branch strategy (trunk-based or GitFlow).
+- [ ] Add `.github/pull_request_template.md` with governance checklist.
+- [ ] Add `CODEOWNERS` and enforce status checks.
+- [ ] Add `CONTRIBUTING.md` detailing commit messages, linking Issues/ADRs.
+- [ ] Provide examples of AaC vs IaC repository boundaries.
+
+---
+
+## Git history and flow (illustrative)
+```mermaid
+gitGraph
+  commit id: "init"
+  branch feature/aac-guardrails
+  commit id: "spec: policy-as-code scaffolding"
+  commit id: "docs: ADR-001 guardrails"
+  checkout main
+  commit id: "chore: CI base"
+  merge feature/aac-guardrails tag: "PR #42"
+  branch hotfix/rollback-guard
+  commit id: "fix: rollback rule"
+  checkout main
+  merge hotfix/rollback-guard tag: "PR #47"
+```
+
+*Source: Chapter 3, “Version Control and Code Structure”.*

--- a/issues/clarify-aac-iac-boundaries.md
+++ b/issues/clarify-aac-iac-boundaries.md
@@ -1,0 +1,22 @@
+# Issue: Clarify AaC vs IaC repository boundaries and contracts via Git
+
+**Summary**
+Chapter 3 and the automation chapter highlight the layered responsibilities of AaC (guardrails, policies, models) vs IaC (execution artefacts). We should formalise the Git “contract”: separate repositories, versioned interfaces, and consumption patterns.
+
+**Why**
+Prevents drift, preserves governance signals, and lets IaC consume approved patterns cleanly.
+
+**Scope**
+- Define “published” AaC artefacts and their versioning scheme.
+- Consumption pattern for IaC repositories (as modules/templates/blueprints).
+- Validation gates: PR checks ensure IaC only uses approved versions.
+
+**References**
+- Chapter 3 (“Abstraction and governance responsibilities…”), and Chapter 5 cross-references to version control.
+
+**Acceptance Criteria**
+- [ ] Spec for AaC release process (tags, changelog, semver).
+- [ ] Example IaC repository that imports a tagged AaC package.
+- [ ] PR check that blocks unapproved/unstable AaC references.
+
+Sources: Chapter 3; Chapter 5 (Automation) cross-reference to version control.

--- a/issues/curate-cicd-workflow-library.md
+++ b/issues/curate-cicd-workflow-library.md
@@ -1,0 +1,27 @@
+# Issue: Curate CI/CD workflow examples and lift into reference library
+
+**Summary**
+Appendix A contains several GitHub Actions/Jenkins pipeline examples (GDPR checks, testing, delivery). We should adopt these as a versioned “reference library” and wire them into our repositories as selectable templates.
+
+**Why**
+Accelerates team adoption, ensures compliance gates (GDPR/data residency), and standardises pipeline quality.
+
+**Scope**
+- Extract and parameterise workflows (environment, residency, cost-centre, etc.).
+- Provide repository-scoped composite actions or reusable workflows.
+- Documentation with when/why to use each template.
+
+**References**
+- Site: Appendix A → “CI/CD Pipelines and Architecture as Code Automation” (e.g., 05_CODE_1, 05_CODE_2), plus testing workflows.
+
+**Acceptance Criteria**
+- [ ] `/.github/workflows/` contains reusable workflows for compliance and testing.
+- [ ] Jenkins examples mirrored (where applicable) or documented alternatives.
+- [ ] Decision guide that maps scenario → workflow.
+
+**Tasks**
+- [ ] Import `05_CODE_1` (GDPR compliance GH Actions) and adapt variable names.
+- [ ] Import `05_CODE_2` (Jenkins variant) or provide GH Actions parity.
+- [ ] Add documentation page linking each template with usage notes.
+
+Source: Appendix A.

--- a/issues/document-transparency.md
+++ b/issues/document-transparency.md
@@ -1,0 +1,37 @@
+# Issue: Document transparency via Issues, Discussions, and commit history
+
+**Summary**
+Chapter 3 emphasises transparency: PRs for peer review, Issues for work tracking, Discussions for strategy, and branch strategies to make flow visible. We should codify how we use these surfaces and add cross-link standards.
+
+**Why**
+Auditable trail for “what/when/who/why”, better stakeholder visibility, and quicker onboarding.
+
+**Scope**
+- Define when to use Issues vs Discussions.
+- Reference patterns for linking Issues ↔ PRs ↔ ADRs.
+- Add labels and project boards per area.
+- Showcase commit history queries for audits.
+
+**Acceptance Criteria**
+- [ ] Playbook with examples (Issue → PR → ADR).
+- [ ] Label set and default project board created.
+- [ ] Search snippets for “show me all changes to X between Y–Z”.
+
+---
+
+## Transparent branch strategy (illustrative)
+```mermaid
+gitGraph
+  commit id: "main: release 1.0"
+  branch feature/transparency-playbook
+  commit id: "docs: usage of Issues vs Discussions (#88)"
+  commit id: "docs: linking PRs to ADRs (#89)"
+  checkout main
+  merge feature/transparency-playbook tag: "PR #90"
+  branch release/1.1
+  commit id: "chore: changelog"
+  checkout main
+  merge release/1.1 tag: "PR #91"
+```
+
+*Source: “Transparency through version control” in Chapter 3.*

--- a/issues/github-actions-book-pipeline.md
+++ b/issues/github-actions-book-pipeline.md
@@ -1,0 +1,29 @@
+# Issue: Implement GitHub Actions CI/CD for book production
+
+**Summary**
+Appendix B details a GitHub Actions pipeline that builds the book from Markdown/diagrams with Pandoc and Mermaid, including caching and release artefacts. We should implement or align our pipeline with this reference.
+
+**Why**
+Provides reproducible builds, validates diagrams/config, and publishes artefacts with an auditable trail.
+
+**Scope**
+- Adopt `build-book.yml` (push/PR/dispatch), add caching, and artefact retention.
+- Integrate diagram generation and quality checks.
+- Automate releases on `main`.
+
+**References**
+- Site: Appendix B → “GitHub Actions: CI/CD Pipeline” and “Build Process and Automation”.
+
+**Acceptance Criteria**
+- [ ] Workflow triggers: push to `main`, PRs to `main`, manual dispatch.
+- [ ] Steps: environment, dependencies, diagram conversion, Pandoc PDF/EPUB/DOCX.
+- [ ] Artefacts uploaded; release on `main` with retention.
+- [ ] Quality gates: template/config/image checks.
+
+**Tasks**
+- [ ] Port the sample `build-book.yml` and tune timeouts.
+- [ ] Add caching for APT, pip, Node.
+- [ ] Add validation steps (template, config, images).
+- [ ] Configure Release publishing with notes.
+
+Source: Appendix B.

--- a/issues/standardise-repo-structure.md
+++ b/issues/standardise-repo-structure.md
@@ -1,0 +1,21 @@
+# Issue: Standardise repository structure and module layout for AaC
+
+**Summary**
+Chapter 3 outlines expectations for code organisation and module structure to keep larger AaC projects maintainable. We need a standard layout (folders, naming, module boundaries) and a starter template.
+
+**Why**
+Consistent layout reduces cognitive load, speeds reviews, and supports reuse across environments.
+
+**Scope**
+- Define a top-level structure for AaC models, ADRs, governance policies, diagrams, and IaC consumers.
+- Provide a template repository with examples and Makefile/tasks.
+
+**References**
+- Site: “Code organisation and module structure” section.
+
+**Acceptance Criteria**
+- [ ] Published repository template with folders for `aac/`, `adr/`, `governance/`, `docs/`, `images/`, `iac/consumers/`.
+- [ ] README explains each folder and how it links to PR checks.
+- [ ] Example module with inputs/outputs and versioning policy.
+
+Source: Chapter 3.


### PR DESCRIPTION
## Summary
- add issue markdown files covering Git workflow, transparency, and CI/CD alignment items from the book
- capture Appendix A and B automation references for future implementation work
- establish backlog entries clarifying AaC and IaC repository contracts

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f87cdb2558833090de0208cf165a4e