### PR TITLE
Add concurrency control to presentation generation workflow

### DIFF
--- a/.github/workflows/generate-presentations.yml
+++ b/.github/workflows/generate-presentations.yml
@@ -19,6 +19,10 @@ on:
       - '.github/workflows/generate-presentations.yml'
   workflow_dispatch: {}  # Allow manual triggering
 
+concurrency:
+  group: presentations-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ARTIFACT_RETENTION_DAYS: 30
 


### PR DESCRIPTION
## Summary
- add concurrency configuration to the presentation generation workflow to prevent overlapping runs

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fcbb9e66748330beb4910ace865062