### PR TITLE
Fix cover page layout for full-bleed images

### DIFF
--- a/docs/pandoc.yaml
+++ b/docs/pandoc.yaml
@@ -46,16 +46,22 @@ variables:
   lang: en-GB
   titlepage: false  # Disable Eisvogel's automatic title page (we use custom title in include-before)
   include-before: |
+    % Full-bleed cover and release pages without cropping their content.
+    \clearpage
+    \begingroup
     \thispagestyle{empty}
-    \begin{center}
-    \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio=false]{images/book-cover.png}
-    \end{center}
-    \newpage
+    \newgeometry{top=0mm,bottom=0mm,left=0mm,right=0mm}
+    \noindent\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio=false]{images/book-cover.png}
+    \restoregeometry
+    \endgroup
+    \clearpage
+    \begingroup
     \thispagestyle{empty}
-    \begin{center}
-    \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio=false]{images/release_information_page.png}
-    \end{center}
-    \newpage
+    \newgeometry{top=0mm,bottom=0mm,left=0mm,right=0mm}
+    \noindent\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio=false]{images/release_information_page.png}
+    \restoregeometry
+    \endgroup
+    \clearpage
   # Simplified header handling
   header-includes: |
     \usepackage{fancyhdr}


### PR DESCRIPTION
## Summary
- ensure the include-before block temporarily removes page margins when rendering the cover and release pages so the artwork is not cropped

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: xelatex not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbb4909f88330824c60a416dd8f38