### PR TITLE
Add concurrency controls to orchestrator workflow

### DIFF
--- a/.github/workflows/orchestrate-all.yml
+++ b/.github/workflows/orchestrate-all.yml
@@ -1,5 +1,9 @@
 name: Build All – Orchestrator
 
+concurrency:
+  group: orchestrate-all-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:
@@ -35,6 +39,7 @@ jobs:
     name: Finalise & (optional) Release
     runs-on: ubuntu-latest
     needs: [book, whitepapers, presentations, site]
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- add a top-level concurrency group to prevent overlapping orchestrator runs
- configure the finalise job with an explicit 20 minute timeout

## Testing
- not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68fcbbc7027c8330bdad7b0ea4e61c2a