### PR TITLE
Fix EPUB generation with non-LaTeX defaults

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -140,6 +140,7 @@ RELEASE_EPUB="$RELEASE_DIR/$OUTPUT_EPUB"
 RELEASE_DOCX="$RELEASE_DIR/$OUTPUT_DOCX"
 PANDOC_TEMPLATES_DIR="$HOME/.local/share/pandoc/templates"
 EISVOGEL_TEMPLATE="$PANDOC_TEMPLATES_DIR/eisvogel.latex"
+NON_LATEX_DEFAULTS_FILE="pandoc-nonlatex.yaml"
 
 # Ensure Eisvogel template exists (install automatically if missing)
 if [ ! -f "$EISVOGEL_TEMPLATE" ]; then
@@ -190,8 +191,15 @@ if [ ! -f "pandoc.yaml" ]; then
     exit 1
 fi
 
-# Ensure release directory exists
 mkdir -p "$RELEASE_DIR"
+
+# Verify that the non-LaTeX defaults file is available for EPUB/DOCX builds
+NON_LATEX_DEFAULTS_ARGS=()
+if [ -f "$NON_LATEX_DEFAULTS_FILE" ]; then
+    NON_LATEX_DEFAULTS_ARGS=("--defaults=$NON_LATEX_DEFAULTS_FILE")
+else
+    echo "⚠️  Warning: Non-LaTeX defaults file '$NON_LATEX_DEFAULTS_FILE' not found. Using Pandoc defaults for EPUB/DOCX."
+fi
 
 # Copy book cover to images directory for Pandoc
 echo "Preparing book cover..."
@@ -476,7 +484,7 @@ generate_other_formats() {
     echo "Generating EPUB format..."
 
     # Generate EPUB with improved metadata
-    if pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" \
+    if pandoc "${NON_LATEX_DEFAULTS_ARGS[@]}" "${NON_LATEX_CHAPTER_FILES[@]}" \
         -t epub \
         -o "$OUTPUT_EPUB" \
         --metadata date="$(date +'%Y-%m-%d')" \
@@ -515,7 +523,7 @@ generate_other_formats() {
     fi
 
     echo "Generating DOCX format..."
-    pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" \
+    pandoc "${NON_LATEX_DEFAULTS_ARGS[@]}" "${NON_LATEX_CHAPTER_FILES[@]}" \
         -t docx \
         --metadata=include-before= \
         --metadata=header-includes= \

--- a/docs/pandoc-nonlatex.yaml
+++ b/docs/pandoc-nonlatex.yaml
@@ -1,0 +1,22 @@
+---
+standalone: true
+toc: true
+toc-depth: 3
+number-sections: true
+
+top-level-division: chapter
+
+highlight-style: tango
+
+epub-chapter-level: 1
+
+metadata:
+  title: "Architecture as Code"
+  subtitle: "A practical handbook for Infrastructure as Code"
+  author: "Gunnar Nordqvist"
+  date: "2025"
+  language: en-GB
+  lang: en-GB
+
+variables:
+  lang: en-GB

--- a/tests/test_epub_validation.py
+++ b/tests/test_epub_validation.py
@@ -188,11 +188,12 @@ class TestBuildPipelineConfiguration:
         assert 'OUTPUT_PDF="architecture_as_code.pdf"' in build_script
         assert 'OUTPUT_EPUB="architecture_as_code.epub"' in build_script
         assert 'OUTPUT_DOCX="architecture_as_code.docx"' in build_script
+        assert 'NON_LATEX_DEFAULTS_FILE="pandoc-nonlatex.yaml"' in build_script
 
     def test_build_script_invokes_pandoc(self, build_script):
         """Verify that the build script renders PDF and DOCX files with Pandoc."""
         assert 'pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -o "$OUTPUT_PDF" 2>&1' in build_script
-        assert 'pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" -t docx -o "$OUTPUT_DOCX"' in build_script
+        assert 'pandoc "${NON_LATEX_DEFAULTS_ARGS[@]}" "${NON_LATEX_CHAPTER_FILES[@]}" \\' in build_script
 
     def test_build_script_runs_epubcheck(self, build_script):
         """Ensure the build script validates EPUB output using epubcheck."""


### PR DESCRIPTION
## Summary
- add a dedicated Pandoc defaults file for non-LaTeX outputs
- update the book build script to rely on the new defaults when generating EPUB/DOCX artefacts
- extend the EPUB validation tests to cover the new configuration

## Testing
- ./docs/build_book.sh --release
- pytest tests/test_epub_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68fcbb5bfa348330be833e1f1cdfe915