### PR TITLE
Add print stylesheet for PDF workflow

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -193,6 +193,15 @@ fi
 
 mkdir -p "$RELEASE_DIR"
 
+# Configure optional print stylesheet for HTML-to-PDF workflows
+PRINT_STYLESHEET="pdf-print.css"
+PANDOC_PRINT_CSS_ARGS=()
+if [ -f "$PRINT_STYLESHEET" ]; then
+    PANDOC_PRINT_CSS_ARGS=("--css=$PRINT_STYLESHEET")
+else
+    echo "⚠️  Warning: Print stylesheet '$PRINT_STYLESHEET' not found."
+fi
+
 # Verify that the non-LaTeX defaults file is available for EPUB/DOCX builds
 NON_LATEX_DEFAULTS_ARGS=()
 if [ -f "$NON_LATEX_DEFAULTS_FILE" ]; then
@@ -396,7 +405,7 @@ else
     echo "⚠️  Warning: Non-LaTeX formats missing cover page markdown ($COVER_PAGE_MARKDOWN not found)"
 fi
 
-pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -o "$OUTPUT_PDF" 2>&1
+pandoc --defaults=pandoc.yaml "${PANDOC_PRINT_CSS_ARGS[@]}" "${CHAPTER_FILES[@]}" -o "$OUTPUT_PDF" 2>&1
 
 # Check if PDF was actually generated
 if [ -f "$OUTPUT_PDF" ] && [ -s "$OUTPUT_PDF" ]; then
@@ -415,6 +424,7 @@ else
     # Try with default LaTeX template
     # Reuse the shared pandoc defaults so LaTeX helpers like \setbookpart stay defined
     if pandoc --defaults=pandoc.yaml \
+        "${PANDOC_PRINT_CSS_ARGS[@]}" \
         --template=default \
         "${CHAPTER_FILES[@]}" \
         -o "$OUTPUT_PDF" \

--- a/docs/pdf-print.css
+++ b/docs/pdf-print.css
@@ -1,0 +1,37 @@
+@page {
+  size: A4;
+  margin: 18mm;
+}
+
+/* Reset full-bleed or hero layouts for print */
+@media print {
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .container,
+  .md-content,
+  .page,
+  .hero,
+  .fullbleed {
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: 100% !important;
+    width: auto !important;
+  }
+
+  img,
+  svg,
+  canvas {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+
+  /* Avoid content spilling outside the printable area */
+  * {
+    box-sizing: border-box;
+    overflow: visible !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a print-focused stylesheet that normalises margins and max-widths for PDF export
- update the book build script to include the stylesheet when invoking Pandoc, with a warning if the file is missing

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: xelatex is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc7cc210483309c984811d676f853