### PR TITLE
Ensure workflow fallback retains DOCX generation

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -69,7 +69,8 @@ jobs:
           mkdir -p releases/book
           cd docs
           chmod +x ./build_book.sh
-          ./build_book.sh --release || ./build_book.sh
+          # Fall back to the full format build if release mode fails to ensure DOCX remains available.
+          ./build_book.sh --release || ./build_book.sh --all-formats
           cd ..
 
       - name: Upload book artefacts


### PR DESCRIPTION
## Summary
- update the book build workflow fallback to rerun the script with --all-formats when --release fails
- document the fallback so DOCX creation is preserved for final release packaging

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fcc8ade2808330b3acce5c8351fabd