### PR TITLE
Add curated issue catalogue with source mappings

### DIFF
--- a/Issues/README.md
+++ b/Issues/README.md
@@ -1,0 +1,12 @@
+# Curated Issue Catalogue
+
+The Architecture as Code workshop tracks high-priority editorial and research tasks in this directory. Each issue template aligns with the reference catalogue so contributors can pick up work with confidence that the cited material is already cleared for inclusion. Issues are grouped by thematic focus and cover all catalogue sources.
+
+## Available Issue Templates
+
+- [issue_01_cloud_native_operating_model.md](issue_01_cloud_native_operating_model.md) – Aligns executive research with the introduction, platform strategy, and organisational change chapters.
+- [issue_02_governance_and_policy_alignment.md](issue_02_governance_and_policy_alignment.md) – Extends governance automation practices and supporting policy sources.
+- [issue_03_visual_modelling_improvements.md](issue_03_visual_modelling_improvements.md) – Improves diagram automation guidance using modelling frameworks and tools.
+- [issue_04_security_and_toolchain_resilience.md](issue_04_security_and_toolchain_resilience.md) – Strengthens security automation and platform resilience coverage across the manuscript.
+
+Each template contains the necessary context, problem framing, acceptance criteria, and recommended labels. Update this list whenever new curated issues are added or retired.

--- a/Issues/issue_01_cloud_native_operating_model.md
+++ b/Issues/issue_01_cloud_native_operating_model.md
@@ -1,0 +1,28 @@
+# Align Cloud Native Research with Operating Model Guidance
+
+## Source IDs
+- [1]
+- [2]
+- [3]
+- [4]
+
+## Relevant Manuscript Sections
+- 01_introduction.md
+- 02_fundamental_principles.md
+- 15_cost_optimization.md
+- 17_organizational_change.md
+- 29_about_the_authors.md
+
+## Problem Statement
+The introduction and operating model chapters reference authoritative market research but do not yet translate the findings into actionable guidance for Architecture as Code teams. Contributors need to surface quantified adoption signals, economic considerations, and narrative framing to help readers position the practice in an enterprise context.
+
+## Acceptance Criteria
+- Integrate a short comparative summary of the selected sources that highlights maturity trends, investment signals, and the organisational drivers behind Architecture as Code.
+- Expand the introduction with a concise subsection that interprets the research data through the lens of Architecture as Code capabilities.
+- Update Chapter 15 with a paragraph that connects public cloud investment forecasts to cost optimisation levers described in the book.
+- Add cross-references from the organisational change chapter that demonstrate how leadership roles respond to the research insights.
+
+## Recommended Labels
+- documentation
+- research
+- architecture

--- a/Issues/issue_02_governance_and_policy_alignment.md
+++ b/Issues/issue_02_governance_and_policy_alignment.md
@@ -1,0 +1,26 @@
+# Strengthen Governance and Policy Automation Narrative
+
+## Source IDs
+- [5]
+- [9]
+- [10]
+- [11]
+
+## Relevant Manuscript Sections
+- 11_governance_as_code.md
+- 17_organizational_change.md
+- 23_soft_as_code_interplay.md
+
+## Problem Statement
+Governance chapters describe policy automation concepts but currently lack clear ties between market sentiment, organisational readiness, and specific control mechanisms. The selected sources provide empirical data and platform-level practices that should be woven into the manuscript.
+
+## Acceptance Criteria
+- Introduce a subsection that links executive confidence levels from the HashiCorp survey to governance-as-code adoption barriers.
+- Reference GitHub and GitLab guidance to provide concrete examples of protective controls and workflow automation.
+- Expand the Software as Code interplay chapter with a paragraph that explains how Policy as Code frameworks operationalise governance checkpoints.
+- Ensure organisational change guidance highlights the human and process adjustments inferred from the research sources.
+
+## Recommended Labels
+- governance
+- documentation
+- dev

--- a/Issues/issue_03_visual_modelling_improvements.md
+++ b/Issues/issue_03_visual_modelling_improvements.md
@@ -1,0 +1,26 @@
+# Enhance Visual Modelling and Diagram Automation Coverage
+
+## Source IDs
+- [7]
+- [8]
+- [12]
+- [13]
+
+## Relevant Manuscript Sections
+- 06_structurizr.md
+- 22_documentation_vs_architecture.md
+- 24_best_practices.md
+
+## Problem Statement
+Diagram automation chapters outline workflows but could better articulate why particular modelling approaches matter to Architecture as Code teams. The selected sources articulate standards, tooling characteristics, and industry context that should inform guidance for modelling consistency.
+
+## Acceptance Criteria
+- Introduce a comparative table or narrative that contrasts Structurizr, Mermaid, and CALM capabilities, referencing the cited material.
+- Document at least one new best practice that demonstrates how C4 modelling conventions connect to Architecture as Code governance needs.
+- Add a cross-link from the documentation versus architecture chapter that positions CALM as a harmonising meta-model.
+- Ensure citations are added where tool-specific recommendations are made so that future automation work can reference the authoritative material.
+
+## Recommended Labels
+- design
+- documentation
+- architecture

--- a/Issues/issue_04_security_and_toolchain_resilience.md
+++ b/Issues/issue_04_security_and_toolchain_resilience.md
@@ -1,0 +1,29 @@
+# Bolster Security and Toolchain Resilience Guidance
+
+## Source IDs
+- [6]
+- [14]
+- [15]
+- [16]
+
+## Relevant Manuscript Sections
+- 05_automation_devops_cicd.md
+- 09a_security_fundamentals.md
+- 09b_security_patterns.md
+- 14_practical_implementation.md
+- 21_digitalization.md
+- 25_future_trends_development.md
+
+## Problem Statement
+Security and automation chapters refer to infrastructure tooling but need clearer, source-backed guidance on securing pipelines and forecasting toolchain investment. The selected sources provide authoritative recommendations that should anchor pragmatic improvements.
+
+## Acceptance Criteria
+- Update the automation and practical implementation chapters with call-out boxes that reference AWS CDK patterns for codifying guardrails.
+- Expand the security fundamentals chapter with specific Terraform state hardening guidance informed by Google Cloud documentation.
+- Highlight future market growth signals from MarketsandMarkets and IDC to justify continued investment in resilient toolchains.
+- Ensure security pattern examples explicitly cite the relevant sources and articulate the risk mitigated by each practice.
+
+## Recommended Labels
+- security
+- dev
+- documentation

--- a/Issues/source_catalogue.json
+++ b/Issues/source_catalogue.json
@@ -1,0 +1,193 @@
+{
+  "sources": [
+    {
+      "id": 1,
+      "title": "CNCF \u2013 State of Cloud Native Development 2024.",
+      "type": "industry_report",
+      "year": 2024,
+      "url": "https://www.cncf.io/reports/state-of-cloud-native-development-2024/",
+      "summary": "Highlights the accelerating adoption of cloud native delivery models and the implications for Architecture as Code operating models.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "07_containerization.md"
+      ]
+    },
+    {
+      "id": 2,
+      "title": "ThoughtWorks \u2013 Architecture as Code: The Next Evolution.",
+      "type": "industry_analysis",
+      "year": 2024,
+      "url": "https://www.thoughtworks.com/radar/techniques/architecture-as-code",
+      "summary": "Explores how Architecture as Code practices mature across enterprises and outlines guardrails for sustainable adoption.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "02_fundamental_principles.md",
+        "29_about_the_authors.md"
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Martin, R. \u2013 Clean Architecture: A Craftsman's Guide to Software Structure.",
+      "type": "book",
+      "year": 2017,
+      "url": "https://www.pearson.com/en-gb/subject-catalog/p/clean-architecture/P200000003394",
+      "summary": "Provides foundational architectural disciplines that underpin the Architecture as Code mindset.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "02_fundamental_principles.md"
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Gartner \u2013 Forecast Analysis: Public Cloud Services Worldwide.",
+      "type": "industry_research",
+      "year": 2024,
+      "url": "https://www.gartner.com/en/documents/forecast-analysis-public-cloud-services-worldwide",
+      "summary": "Quantifies demand for managed cloud services and provides benchmarks for platform governance sections.",
+      "supports_chapters": [
+        "15_cost_optimization.md",
+        "17_organizational_change.md"
+      ]
+    },
+    {
+      "id": 5,
+      "title": "HashiCorp \u2013 State of Cloud Strategy Survey 2024.",
+      "type": "industry_research",
+      "year": 2024,
+      "url": "https://www.hashicorp.com/state-of-cloud-strategy",
+      "summary": "Captures executive perspectives on multi-cloud operating models relevant to organisational change guidance.",
+      "supports_chapters": [
+        "17_organizational_change.md",
+        "27_conclusion.md"
+      ]
+    },
+    {
+      "id": 6,
+      "title": "AWS \u2013 AWS Cloud Development Kit (CDK) Developer Guide.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://docs.aws.amazon.com/cdk/latest/guide/home.html",
+      "summary": "Documents infrastructure as code patterns that are extended in Automation and Practical Implementation chapters.",
+      "supports_chapters": [
+        "05_automation_devops_cicd.md",
+        "14_practical_implementation.md"
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Brown, S. \u2013 C4 Model Overview.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://c4model.com/",
+      "summary": "Defines the C4 diagramming approach referenced when introducing visual conventions for Architecture as Code.",
+      "supports_chapters": [
+        "06_structurizr.md",
+        "24_best_practices.md"
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Mermaid \u2013 Mermaid: Diagramming and Charting Tool.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://mermaid.js.org/",
+      "summary": "Explains declarative diagramming techniques that underpin the book's diagram automation workflows.",
+      "supports_chapters": [
+        "22_documentation_vs_architecture.md"
+      ]
+    },
+    {
+      "id": 9,
+      "title": "GitHub Docs \u2013 About protected branches.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/about-protected-branches",
+      "summary": "Describes governance controls that inform the policy automation blueprints.",
+      "supports_chapters": [
+        "11_governance_as_code.md",
+        "23_soft_as_code_interplay.md"
+      ]
+    },
+    {
+      "id": 10,
+      "title": "HashiCorp \u2013 Policy as Code Overview.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://developer.hashicorp.com/terraform/enterprise/policy-as-code",
+      "summary": "Introduces policy as code guardrails referenced throughout governance patterns.",
+      "supports_chapters": [
+        "23_soft_as_code_interplay.md"
+      ]
+    },
+    {
+      "id": 11,
+      "title": "GitLab \u2013 Building a Single Source of Truth with APIs and CLI.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://about.gitlab.com/topics/devops/api-cli-single-source-of-truth/",
+      "summary": "Highlights integration and automation practices that reinforce Architecture as Code workflows.",
+      "supports_chapters": [
+        "02_fundamental_principles.md",
+        "11_governance_as_code.md"
+      ]
+    },
+    {
+      "id": 12,
+      "title": "FINOS \u2013 CALM: Common Architecture Language Model.",
+      "type": "industry_initiative",
+      "year": 2024,
+      "url": "https://calm.finos.org/",
+      "summary": "Outlines an industry-backed meta-model that complements the book's modelling recommendations.",
+      "supports_chapters": [
+        "22_documentation_vs_architecture.md"
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Thoughtworks Technology Radar \u2013 Governance as Code.",
+      "type": "industry_analysis",
+      "year": 2024,
+      "url": "https://www.thoughtworks.com/radar/techniques/governance-as-code",
+      "summary": "Positions governance automation as a mainstream technique and supports the governance-focused chapters.",
+      "supports_chapters": [
+        "11_governance_as_code.md"
+      ]
+    },
+    {
+      "id": 14,
+      "title": "MarketsandMarkets \u2013 Infrastructure as Code Market Report.",
+      "type": "industry_research",
+      "year": 2023,
+      "url": "https://www.marketsandmarkets.com/PressReleases/infrastructure-as-code.asp",
+      "summary": "Quantifies Infrastructure as Code market growth, underpinning economic arguments in cost optimisation.",
+      "supports_chapters": [
+        "15_cost_optimization.md",
+        "25_future_trends_development.md"
+      ]
+    },
+    {
+      "id": 15,
+      "title": "IDC \u2013 Worldwide DevOps Software Tools Forecast, 2023\u20132027.",
+      "type": "industry_research",
+      "year": 2023,
+      "url": "https://www.idc.com/getdoc.jsp?containerId=US50951123",
+      "summary": "Examines toolchain investment trends that influence automation strategy guidance.",
+      "supports_chapters": [
+        "05_automation_devops_cicd.md",
+        "21_digitalization.md"
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Google Cloud \u2013 Store Terraform state in Cloud Storage.",
+      "type": "technical_documentation",
+      "year": 2024,
+      "url": "https://cloud.google.com/docs/terraform/resource-management/store-terraform-state",
+      "summary": "Details secure state management controls referenced in the security-focused chapters.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a curated Issues/ directory with README guidance and four ready-to-use issue templates
- define a source catalogue covering IDs 1-16 with metadata and chapter mappings
- ensure templates reference catalogue sources and chapters for alignment with references

## Testing
- pytest tests/test_issue_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68fcca059a308330a00a20be6fc12622