### PR TITLE
Add curated issue catalogue for Architecture as Code templates

### DIFF
--- a/Issues/README.md
+++ b/Issues/README.md
@@ -1,0 +1,18 @@
+# Curated Issue Catalogue
+
+This directory contains pre-drafted GitHub Issues that align with the Architecture as Code roadmap. Each template references approved research sources and key chapters to accelerate backlog curation whilst preserving academic rigour.
+
+## Available Issue Templates
+
+- [issue_001_documentation_alignment.md](issue_001_documentation_alignment.md) — Embed documentation-as-code workflows and ADR guidance.
+- [issue_002_structurizr_enablement.md](issue_002_structurizr_enablement.md) — Strengthen Structurizr adoption and diagram governance.
+- [issue_003_policy_alignment.md](issue_003_policy_alignment.md) — Harmonise policy as code practices across delivery platforms.
+- [issue_004_testing_and_state_resilience.md](issue_004_testing_and_state_resilience.md) — Reinforce testing discipline and Terraform state resilience.
+
+## Using the Templates
+
+1. Copy the relevant markdown file into a new GitHub Issue, keeping the headings intact.
+2. Tailor the problem statement and acceptance criteria to your context whilst retaining cited Source IDs.
+3. Apply the recommended labels so automation bots trigger the appropriate workflows described in the repository.
+
+Maintaining consistency between these templates, the source catalogue, and the references chapter ensures every Issue maintains traceable provenance.

--- a/Issues/issue_001_documentation_alignment.md
+++ b/Issues/issue_001_documentation_alignment.md
@@ -1,0 +1,25 @@
+# Issue: Align Documentation Workflows with Architecture as Code
+
+## Source IDs
+- [1]
+- [2]
+- [3]
+- [10]
+
+## Relevant Manuscript Sections
+- Chapter 02: Fundamental Principles (`docs/02_fundamental_principles.md`)
+- Chapter 03: Version Control (`docs/03_version_control.md`)
+- Chapter 22: Documentation vs Architecture (`docs/22_documentation_vs_architecture.md`)
+
+## Problem Statement
+Architecture contributors rely on a mixture of wikis and ad-hoc notes, which undermines traceability for decision records and documentation updates. The book advocates managing documentation alongside architecture artefacts, yet the repository lacks an integrated workflow and templates to make this practical for contributors.
+
+## Acceptance Criteria
+- ADR templates and contribution guidelines reference a shared documentation workflow using Git-based reviews.
+- Automation linting ensures markdown contributions follow the agreed conventions for headings and link formats.
+- Version control guidance explicitly points to documentation-as-code examples that reflect the book's recommendations.
+
+## Recommended Labels
+- `documentation`
+- `architecture`
+- `dev`

--- a/Issues/issue_002_structurizr_enablement.md
+++ b/Issues/issue_002_structurizr_enablement.md
@@ -1,0 +1,26 @@
+# Issue: Strengthen Structurizr Enablement for Architecture Teams
+
+## Source IDs
+- [4]
+- [5]
+- [6]
+- [8]
+- [9]
+
+## Relevant Manuscript Sections
+- Chapter 06: Structurizr and Diagram Automation (`docs/06_structurizr.md`)
+- Chapter 24: Best Practices (`docs/24_best_practices.md`)
+- Chapter 31: Technical Architecture (`docs/31_technical_architecture.md`)
+
+## Problem Statement
+Teams struggle to apply Structurizr effectively, leading to inconsistent diagram styles and duplication of effort across programmes. The manuscript highlights how the C4 model and Structurizr tooling underpin maintainable diagrams, yet the repository lacks onboarding material and shared viewpoints to make adoption straightforward.
+
+## Acceptance Criteria
+- Provide a curated Structurizr workspace example aligned to the C4 abstractions referenced in the book.
+- Document the contribution process for updating diagrams, including review expectations and automation steps.
+- Publish guidance on applying evolutionary architecture fitness functions to ongoing diagram updates.
+
+## Recommended Labels
+- `architecture`
+- `design`
+- `documentation`

--- a/Issues/issue_003_policy_alignment.md
+++ b/Issues/issue_003_policy_alignment.md
@@ -1,0 +1,27 @@
+# Issue: Align Policy as Code Guidance Across Platforms
+
+## Source IDs
+- [7]
+- [11]
+- [12]
+- [13]
+- [14]
+
+## Relevant Manuscript Sections
+- Chapter 09a: Security Fundamentals (`docs/09a_security_fundamentals.md`)
+- Chapter 10: Policy and Security Automation (`docs/10_policy_and_security.md`)
+- Chapter 11: Governance as Code (`docs/11_governance_as_code.md`)
+- Chapter 23: Software as Code Interplay (`docs/23_soft_as_code_interplay.md`)
+
+## Problem Statement
+Platform teams manage multiple policy engines—Sentinel, OPA, and bespoke scripts—without a unifying governance standard. The book positions policy as code as an essential discipline for secure operations, but the repository does not yet include comparative guidance or reusable controls to harmonise approaches.
+
+## Acceptance Criteria
+- Produce a cross-platform policy guide summarising shared controls and how they surface in Terraform, Kubernetes, and application pipelines.
+- Provide reference implementations demonstrating GitLab-driven compliance automation informed by the highlighted research.
+- Update governance chapters with links to living policy catalogues and escalation workflows maintained in the repository.
+
+## Recommended Labels
+- `architecture`
+- `security`
+- `dev`

--- a/Issues/issue_004_testing_and_state_resilience.md
+++ b/Issues/issue_004_testing_and_state_resilience.md
@@ -1,0 +1,23 @@
+# Issue: Improve Testing and State Resilience for Infrastructure Pipelines
+
+## Source IDs
+- [15]
+- [16]
+
+## Relevant Manuscript Sections
+- Chapter 09a: Security Fundamentals (`docs/09a_security_fundamentals.md`)
+- Chapter 13: Testing Strategies (`docs/13_testing_strategies.md`)
+- Chapter 14: Practical Implementation (`docs/14_practical_implementation.md`)
+
+## Problem Statement
+Current infrastructure pipelines apply limited automated testing and do not enforce robust handling for Terraform state files. The cited sources stress the need for comprehensive validation and hardened state management, yet the repository lacks example suites or documentation for these practices.
+
+## Acceptance Criteria
+- Introduce automated test scaffolding for IaC projects that mirrors Pulumi and Terraform guidance from the sources.
+- Document encryption and remote backend configuration patterns for Terraform state, including monitoring and alerting steps.
+- Provide a resilience checklist for infrastructure changes covering tests, state recovery, and rollback readiness.
+
+## Recommended Labels
+- `architecture`
+- `dev`
+- `qa`

--- a/Issues/source_catalogue.json
+++ b/Issues/source_catalogue.json
@@ -1,0 +1,196 @@
+{
+  "sources": [
+    {
+      "id": 1,
+      "title": "Architecture Decision Records Community – ADR Guidelines and Templates",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://adr.github.io",
+      "summary": "Community maintained guide describing patterns for documenting architecture decisions using ADRs.",
+      "supports_chapters": [
+        "04_adr.md",
+        "24_best_practices.md"
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Atlassian – Documentation as Code: Treating Docs as a First-Class Citizen",
+      "type": "Article",
+      "year": 2023,
+      "url": "https://developer.atlassian.com/platform/forge/documentation-as-code",
+      "summary": "Explores how teams can manage documentation alongside code to improve transparency and collaboration.",
+      "supports_chapters": [
+        "02_fundamental_principles.md",
+        "22_documentation_vs_architecture.md"
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Atlassian – Git Workflows for Architecture as Code",
+      "type": "Guide",
+      "year": 2024,
+      "url": "https://www.atlassian.com/git/tutorials/comparing-workflows",
+      "summary": "Guidance on applying established Git workflows to collaborative architecture repositories.",
+      "supports_chapters": [
+        "03_version_control.md",
+        "19_management_as_code.md"
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Brown, S. – C4 Model Overview",
+      "type": "Website",
+      "year": 2024,
+      "url": "https://c4model.com/",
+      "summary": "Introduces the C4 model for visualising software architecture across multiple abstraction levels.",
+      "supports_chapters": [
+        "06_structurizr.md",
+        "24_best_practices.md"
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Brown, S. – Documenting Software Architecture with Structurizr",
+      "type": "Article",
+      "year": 2022,
+      "url": "https://structurizr.com/help/documenting-software-architecture",
+      "summary": "Explains how Structurizr supports living architecture diagrams and collaborative modelling.",
+      "supports_chapters": [
+        "06_structurizr.md",
+        "31_technical_architecture.md"
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Brown, S. – Software Architecture for Developers",
+      "type": "Book",
+      "year": 2024,
+      "url": "https://leanpub.com/software-architecture-for-developers",
+      "summary": "Comprehensive treatment of software architecture foundations with modern tooling guidance.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "06_structurizr.md"
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Cloud Native Computing Foundation – State of Cloud Native Development 2024",
+      "type": "Report",
+      "year": 2024,
+      "url": "https://www.cncf.io/reports/state-of-cloud-native-development-2024/",
+      "summary": "Industry research on adoption trends for cloud native technologies and operating models.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "07_containerization.md"
+      ]
+    },
+    {
+      "id": 8,
+      "title": "FINOS – CALM: Common Architecture Language Model",
+      "type": "Website",
+      "year": 2024,
+      "url": "https://calm.finos.org/",
+      "summary": "Outlines the CALM initiative enabling financial services firms to describe architectures consistently.",
+      "supports_chapters": [
+        "22_documentation_vs_architecture.md",
+        "31_technical_architecture.md"
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Ford, Neal et al. – Building Evolutionary Architectures",
+      "type": "Book",
+      "year": 2017,
+      "url": "https://www.thoughtworks.com/books/building-evolutionary-architectures",
+      "summary": "Establishes the principles of evolutionary architecture and fitness functions for continuous change.",
+      "supports_chapters": [
+        "02_fundamental_principles.md",
+        "24_best_practices.md"
+      ]
+    },
+    {
+      "id": 10,
+      "title": "GitLab – Documentation as Code: Best Practices and Implementation",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://about.gitlab.com/handbook/engineering/ux/technical-writing/documentation-as-code/",
+      "summary": "Discusses how GitLab applies documentation as code techniques across distributed teams.",
+      "supports_chapters": [
+        "02_fundamental_principles.md",
+        "22_documentation_vs_architecture.md"
+      ]
+    },
+    {
+      "id": 11,
+      "title": "GitLab – Building a Single Source of Truth with APIs and CLI",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://about.gitlab.com/topics/devops/single-source-of-truth/",
+      "summary": "Describes how automation pipelines integrate APIs and CLIs to maintain accurate operational data.",
+      "supports_chapters": [
+        "11_governance_as_code.md",
+        "21_digitalization.md"
+      ]
+    },
+    {
+      "id": 12,
+      "title": "HashiCorp – Policy as Code Overview",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://developer.hashicorp.com/terraform/enterprise/policy-as-code",
+      "summary": "Summarises the concepts behind policy as code within Terraform Enterprise and Sentinel.",
+      "supports_chapters": [
+        "10_policy_and_security.md",
+        "23_soft_as_code_interplay.md"
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Open Policy Agent – Policy as Code: Expressing Requirements as Code",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://www.openpolicyagent.org/docs/latest/",
+      "summary": "Explains how Open Policy Agent enables declarative enforcement of organisational policies.",
+      "supports_chapters": [
+        "11_governance_as_code.md",
+        "23_soft_as_code_interplay.md"
+      ]
+    },
+    {
+      "id": 14,
+      "title": "ThoughtWorks – Architecture as Code: The Next Evolution",
+      "type": "Report",
+      "year": 2024,
+      "url": "https://www.thoughtworks.com/insights/articles/architecture-as-code-next-evolution",
+      "summary": "Highlights emerging practices for treating architectural knowledge as versioned, automated artefacts.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "29_about_the_authors.md"
+      ]
+    },
+    {
+      "id": 15,
+      "title": "Pulumi – Testing Infrastructure as Code Programs",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://www.pulumi.com/blog/testing-infrastructure-as-code-programs/",
+      "summary": "Provides patterns for unit and integration testing Pulumi infrastructure programs.",
+      "supports_chapters": [
+        "13_testing_strategies.md",
+        "14_practical_implementation.md"
+      ]
+    },
+    {
+      "id": 16,
+      "title": "HashiCorp – Securing Terraform State",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://developer.hashicorp.com/terraform/cloud-docs/state/securing",
+      "summary": "Details practices for protecting Terraform state, including encryption and remote backends.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a curated Issues directory with markdown templates tied to Architecture as Code chapters
- capture supporting references in a source catalogue so each template cites approved research

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fce68dc9a0833091340d16686bebc5