### PR TITLE
Add curated issue backlog and source catalogue

### DIFF
--- a/Issues/README.md
+++ b/Issues/README.md
@@ -1,0 +1,14 @@
+# Architecture as Code Issue Catalogue
+
+This directory curates ready-to-use GitHub issues that translate the book's guidance into actionable backlog items. Each issue references validated sources, links to the relevant manuscript chapters, and proposes labels to streamline triage.
+
+## Issue Templates
+- [issue_01_governance_and_security_alignment.md](issue_01_governance_and_security_alignment.md) – Establish cross-cloud governance, policy-as-code, and secure state backends.
+- [issue_02_diagram_automation_enhancement.md](issue_02_diagram_automation_enhancement.md) – Automate Structurizr workflows and enforce diagram-review quality gates.
+- [issue_03_documentation_and_adr_alignment.md](issue_03_documentation_and_adr_alignment.md) – Align ADR processes with documentation-as-code practices.
+- [issue_04_testing_and_delivery_quality.md](issue_04_testing_and_delivery_quality.md) – Build comprehensive infrastructure testing pipelines and runbooks.
+
+## Maintaining the Catalogue
+- Keep `source_catalogue.json` updated whenever new authoritative references are added to docs/33_references.md.
+- Ensure every issue template lists one or more Source IDs and that, in aggregate, the set covers every defined source.
+- When adding a new issue file, update this README so the listing matches the files present in the directory.

--- a/Issues/issue_01_governance_and_security_alignment.md
+++ b/Issues/issue_01_governance_and_security_alignment.md
@@ -1,0 +1,33 @@
+# Governance and Security Controls as Code Backlog
+
+## Source IDs
+- [1] ThoughtWorks. "Architecture as Code: The Next Evolution." Technology Radar, 2024.
+- [2] Cloud Native Computing Foundation. "State of Cloud Native Development 2024." Cloud Native Computing Foundation, 2024.
+- [6] HashiCorp. "Terraform Security Best Practices." HashiCorp Learning Resources, 2023.
+- [9] Google Cloud. "Store Terraform state in Cloud Storage." Google Cloud Documentation, 2024.
+- [10] Microsoft Learn. "Store Terraform state in Azure Storage." Microsoft Learn Documentation, 2024.
+- [11] HashiCorp. "Securing Terraform State." HashiCorp Developer Documentation, 2024.
+- [12] HashiCorp. "Backend Type: s3." HashiCorp Developer Documentation, 2024.
+- [13] Open Policy Agent. "Policy as Code Overview." https://www.openpolicyagent.org/docs/latest/
+- [14] Thoughtworks Technology Radar. "Governance as Code." https://www.thoughtworks.com/radar/techniques/governance-as-code
+
+## Relevant Manuscript Sections
+- docs/09a_security_fundamentals.md
+- docs/09b_security_patterns.md
+- docs/11_governance_as_code.md
+- docs/23_soft_as_code_interplay.md
+
+## Problem Statement
+Chapters covering governance and state management outline strong conceptual principles but lack actionable issue templates for backlog management. Without curated issues, delivery teams struggle to translate guidance on policy-as-code, secure state backends, and cross-cloud guardrails into iterative work. This gap prevents consistent adoption of the controls described in the manuscript.
+
+## Acceptance Criteria
+- A cross-cloud backlog that sequences the implementation of secure Terraform state storage for AWS, Azure, and Google Cloud, each with policy-as-code validation gates.
+- Acceptance tests defined for each work item to confirm encryption, role separation, and automated policy evaluation are in place.
+- Documentation tasks identified so that updated governance runbooks reference the live policy-as-code artefacts.
+- Measurement of governance coverage captured as Definition of Done notes to maintain transparency for auditors and platform stakeholders.
+
+## Recommended Labels
+- area:governance
+- area:security
+- enhancement
+- good first issue

--- a/Issues/issue_02_diagram_automation_enhancement.md
+++ b/Issues/issue_02_diagram_automation_enhancement.md
@@ -1,0 +1,26 @@
+# Structurizr and Diagram Automation Enhancements
+
+## Source IDs
+- [2] Cloud Native Computing Foundation. "State of Cloud Native Development 2024." Cloud Native Computing Foundation, 2024.
+- [3] Martin, R. "Clean Architecture: A Craftsman's Guide to Software Structure." Prentice Hall, 2017.
+- [15] Structurizr. "Structurizr DSL Language Reference." Structurizr Documentation, 2024.
+
+## Relevant Manuscript Sections
+- docs/06_structurizr.md
+- docs/22_documentation_vs_architecture.md
+- docs/24_best_practices.md
+
+## Problem Statement
+The Structurizr automation chapter explains the rationale for diagrams as code but lacks an incremental roadmap for automating reviews, publishing rendered assets, and keeping diagram context synchronised with ADRs. Teams therefore fall back to manual exports, which undermines the consistency expected by the manuscript's workflow guidance.
+
+## Acceptance Criteria
+- Automated pipeline steps render Structurizr diagrams on pull requests and attach the resulting PNG artefacts to build outputs.
+- Diagram definitions link to canonical ADR identifiers, ensuring reviewers can cross-reference structural decisions quickly.
+- Documentation explains how to regenerate diagrams locally with a single command, including troubleshooting steps for common platform tooling.
+- Quality checks prevent merging changes when diagrams and markdown representations drift.
+
+## Recommended Labels
+- area:automation
+- area:documentation
+- enhancement
+- needs research

--- a/Issues/issue_03_documentation_and_adr_alignment.md
+++ b/Issues/issue_03_documentation_and_adr_alignment.md
@@ -1,0 +1,27 @@
+# Documentation and ADR Alignment Improvements
+
+## Source IDs
+- [1] ThoughtWorks. "Architecture as Code: The Next Evolution." Technology Radar, 2024.
+- [4] Atlassian. "Documentation as Code: Treating Docs as a First-Class Citizen." Atlassian Developer, 2023.
+- [5] GitLab. "Documentation as Code: Best Practices and Implementation." GitLab Documentation, 2024.
+- [16] Architecture Decision Records Community. "ADR Guidelines and Templates." https://adr.github.io
+
+## Relevant Manuscript Sections
+- docs/02_fundamental_principles.md
+- docs/04_adr.md
+- docs/22_documentation_vs_architecture.md
+
+## Problem Statement
+Although the manuscript promotes documentation as code disciplines, there is no explicit backlog to align ADR workflows with the documentation automation pipeline. Contributors frequently capture decisions without linking them to the structured content strategy, leading to discoverability issues and fragmented review discussions.
+
+## Acceptance Criteria
+- ADR templates updated to include required metadata for linking to chapters, diagrams, and backlog items.
+- Continuous integration checks confirming that every ADR referenced in the manuscript exists in the repository with validated front matter.
+- Contribution guidelines refreshed so new ADRs automatically feed into the documentation site navigation and changelog process.
+- Example ADR migration plan created to demonstrate how legacy decisions will be imported into the new format.
+
+## Recommended Labels
+- area:documentation
+- area:process
+- enhancement
+- help wanted

--- a/Issues/issue_04_testing_and_delivery_quality.md
+++ b/Issues/issue_04_testing_and_delivery_quality.md
@@ -1,0 +1,26 @@
+# Testing and Delivery Quality Improvements
+
+## Source IDs
+- [2] Cloud Native Computing Foundation. "State of Cloud Native Development 2024." Cloud Native Computing Foundation, 2024.
+- [7] Pulumi. "Testing Infrastructure as Code Programs." Pulumi Blog, 2024.
+- [8] AWS. "AWS Cloud Development Kit (CDK) Developer Guide." https://docs.aws.amazon.com/cdk/latest/guide/home.html
+
+## Relevant Manuscript Sections
+- docs/05_automation_devops_cicd.md
+- docs/13_testing_strategies.md
+- docs/14_practical_implementation.md
+
+## Problem Statement
+The automation chapters advocate for continuous testing of infrastructure definitions, yet the repository lacks a sequenced set of issues to build and maintain those safeguards. Without this backlog, teams risk regressions in deployment pipelines, insufficient coverage of IaC unit tests, and limited visibility of platform quality metrics.
+
+## Acceptance Criteria
+- Automated test harness created for representative Terraform, Pulumi, and CDK modules referenced in the manuscript.
+- Continuous integration jobs execute the harness on every pull request and publish results as part of the book's artefact exports.
+- Testing documentation outlines the minimum expected coverage for infrastructure modules and explains how to extend scenarios.
+- Runbooks include guidance for triaging failing infrastructure tests, ensuring operations teams can respond within agreed service levels.
+
+## Recommended Labels
+- area:automation
+- area:quality
+- enhancement
+- needs discussion

--- a/Issues/source_catalogue.json
+++ b/Issues/source_catalogue.json
@@ -1,0 +1,193 @@
+{
+  "sources": [
+    {
+      "id": 1,
+      "title": "**ThoughtWorks.** \"Architecture as Code: The Next Evolution.\" Technology Radar, 2024.",
+      "type": "Industry report",
+      "year": 2024,
+      "url": "https://www.thoughtworks.com/radar/techniques/architecture-as-code",
+      "summary": "ThoughtWorks highlights architecture as code as a maturing discipline and outlines the organisational enablers required for adoption.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "02_fundamental_principles.md",
+        "29_about_the_authors.md"
+      ]
+    },
+    {
+      "id": 2,
+      "title": "**Cloud Native Computing Foundation.** \"State of Cloud Native Development 2024.\" Cloud Native Computing Foundation, 2024.",
+      "type": "Industry report",
+      "year": 2024,
+      "url": "https://www.cncf.io/reports/state-of-cloud-native-development-2024/",
+      "summary": "Annual assessment of cloud native trends, including infrastructure automation and platform engineering capabilities.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "07_containerization.md"
+      ]
+    },
+    {
+      "id": 3,
+      "title": "**Martin, R.** \"Clean Architecture: A Craftsman's Guide to Software Structure.\" Prentice Hall, 2017.",
+      "type": "Book",
+      "year": 2017,
+      "url": "https://www.pearson.com/en-gb/subject-catalog/p/clean-architecture/P200000003792/9780134494272",
+      "summary": "Foundational text describing component cohesion, coupling, and architectural boundaries for resilient systems.",
+      "supports_chapters": [
+        "01_introduction.md",
+        "02_fundamental_principles.md"
+      ]
+    },
+    {
+      "id": 4,
+      "title": "**Atlassian.** \"Documentation as Code: Treating Docs as a First-Class Citizen.\" Atlassian Developer, 2023.",
+      "type": "Article",
+      "year": 2023,
+      "url": "https://developer.atlassian.com/platform/marketplace/documentation-as-code/",
+      "summary": "Explores how treating documentation as code improves traceability, review quality, and collaboration workflows.",
+      "supports_chapters": [
+        "02_fundamental_principles.md"
+      ]
+    },
+    {
+      "id": 5,
+      "title": "**GitLab.** \"Documentation as Code: Best Practices and Implementation.\" GitLab Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://docs.gitlab.com/ee/user/project/repository/documentation/",
+      "summary": "Guidance on building documentation pipelines that align with code review and continuous delivery practices.",
+      "supports_chapters": [
+        "02_fundamental_principles.md"
+      ]
+    },
+    {
+      "id": 6,
+      "title": "**HashiCorp.** \"Terraform Security Best Practices.\" HashiCorp Learning Resources, 2023.",
+      "type": "Documentation",
+      "year": 2023,
+      "url": "https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices/security",
+      "summary": "Recommends patterns for protecting Terraform state, credentials, and execution environments in regulated settings.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    },
+    {
+      "id": 7,
+      "title": "**Pulumi.** \"Testing Infrastructure as Code Programs.\" Pulumi Blog, 2024.",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://www.pulumi.com/blog/testing-infrastructure-as-code/",
+      "summary": "Outlines automated testing strategies for infrastructure as code programmes, spanning unit and integration coverage.",
+      "supports_chapters": [
+        "13_testing_strategies.md",
+        "14_practical_implementation.md"
+      ]
+    },
+    {
+      "id": 8,
+      "title": "**AWS.** \"AWS Cloud Development Kit (CDK) Developer Guide.\" https://docs.aws.amazon.com/cdk/latest/guide/home.html",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://docs.aws.amazon.com/cdk/latest/guide/home.html",
+      "summary": "Comprehensive reference for modelling cloud infrastructure in code using the AWS CDK framework.",
+      "supports_chapters": [
+        "05_automation_devops_cicd.md",
+        "14_practical_implementation.md"
+      ]
+    },
+    {
+      "id": 9,
+      "title": "**Google Cloud.** \"Store Terraform state in Cloud Storage.\" Google Cloud Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://cloud.google.com/docs/terraform/resource-management/store-terraform-state",
+      "summary": "Describes Google Cloud storage backends for Terraform state management with security controls and automation hooks.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    },
+    {
+      "id": 10,
+      "title": "**Microsoft Learn.** \"Store Terraform state in Azure Storage.\" Microsoft Learn Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://learn.microsoft.com/en-gb/azure/developer/terraform/store-state-in-azure-storage",
+      "summary": "Provides guidance for storing Terraform state securely in Azure storage accounts and integrating with pipelines.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    },
+    {
+      "id": 11,
+      "title": "**HashiCorp.** \"Securing Terraform State.\" HashiCorp Developer Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://developer.hashicorp.com/terraform/cloud-docs/state/securing",
+      "summary": "Details encryption, role separation, and policy guardrails for Terraform state stored in Terraform Cloud.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    },
+    {
+      "id": 12,
+      "title": "**HashiCorp.** \"Backend Type: s3.\" HashiCorp Developer Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://developer.hashicorp.com/terraform/language/settings/backends/s3",
+      "summary": "Explains how to configure and harden the S3 backend for Terraform state in multi-team deployments.",
+      "supports_chapters": [
+        "09a_security_fundamentals.md",
+        "09b_security_patterns.md"
+      ]
+    },
+    {
+      "id": 13,
+      "title": "**Open Policy Agent.** \"Policy as Code Overview.\" https://www.openpolicyagent.org/docs/latest/",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://www.openpolicyagent.org/docs/latest/",
+      "summary": "Summarises how to codify governance controls using OPA and integrate Rego policies into delivery pipelines.",
+      "supports_chapters": [
+        "11_governance_as_code.md",
+        "23_soft_as_code_interplay.md"
+      ]
+    },
+    {
+      "id": 14,
+      "title": "**Thoughtworks Technology Radar.** \"Governance as Code.\" https://www.thoughtworks.com/radar/techniques/governance-as-code",
+      "type": "Article",
+      "year": 2024,
+      "url": "https://www.thoughtworks.com/radar/techniques/governance-as-code",
+      "summary": "Discusses how governance as code accelerates compliance whilst maintaining developer autonomy.",
+      "supports_chapters": [
+        "11_governance_as_code.md"
+      ]
+    },
+    {
+      "id": 15,
+      "title": "**Structurizr.** \"Structurizr DSL Language Reference.\" Structurizr Documentation, 2024.",
+      "type": "Documentation",
+      "year": 2024,
+      "url": "https://github.com/structurizr/dsl",
+      "summary": "Reference for modelling systems using the Structurizr DSL and automating diagram generation.",
+      "supports_chapters": [
+        "06_structurizr.md",
+        "22_documentation_vs_architecture.md"
+      ]
+    },
+    {
+      "id": 16,
+      "title": "**Architecture Decision Records Community.** \"ADR Guidelines and Templates.\" https://adr.github.io",
+      "type": "Guidelines",
+      "year": 2024,
+      "url": "https://adr.github.io",
+      "summary": "Provides standardised templates and best practice advice for capturing architecture decision records.",
+      "supports_chapters": [
+        "04_adr.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a curated Issues/README index describing the new backlog templates
- provide four issue templates covering governance, documentation, diagrams, and infrastructure testing with British English copy
- define Issues/source_catalogue.json with 16 referenced sources aligned to docs/33_references.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fce707d238833091805e5ab4764a83