### PR TITLE
Fix Picnic radio styling on maturity model form

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -65,11 +65,13 @@
     .question .options label {
       display: inline-flex;
       align-items: center;
+      gap: 0.5rem;
       font-weight: 400;
+      cursor: pointer;
     }
 
-    .question .options input {
-      margin-right: 0.375rem;
+    .question .options label .checkable {
+      margin: 0;
     }
 
     button {
@@ -311,9 +313,15 @@
       input.value = value;
       input.id = id;
       input.required = true;
+
+      const indicator = document.createElement("span");
+      indicator.className = "checkable";
+      indicator.textContent = labelText;
+
       label.setAttribute("for", id);
       label.appendChild(input);
-      label.appendChild(document.createTextNode(` ${labelText}`));
+      label.appendChild(indicator);
+
       return label;
     }
 


### PR DESCRIPTION
## Summary
- add Picnic-compatible checkable elements to the maturity radar radio buttons so clicks register visually
- tweak the option label styling to keep spacing while maintaining pointer cues

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fdb2986bec83308e4dd3e1b83e4fd3