### PR TITLE
Fix Mermaid radar diagram syntax

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -398,12 +398,15 @@
 
     function buildRadarDefinition(results, maxQuestions) {
       const labels = results.map((result) => result.aspectName);
-      const dataPoints = results.map((result) => result.yesCount);
+      const dataPoints = results.map((result) => result.yesCount ?? 0);
       const maxScale = Math.max(maxQuestions, 5);
 
-      return `radar\n  title Architecture as Code Maturity Snapshot\n  x-axis ${JSON.stringify(
-        labels
-      )}\n  y-axis 0 --> ${maxScale}\n  dataset\n    label: Current assessment\n    data: ${JSON.stringify(dataPoints)}`;
+      const escapedLabels = labels.map((label) =>
+        `"${label.replace(/"/g, '\\"')}"`
+      );
+      const dataSeries = dataPoints.join(", ");
+
+      return `radar\n  title Architecture as Code Maturity Snapshot\n  x-axis ${escapedLabels.join(", ")}\n  y-axis 0 --> ${maxScale}\n  dataset\n    label: Current assessment\n    data: ${dataSeries}`;
     }
 
     function renderRadar(definition) {


### PR DESCRIPTION
## Summary
- adjust the generated radar definition so Mermaid receives comma-separated labels and values
- escape label text and normalise empty scores to avoid syntax errors in the diagram renderer

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdb78f57bc8330ab9ab55fa0b91977