### PR TITLE
Fix Mermaid radar syntax for maturity snapshot

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -938,9 +938,10 @@
       const escapedLabels = labels.map((label) =>
         `"${label.replace(/"/g, '\\"')}"`
       );
+      const axisValues = escapedLabels.join(", ");
       const dataSeries = dataPoints.join(", ");
 
-      return `radar\n  title Architecture as Code Maturity Snapshot\n  x-axis ${escapedLabels.join(", ")}\n  y-axis 0 --> ${maxScale}\n  dataset\n    label: Current assessment\n    data: ${dataSeries}`;
+      return `radar\n  title Architecture as Code Maturity Snapshot\n  x-axis [${axisValues}]\n  y-axis [0, ${maxScale}]\n  dataset\n    title: Current assessment\n    data: [${dataSeries}]`;
     }
 
     async function renderRadar(definition) {


### PR DESCRIPTION
## Summary
- ensure the generated Mermaid radar chart uses bracketed axes and dataset syntax that matches current Mermaid expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fddbbd82f08330b406fc5a320fcdf8