### PR TITLE
Update maturity model radar page to Mermaid 11.3.0

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -188,7 +188,7 @@
       }
     }
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.min.js"></script>
   <script>
     mermaid.initialize({ startOnLoad: false });
 


### PR DESCRIPTION
## Summary
- bump the Mermaid CDN reference on the maturity model radar HTML page to v11.3.0 so the radar syntax matches the stable release

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: pandoc: architecture_as_code_model.md: withBinaryFile: does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fde71582048330beffc870f04e8b21