### PR TITLE
Enable Mermaid radar diagrams on maturity model page

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -188,9 +188,24 @@
       }
     }
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.min.js"></script>
-  <script>
-    mermaid.initialize({ startOnLoad: false });
+  <script type="module">
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs";
+
+    const radarDiagramModuleUrl =
+      "https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/diagrams/radarDiagram-definition.esm.min.mjs";
+
+    mermaid.initialize({
+      startOnLoad: false,
+      diagramLoader: async (type) => {
+        if (type === "radar") {
+          return import(radarDiagramModuleUrl);
+        }
+
+        throw new Error(`Diagram type ${type} is not supported by this loader.`);
+      }
+    });
+
+    window.mermaid = mermaid;
 
     const aspects = [
       {


### PR DESCRIPTION
## Summary
- load Mermaid as an ES module so the radar diagram definition can be imported on demand
- register the radar diagram loader and expose the Mermaid instance globally for the existing renderer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fde8f2ed788330be77457400560cf2