### PR TITLE
Enable Mermaid radar diagrams on the documentation site

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,35 @@
+(function initialiseMermaid() {
+  if (window.mermaidReady) {
+    return;
+  }
+
+  const mermaidVersion = "11.3.0";
+  const mermaidSource = `https://cdn.jsdelivr.net/npm/mermaid@${mermaidVersion}/dist/mermaid.esm.min.mjs`;
+  const radarModuleSource = `https://cdn.jsdelivr.net/npm/mermaid@${mermaidVersion}/dist/diagrams/radarDiagram-definition.esm.min.mjs`;
+
+  window.mermaidReady = (async () => {
+    try {
+      const module = await import(mermaidSource);
+      const mermaid = module?.default ?? module;
+
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: "default",
+        securityLevel: "loose",
+        diagramLoader: async (type) => {
+          if (type === "radar") {
+            return import(radarModuleSource);
+          }
+
+          return undefined;
+        }
+      });
+
+      window.mermaid = mermaid;
+      return mermaid;
+    } catch (error) {
+      console.error("Mermaid initialisation failed", error);
+      throw error;
+    }
+  })();
+})();

--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -188,31 +188,26 @@
       }
     }
   </style>
-  <script type="module">
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs";
-
-    const radarDiagramModuleUrl =
-      "https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/diagrams/radarDiagram-definition.esm.min.mjs";
-
-    mermaid.initialize({
-      startOnLoad: false,
-      diagramLoader: async (type) => {
-        if (type === "radar") {
-          return import(radarDiagramModuleUrl);
+  <script>
+    (async () => {
+      let mermaid;
+      try {
+        if (window.mermaidReady && typeof window.mermaidReady.then === "function") {
+          mermaid = await window.mermaidReady;
+        } else if (window.mermaid) {
+          mermaid = window.mermaid;
         }
-
-        if (type === "radar-beta") {
-          // Allow Mermaid to fall back to the built-in legacy loader.
-          return undefined;
-        }
-
-        throw new Error(`Diagram type ${type} is not supported by this loader.`);
+      } catch (error) {
+        console.error("Unable to prepare Mermaid for the radar visualisation", error);
+        return;
       }
-    });
 
-    window.mermaid = mermaid;
+      if (!mermaid) {
+        console.error("Mermaid is unavailable, so the radar visualisation cannot be rendered.");
+        return;
+      }
 
-    const aspects = [
+      const aspects = [
       {
         key: "iac",
         name: "Infrastructure as code (IaC)",
@@ -1330,6 +1325,7 @@
       const { detailedResults, resultPayload } = calculateResults(form);
       updateOutputs(detailedResults, resultPayload);
     }
+    })();
   </script>
 </head>
 <body>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,3 +59,5 @@ markdown_extensions:
   - tables
 extra_css:
   - stylesheets/code-dark.css
+extra_javascript:
+  - javascripts/mermaid-init.js


### PR DESCRIPTION
## Summary
- add an asynchronous Mermaid initialisation script that imports the modular radar diagram definition
- configure MkDocs to load the shared initialisation so Mermaid 11 renders radar charts across the site
- update the maturity model radar page to wait for the shared Mermaid setup before generating the diagram

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fdf0818a0c8330aad16aa515fed451