### PR TITLE
Fix maturity model appendix navigation and link to radar

### DIFF
--- a/docs/architecture_as_code_maturity_model.md
+++ b/docs/architecture_as_code_maturity_model.md
@@ -9,6 +9,10 @@ they use machine-readable formats, live in version control and are automatically
 This maturity model synthesises those insights into staged levels of adoption.
 It recognises that organisations progress from ad-hoc scripting and isolated diagrams to integrated, self-optimising systems that manage compliance, governance and knowledge via code.
 
+## Interactive radar assessment
+
+For an interactive experience that mirrors the full questionnaire and generates a downloadable radar chart, use the [Architecture as Code maturity radar tool](maturity_model_radar.html). The tool captures every checklist question from this appendix, visualises the current capabilities and produces prioritised improvement guidance that can be shared across teams.
+
 ## Staircase overview of maturity progression
 
 ![Architecture as Code maturity staircase highlighting Levels 0 to 5](images/diagram_32_maturity_model.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,8 @@ nav:
       - Appendix A – Code Examples and Technical Implementations: 30_appendix_code_examples.md
       - Appendix B – Technical Architecture for Book Production: 31_technical_architecture.md
       - Appendix C – FINOS Project Blueprint: 32_finos_project_blueprint.md
-      - Appendix D – Architecture as Code Maturity Model: architecture_as_code_model.md
+      - Appendix D – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
+      - Appendix E – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
       - About the Author: 29_about_the_authors.md
       - References and Sources: 33_references.md
   - Prezi Deck: prezi/index.html


### PR DESCRIPTION
## Summary
- correct the MkDocs navigation so Appendix D points to the maturity model content and expose the radar tool alongside it
- reference the interactive radar assessment from the maturity model appendix to guide readers to the full questionnaire and visual output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fdfe05bd888330acbe1073f814a1d1