### PR TITLE
Update navigation to use alphanumeric part links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,36 +7,43 @@ nav:
   - Overview:
       - Welcome: index.md
       - Book Structure: book_structure.md
-  - Part 1 – Foundations:
+  - Part A – Foundations:
+      - index: part_a_foundations.md
       - Introduction to Architecture as Code: 01_introduction.md
       - Fundamental Principles of Architecture as Code: 02_fundamental_principles.md
       - Version Control and Code Structure: 03_version_control.md
       - Architecture Decision Records (ADR): 04_adr.md
-  - Part 2 – Architecture Platform:
+  - Part B – Architecture Platform:
+      - index: part_b_architecture_platform.md
       - Automation, DevOps and CI/CD for Infrastructure as Code: 05_automation_devops_cicd.md
       - Containerization and Orchestration as Code: 07_containerization.md
       - Microservices Architecture as Code: 08_microservices.md
-  - Part 3 – Security & Governance:
+  - Part C – Security & Governance:
+      - index: part_c_security_governance.md
       - Security Fundamentals for Architecture as Code: 09a_security_fundamentals.md
       - Advanced Security Patterns and Implementation: 09b_security_patterns.md
       - Policy and Security as Code in Detail: 10_policy_and_security.md
       - Governance as Code: 11_governance_as_code.md
       - Compliance and Regulatory Adherence: 12_compliance.md
-  - Part 4 – Delivery & Operations:
+  - Part D – Delivery & Operations:
+      - index: part_d_delivery_operations.md
       - Testing Strategies for Infrastructure as Code: 13_testing_strategies.md
       - Architecture as Code in Practice: 14_practical_implementation.md
-      - Cost Optimization and Resource Management: 15_cost_optimization.md
+      - Cost Optimisation and Resource Management: 15_cost_optimization.md
       - Migration from Traditional Infrastructure: 16_migration.md
-  - Part 5 – Organisation & Leadership:
+  - Part E – Organisation & Leadership:
+      - index: part_e_organisation_leadership.md
       - Organisational Change and Team Structures: 17_organizational_change.md
       - Management as Code: 19_management_as_code.md
       - AI Agent Team for Architecture as Code Initiatives: 20_ai_agent_team.md
-      - Digitalization through Code-based Infrastructure: 21_digitalization.md
-  - Part 6 – Experience & Best Practices:
+      - Digitalisation through Code-based Infrastructure: 21_digitalization.md
+  - Part F – Experience & Best Practices:
+      - index: part_f_experience_best_practices.md
       - Documentation as Code vs Architecture as Code: 22_documentation_vs_architecture.md
       - Interplay Between Soft-As-Code Disciplines: 23_soft_as_code_interplay.md
       - Best Practices and Lessons Learned: 24_best_practices.md
-  - Part 7 – Future & Wrap-up:
+  - Part G – Future & Wrap-up:
+      - index: part_g_future_wrap_up.md
       - Future Trends in Architecture as Code: 25_future_trends.md
       - Future Development: 26_aac_anti_patterns.md
       - Conclusion: 27_conclusion.md


### PR DESCRIPTION
## Summary
- update the MkDocs navigation so each part heading links to its part overview page
- rename the part sections in the menu to use alphanumeric identifiers that match the part overview documents

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68fe00ce56308330b8771a267be00da0