### PR TITLE
Add PDF report export to maturity radar assessment

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -184,6 +184,85 @@
       margin-top: 0.25rem;
     }
 
+    .report-export p {
+      max-width: 60rem;
+    }
+
+    #pdfReport {
+      display: none;
+    }
+
+    .pdf-report {
+      background-color: #ffffff;
+      color: #1f2933;
+      padding: 2rem;
+      max-width: 210mm;
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    }
+
+    .pdf-report h1 {
+      margin-top: 0;
+    }
+
+    .pdf-report h2 {
+      margin-bottom: 0.5rem;
+    }
+
+    .pdf-report h3 {
+      margin-top: 1rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .pdf-report section {
+      margin-top: 1.5rem;
+    }
+
+    .pdf-report table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.75rem;
+    }
+
+    .pdf-report th,
+    .pdf-report td {
+      border: 1px solid #d2d6dc;
+      padding: 0.5rem;
+      text-align: left;
+    }
+
+    .pdf-report th {
+      background-color: #f1f5f9;
+    }
+
+    .pdf-report .meta {
+      margin-bottom: 1rem;
+    }
+
+    .pdf-report .answers-list {
+      margin-top: 0.5rem;
+      padding-left: 1.25rem;
+    }
+
+    .pdf-report .answer-entry {
+      margin-bottom: 0.5rem;
+    }
+
+    .pdf-report .question-label {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    .pdf-report .risk {
+      color: #991b1b;
+      font-weight: 500;
+      margin: 0.25rem 0;
+    }
+
+    .pdf-report .reference-link {
+      display: inline-block;
+      margin-top: 0.25rem;
+    }
+
     @media (max-width: 768px) {
       body {
         margin: 1rem;
@@ -194,6 +273,7 @@
       }
     }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js"></script>
   <script type="module">
     import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.esm.min.mjs";
 
@@ -202,6 +282,11 @@
     });
 
     window.mermaid = mermaid;
+
+    let latestAssessment = null;
+    let initialRadarContent = "";
+    let initialSummaryContent = "";
+    let initialSuggestionsContent = "";
 
     const aspects = [
       {
@@ -893,6 +978,31 @@
       buildForm();
       const form = document.getElementById("assessmentForm");
       form.addEventListener("submit", handleAssessment);
+      form.addEventListener("reset", handleReset);
+
+      const radarContainer = document.getElementById("radarDiagram");
+      const summaryContainer = document.getElementById("resultSummary");
+      const suggestionsContainer = document.getElementById("improvementSuggestions");
+
+      if (radarContainer) {
+        initialRadarContent = radarContainer.innerHTML;
+      }
+
+      if (summaryContainer) {
+        initialSummaryContent = summaryContainer.innerHTML;
+      }
+
+      if (suggestionsContainer) {
+        initialSuggestionsContent = suggestionsContainer.innerHTML;
+      }
+
+      togglePdfButton(false);
+
+      const downloadPdfButton = document.getElementById("downloadPdf");
+      if (downloadPdfButton) {
+        downloadPdfButton.addEventListener("click", handleDownloadPdf);
+      }
+
       document
         .getElementById("copyJson")
         .addEventListener("click", copyJsonToClipboard);
@@ -1031,10 +1141,20 @@
       const radarDefinition = buildRadarDefinition(detailedResults);
       renderRadar(radarDefinition);
       renderSummaryTable(detailedResults);
-      renderSuggestions(collectImprovementSuggestions(detailedResults));
+      const suggestions = collectImprovementSuggestions(detailedResults);
+      renderSuggestions(suggestions);
 
       const jsonOutput = document.getElementById("jsonOutput");
       jsonOutput.value = JSON.stringify(resultPayload, null, 2);
+
+      latestAssessment = {
+        detailedResults,
+        suggestions,
+        resultPayload
+      };
+
+      updatePdfReport(detailedResults, suggestions, resultPayload);
+      togglePdfButton(true);
     }
 
     function buildRadarDefinition(results) {
@@ -1292,6 +1412,275 @@
       container.appendChild(list);
     }
 
+    function togglePdfButton(isEnabled) {
+      const button = document.getElementById("downloadPdf");
+      if (!button) {
+        return;
+      }
+
+      button.disabled = !isEnabled;
+      button.setAttribute("aria-disabled", String(!isEnabled));
+    }
+
+    async function handleDownloadPdf() {
+      const report = document.getElementById("pdfReport");
+      const button = document.getElementById("downloadPdf");
+
+      if (!report || !button) {
+        return;
+      }
+
+      if (!latestAssessment) {
+        alert("Please complete the assessment before downloading the PDF report.");
+        return;
+      }
+
+      if (typeof window.html2pdf !== "function") {
+        alert("PDF generation is currently unavailable. Please try again shortly.");
+        return;
+      }
+
+      const originalLabel = button.textContent;
+      const previousDisplay = report.style.display;
+
+      button.disabled = true;
+      button.setAttribute("aria-disabled", "true");
+      button.textContent = "Preparing PDF…";
+      report.style.display = "block";
+
+      try {
+        await window
+          .html2pdf()
+          .set({
+            margin: [0.5, 0.5, 0.5, 0.5],
+            filename: "aac_maturity_assessment.pdf",
+            html2canvas: { scale: 2, useCORS: true },
+            jsPDF: { unit: "in", format: "a4", orientation: "portrait" }
+          })
+          .from(report)
+          .save();
+      } catch (error) {
+        console.error("Failed to generate PDF report", error);
+        alert("The PDF could not be generated. Please try again.");
+      } finally {
+        report.style.display = previousDisplay || "none";
+        button.textContent = originalLabel;
+        button.disabled = false;
+        button.setAttribute("aria-disabled", "false");
+      }
+    }
+
+    function updatePdfReport(results, suggestions, payload) {
+      const container = document.getElementById("pdfReport");
+      if (!container) {
+        return;
+      }
+
+      container.innerHTML = "";
+      container.className = "pdf-report";
+
+      const title = document.createElement("h1");
+      title.textContent = "Architecture as Code Maturity Assessment";
+      container.appendChild(title);
+
+      const meta = document.createElement("p");
+      meta.className = "meta";
+      const generatedOn = payload?.generatedAt
+        ? new Date(payload.generatedAt)
+        : new Date();
+      meta.textContent = `Generated on ${generatedOn.toLocaleString("en-GB", {
+        dateStyle: "long",
+        timeStyle: "short"
+      })}`;
+      container.appendChild(meta);
+
+      if (payload?.totals) {
+        const overview = document.createElement("p");
+        const roundedAverage = Number.parseFloat(payload.totals.averagePercentage);
+        const formattedAverage = Number.isFinite(roundedAverage)
+          ? `${Math.round(roundedAverage)}%`
+          : "0%";
+        overview.textContent = `Affirmative responses: ${payload.totals.overallYes} of ${payload.totals.overallQuestions} (${formattedAverage} average across disciplines).`;
+        container.appendChild(overview);
+      }
+
+      const radarFigure = document.querySelector("#radarDiagram svg");
+      if (radarFigure) {
+        const radarSection = document.createElement("section");
+        const radarHeading = document.createElement("h2");
+        radarHeading.textContent = "Radar snapshot";
+        radarSection.appendChild(radarHeading);
+
+        const figureWrapper = document.createElement("div");
+        figureWrapper.innerHTML = radarFigure.outerHTML;
+        radarSection.appendChild(figureWrapper);
+
+        container.appendChild(radarSection);
+      }
+
+      const summarySection = document.createElement("section");
+      const summaryHeading = document.createElement("h2");
+      summaryHeading.textContent = "Summary by discipline";
+      summarySection.appendChild(summaryHeading);
+
+      const summaryTable = document.createElement("table");
+      const headerRow = document.createElement("tr");
+      [
+        "Discipline",
+        "Affirmative responses",
+        "Total questions",
+        "Percentage"
+      ].forEach((heading) => {
+        const cell = document.createElement("th");
+        cell.textContent = heading;
+        headerRow.appendChild(cell);
+      });
+      summaryTable.appendChild(headerRow);
+
+      results.forEach((result) => {
+        const row = document.createElement("tr");
+
+        const aspectCell = document.createElement("td");
+        aspectCell.textContent = result.aspectName;
+        row.appendChild(aspectCell);
+
+        const yesCell = document.createElement("td");
+        yesCell.textContent = result.yesCount;
+        row.appendChild(yesCell);
+
+        const totalCell = document.createElement("td");
+        totalCell.textContent = result.totalQuestions;
+        row.appendChild(totalCell);
+
+        const percentageCell = document.createElement("td");
+        percentageCell.textContent = `${result.percentage}%`;
+        row.appendChild(percentageCell);
+
+        summaryTable.appendChild(row);
+      });
+
+      summarySection.appendChild(summaryTable);
+      container.appendChild(summarySection);
+
+      const suggestionsSection = document.createElement("section");
+      const suggestionsHeading = document.createElement("h2");
+      suggestionsHeading.textContent = "Recommendations";
+      suggestionsSection.appendChild(suggestionsHeading);
+
+      if (!suggestions.length) {
+        const placeholder = document.createElement("p");
+        placeholder.textContent = "All disciplines met every criterion, so no immediate recommendations were generated.";
+        suggestionsSection.appendChild(placeholder);
+      } else {
+        const list = document.createElement("ol");
+
+        suggestions.forEach((suggestion) => {
+          const item = document.createElement("li");
+
+          const label = document.createElement("p");
+          label.className = "question-label";
+          label.textContent = `${suggestion.aspectName} – ${suggestion.question}`;
+          item.appendChild(label);
+
+          if (suggestion.risk) {
+            const risk = document.createElement("p");
+            risk.className = "risk";
+            risk.textContent = suggestion.risk;
+            item.appendChild(risk);
+          }
+
+          const recommendation = document.createElement("p");
+          recommendation.textContent = suggestion.recommendation;
+          item.appendChild(recommendation);
+
+          if (suggestion.reference) {
+            const referenceLink = document.createElement("a");
+            referenceLink.className = "reference-link";
+            referenceLink.href = suggestion.reference.url;
+            referenceLink.textContent = suggestion.reference.title;
+            referenceLink.target = "_blank";
+            referenceLink.rel = "noopener noreferrer";
+            item.appendChild(referenceLink);
+          }
+
+          list.appendChild(item);
+        });
+
+        suggestionsSection.appendChild(list);
+      }
+
+      container.appendChild(suggestionsSection);
+
+      const responsesSection = document.createElement("section");
+      const responsesHeading = document.createElement("h2");
+      responsesHeading.textContent = "Responses by discipline";
+      responsesSection.appendChild(responsesHeading);
+
+      results.forEach((result) => {
+        const aspectWrapper = document.createElement("div");
+
+        const aspectHeading = document.createElement("h3");
+        aspectHeading.textContent = `${result.aspectName} (${result.yesCount} of ${result.totalQuestions})`;
+        aspectWrapper.appendChild(aspectHeading);
+
+        const answersList = document.createElement("ol");
+        answersList.className = "answers-list";
+
+        result.answers.forEach((answer) => {
+          const entry = document.createElement("li");
+          entry.className = "answer-entry";
+
+          const outcome = document.createElement("strong");
+          outcome.textContent = answer.response === "yes" ? "Yes" : "No";
+          entry.appendChild(outcome);
+          entry.appendChild(document.createTextNode(` – ${answer.question}`));
+
+          answersList.appendChild(entry);
+        });
+
+        aspectWrapper.appendChild(answersList);
+        responsesSection.appendChild(aspectWrapper);
+      });
+
+      container.appendChild(responsesSection);
+
+      const closing = document.createElement("p");
+      closing.textContent = "Share this PDF to communicate your Architecture as Code maturity baseline and track progress over time.";
+      container.appendChild(closing);
+    }
+
+    function handleReset() {
+      latestAssessment = null;
+
+      const radarContainer = document.getElementById("radarDiagram");
+      if (radarContainer) {
+        radarContainer.innerHTML = initialRadarContent;
+      }
+
+      const summaryContainer = document.getElementById("resultSummary");
+      if (summaryContainer) {
+        summaryContainer.innerHTML = initialSummaryContent;
+      }
+
+      const suggestionsContainer = document.getElementById("improvementSuggestions");
+      if (suggestionsContainer) {
+        suggestionsContainer.innerHTML = initialSuggestionsContent;
+      }
+
+      const jsonOutput = document.getElementById("jsonOutput");
+      if (jsonOutput) {
+        jsonOutput.value = "";
+      }
+
+      const pdfContainer = document.getElementById("pdfReport");
+      if (pdfContainer) {
+        pdfContainer.innerHTML = "";
+        pdfContainer.style.display = "none";
+      }
+
+      togglePdfButton(false);
+    }
+
     async function copyTextToClipboard(text) {
       if (!text) {
         return;
@@ -1435,6 +1824,17 @@
       </div>
     </section>
 
+    <section class="result-summary report-export">
+      <h2>PDF report</h2>
+      <p>
+        Save a shareable PDF that captures the radar snapshot, summary table, recommendations and a full breakdown of your
+        responses.
+      </p>
+      <div class="actions">
+        <button type="button" id="downloadPdf" disabled aria-disabled="true">Download PDF report</button>
+      </div>
+    </section>
+
     <section class="result-summary">
       <h2>JSON export</h2>
       <p>The JSON payload includes the radar data and individual answers so you can archive or process the assessment.</p>
@@ -1453,5 +1853,6 @@
       </div>
     </section>
   </main>
+  <div id="pdfReport" aria-hidden="true"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add styling and dependencies needed to render printable PDF assessment reports
- enable PDF export button with new logic that builds a detailed report payload alongside existing outputs
- ensure resets clear generated artefacts and disable the download action until a fresh assessment is produced

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe019eee94833084aa5951e8bfb070