### PR TITLE
Add curated Structurizr workspace and guidance for architecture teams

### DIFF
--- a/docs/06_structurizr.md
+++ b/docs/06_structurizr.md
@@ -358,6 +358,58 @@ externalPayment = softwareSystem "Payment Provider" {
 }
 ```
 
+## Reference Workspace for Architecture Teams
+
+To accelerate onboarding, the repository now ships with a curated Structurizr workspace that mirrors the C4 abstractions descri
+bed throughout this chapter. You can find the canonical definition in `docs/examples/structurizr/aac_reference_workspace.dsl`, w
+ith supporting guidance in `docs/examples/structurizr/README.md`.
+
+### Repository artefacts
+
+- **Workspace DSL** – Implements System Context, Container, Component, Dynamic, and Deployment views for the Architecture as Co
+de platform, providing a ready-made baseline for teams to copy or extend.
+- **Styling conventions** – Applies consistent British English tagging and a colour palette that emphasises governance, automat
+ion, and telemetry pathways referenced in the book.
+- **Configuration metadata** – Pins a minimum Structurizr CLI version so that exports remain reproducible across developer machi
+nes and the CI pipeline.
+
+### Exploring the reference workspace
+
+Follow these steps to render the workspace locally:
+
+1. Install the Structurizr CLI (version `2024.03.01` or later).
+2. From the repository root, run:
+   ```bash
+   structurizr.sh export \
+     -workspace docs/examples/structurizr/aac_reference_workspace.dsl \
+     -format plantuml,mermaid,structurizr
+   ```
+3. Open the exported diagrams or load the generated Structurizr Lite workspace to explore the interactive views.
+
+These commands align with the automation demonstrated earlier in this chapter, ensuring that developers, architects, and editor
+s can iterate confidently without bespoke tooling.
+
+### Contribution workflow for diagram updates
+
+A consistent contribution workflow prevents diagram drift and preserves traceability across programmes:
+
+1. **Create a feature branch** – Prefix it with `structurizr/` to signal architecture-oriented work.
+2. **Amend the DSL** – Update `aac_reference_workspace.dsl` or add modular `!include` files in the same directory. Each change s
+hould retain the C4 hierarchy and respect agreed tags.
+3. **Validate locally** – Execute `structurizr.sh validate -workspace docs/examples/structurizr/aac_reference_workspace.dsl` fol
+lowed by the export command above. Address any reported warnings before requesting review.
+4. **Document intent** – Capture the architectural rationale in the pull request description and, where relevant, reference rela
+ted Architecture Decision Records.
+5. **Run the book build** – `python3 generate_book.py && docs/build_book.sh` ensures that downstream artefacts (including PNG di
+agrams referenced in the manuscript) remain in sync.
+6. **Request dual review** – Tag at least one platform engineer and one product architect so that automation and domain perspect
+ives both evaluate the change.
+7. **Check automation outcomes** – Confirm that GitHub Actions architecture checks and the main book build succeed before mergin
+g.
+
+By following these steps, teams maintain a shared, version-controlled architecture narrative that evolves alongside the software
+delivery platform.
+
 ## Integration with CI/CD Pipelines
 
 Automating architecture documentation ensures diagrams stay synchronized with code changes.

--- a/docs/24_best_practices.md
+++ b/docs/24_best_practices.md
@@ -138,6 +138,17 @@ Balanced portfolios prevent lock-in and create negotiation leverage. Where a sin
 
 Regular service reviews examine performance metrics, support responsiveness, and roadmap alignment. Joint innovation forums allow vendors and platform teams to co-design features that deliver measurable value.
 
+## Structurizr Enablement Patterns
+
+Architecture teams thrive when diagrams and narrative assets share the same governance standards as application code. To that end, maintain a living Structurizr workspace and reinforce shared practices:
+
+- **Start from the curated workspace** – `docs/examples/structurizr/aac_reference_workspace.dsl` reflects the C4 hierarchy described in Chapter 06. Encourage new teams to clone this definition so that terminology, styles, and relationship semantics remain consistent.
+- **Automate every validation** – Embed `structurizr.sh validate` and `structurizr.sh export` in local pre-commit hooks or repository CI workflows. Automation ensures that diagram assets regenerate on demand and prevents last-minute surprises during release reviews.
+- **Treat diagram reviews as code reviews** – Pull requests should highlight the change intent, link to any relevant Architecture Decision Records, and include before/after renders. Reviewers confirm that tags, layout, and element descriptions align with repository conventions and that the change maps to an approved initiative.
+- **Close the feedback loop** – When changes land, run `python3 generate_book.py && docs/build_book.sh` to refresh downstream artefacts. Sharing the resulting PNGs or Structurizr workspace exports during showcases helps teams internalise the latest architecture story.
+
+These routines eliminate duplicated diagramming effort across programmes, allowing architects to focus on structural decisions rather than cosmetic fixes.
+
 ## Risk Management and Resilience
 
 Risk management integrates technical safeguards with business continuity planning so that infrastructure disruption does not cascade into customer harm.

--- a/docs/31_technical_architecture.md
+++ b/docs/31_technical_architecture.md
@@ -126,6 +126,27 @@ pandoc --defaults=pandoc.yaml "${CHAPTER_FILES[@]}" -o architecture_as_code.pdf
 - **Image handling**: Ensures every diagram reference resolves correctly.
 - **Output verification**: Confirms the generated files meet expectations.
 
+## Evolutionary Architecture Fitness Functions
+
+Architecture as Code encourages continuous evaluation of structural decisions. To stop Structurizr diagrams drifting away from r
+eality, embed evolutionary architecture fitness functions in the publication pipeline:
+
+- **Workspace validity** – Run `structurizr.sh validate` against `docs/examples/structurizr/aac_reference_workspace.dsl` on eve
+ry pull request. The command verifies element definitions, relationships, and view completeness before reviewers examine the nar
+rative.
+- **Structural coverage thresholds** – Extend the validation job with custom scripts that assert minimum coverage for people, c
+ontainers, and critical data stores. Failing the check prompts architects to capture missing perspectives before merging.
+- **Tag conformance** – Compare element tags against an approved list (for example, `Core System`, `Operations`, or `External P
+erson`). Non-conforming tags indicate inconsistent language and trigger follow-up conversations during review.
+- **Fitness score export** – Use the policy evaluator component described in the reference workspace to calculate scores for la
+tency, operability, and compliance rules. Surface these scores in the Observability Hub dashboards so that teams track trends o
+ver time.
+- **Change intelligence** – Record before/after diffs of the Structurizr DSL and correlate them with production incidents. This
+ evidence helps determine whether architecture shifts improved resilience or introduced regressions.
+
+By codifying these checks, the programme maintains a living architecture model whose quality improves with each iteration instea
+d of eroding through manual drift.
+
 ## GitHub Actions: CI/CD Pipeline
 
 ### Primary Workflow for Book Production

--- a/docs/examples/structurizr/README.md
+++ b/docs/examples/structurizr/README.md
@@ -1,0 +1,33 @@
+# Architecture as Code Structurizr Workspace Example
+
+This curated workspace accompanies Chapter 06 and demonstrates how the book's C4 abstractions translate into Structurizr DSL. It models the end-to-end book production platform, including:
+
+- A **System Context** view aligning with the collaboration model explained in the manuscript.
+- A **Container** view showing the automation platform, diagram tooling, and supporting telemetry services.
+- A **Component** view for the diagram automation service, highlighting where Structurizr-centric policy enforcement sits.
+- A **Dynamic** view that tracks a diagram change from submission through automated review.
+- A **Deployment** view for the production pipeline, enabling operational rehearsals and environment drift checks.
+
+## Quick start
+
+1. Install the Structurizr CLI (minimum version 2024.03.01 as referenced in the workspace configuration).
+2. From the repository root, render the workspace using:
+   ```bash
+   structurizr.sh export \
+     -workspace docs/examples/structurizr/aac_reference_workspace.dsl \
+     -format plantuml,mermaid,structurizr
+   ```
+3. Open the generated diagrams (PNG/SVG) or the Structurizr Lite workspace to explore interactive tooling.
+
+## Alignment with the book
+
+- The workspace uses the **British English** nomenclature and tagging conventions described in `docs/06_structurizr.md`.
+- Naming and relationship statements match the **Architecture as Code** pipeline introduced across Chapters 03, 05, and 31 so that newcomers can cross-reference narrative text with diagrams.
+- Styles emphasise **governance, automation, and telemetry** pathways so platform and architecture teams can reason about evolution without redrawing diagrams from scratch.
+
+## Extending the workspace
+
+- Additional views may be appended in dedicated `views` blocks; align new view identifiers with chapter numbers for traceability.
+- Reusable fragments (such as shared people or external systems) should be extracted into `!include` files. Keep those includes alongside the workspace file to simplify code review.
+- All contributions should pass the Structurizr CLI validation (`structurizr.sh validate`) before opening a pull request.
+

--- a/docs/examples/structurizr/aac_reference_workspace.dsl
+++ b/docs/examples/structurizr/aac_reference_workspace.dsl
@@ -1,0 +1,185 @@
+workspace "Architecture as Code Reference" "Curated Structurizr workspace aligned to the book's C4 guidance." {
+
+    model {
+        user = person "Digital Service User" "Citizen or customer interacting with the public-facing capabilities." {
+            tags "External Person"
+        }
+
+        editor = person "Book Editor" "Curates narrative updates and approves publication-ready material." {
+            tags "Internal Person"
+        }
+
+        platformEngineer = person "Platform Engineer" "Maintains the automation platform and contributes new capabilities." {
+            tags "Internal Person"
+        }
+
+        aacPlatform = softwareSystem "Architecture as Code Platform" "Automates manuscript generation, diagram rendering, and publication assets." {
+            tags "Core System"
+        }
+
+        analyticsService = softwareSystem "Analytics Service" "Delivers telemetry about readership and pipeline health." {
+            tags "Supporting System"
+        }
+
+        paymentGateway = softwareSystem "Payment Gateway" "Processes book orders for print-on-demand partners." {
+            tags "External System"
+        }
+
+        model { aacPlatform -> analyticsService "Publishes build telemetry and readership events." }
+        model { paymentGateway -> analyticsService "Shares purchase signals for aggregated reporting." }
+
+        aacPlatform {
+            authoringPortal = container "Authoring Portal" "Markdown-first editorial tooling exposed to contributors." "Next.js" {
+                tags "Web Application"
+            }
+
+            diagramService = container "Diagram Service" "Converts Structurizr and Mermaid definitions into publishable assets." "Node.js" {
+                tags "Service"
+            }
+
+            contentPipeline = container "Content Pipeline" "Generates book artefacts, validates diagrams, and assembles releases." "Python" {
+                tags "Pipeline"
+            }
+
+            knowledgeGraph = container "Knowledge Graph" "Stores relationships between chapters, diagrams, and review decisions." "Neo4j" {
+                tags "Data"
+            }
+
+            observabilityHub = container "Observability Hub" "Aggregates telemetry, alerts, and architecture fitness scores." "Grafana" {
+                tags "Operations"
+            }
+
+            # Container relationships
+            authoringPortal -> contentPipeline "Submits chapter updates and diagram changes." "HTTPS/JSON"
+            contentPipeline -> diagramService "Requests diagram renders and Structurizr exports." "gRPC"
+            contentPipeline -> knowledgeGraph "Persists narrative and diagram metadata." "Bolt"
+            diagramService -> knowledgeGraph "Indexes rendered diagrams for traceability." "Bolt"
+            observabilityHub -> analyticsService "Synchronises usage metrics." "REST"
+            observabilityHub -> knowledgeGraph "Queries historical architecture decisions." "Bolt"
+            contentPipeline -> observabilityHub "Emits build and validation telemetry." "OTLP"
+            authoringPortal -> observabilityHub "Displays health dashboards." "HTTPS"
+
+            diagramService {
+                dslParser = component "DSL Parser" "Validates Structurizr DSL syntax and resolves workspace fragments." "Kotlin"
+                renderer = component "Diagram Renderer" "Calls Structurizr Lite for PNG/SVG generation." "Java"
+                versioningAdapter = component "Versioning Adapter" "Synchronises workspace snapshots with Git repositories." "Python"
+                policyEvaluator = component "Policy Evaluator" "Applies architecture fitness functions to proposed changes." "Python"
+
+                dslParser -> renderer "Produces normalised model definitions for." 
+                renderer -> versioningAdapter "Publishes rendered diagrams and metadata." 
+                policyEvaluator -> dslParser "Receives parsed workspace structures." 
+                policyEvaluator -> observabilityHub "Emits compliance scores." "HTTPS"
+            }
+        }
+
+        analyticsService {
+            reportingWarehouse = container "Reporting Warehouse" "Holds consolidated analytics events." "BigQuery"
+            reportingWarehouse -> observabilityHub "Feeds curated dashboards." "Scheduled ETL"
+        }
+
+        # External interactions
+        user -> authoringPortal "Reads previews and contributes errata." "Browser"
+        editor -> authoringPortal "Reviews submissions and manages releases." "Browser"
+        platformEngineer -> contentPipeline "Implements automation enhancements." "Git Push"
+        contentPipeline -> paymentGateway "Triggers royalty reconciliation." "REST"
+    }
+
+    views {
+        systemContext aacPlatform "AaC-SystemContext" "Context view showing collaborators and neighbouring systems." {
+            include *
+            autoLayout lr
+        }
+
+        container aacPlatform "AaC-Containers" "Container view of the Architecture as Code platform." {
+            include authoringPortal
+            include diagramService
+            include contentPipeline
+            include knowledgeGraph
+            include observabilityHub
+            include analyticsService
+            include paymentGateway
+            include user
+            include editor
+            include platformEngineer
+            autoLayout lr
+        }
+
+        component diagramService "AaC-DiagramService" "Component view describing Structurizr automation internals." {
+            include *
+            autoLayout lr
+        }
+
+        dynamic aacPlatform "AaC-ChangeReview" "Dynamic view covering a diagram change review." {
+            user -> authoringPortal "Submits revised workspace fragment." "Change request"
+            authoringPortal -> contentPipeline "Creates pull request for workspace update." "Git integration"
+            contentPipeline -> diagramService "Runs Structurizr validation job." "CI step"
+            diagramService -> policyEvaluator "Executes architecture fitness functions." "Async task"
+            policyEvaluator -> observabilityHub "Publishes scores and rule outcomes." "Event"
+            observabilityHub -> editor "Alerts reviewers if thresholds fail." "Notification"
+            editor -> authoringPortal "Requests adjustments or approves change." "Review decision"
+        }
+
+        deployment aacPlatform "AaC-Deployment" "Deployment view for production." {
+            include contentPipeline
+            include diagramService
+            include knowledgeGraph
+            include observabilityHub
+            include analyticsService
+            autoLayout lr
+        }
+
+        styles {
+            element "Software System" {
+                background "#0b3d91"
+                colour "#ffffff"
+                shape RoundedBox
+            }
+            element "Container" {
+                background "#205493"
+                colour "#ffffff"
+            }
+            element "Component" {
+                background "#5778a3"
+                colour "#ffffff"
+            }
+            element "External System" {
+                background "#c4d4f2"
+                colour "#1f2a44"
+            }
+            element "External Person" {
+                background "#f4f6fc"
+                colour "#1f2a44"
+            }
+            element "Internal Person" {
+                background "#2e8540"
+                colour "#ffffff"
+            }
+            element "Pipeline" {
+                background "#7f9bb3"
+                colour "#ffffff"
+            }
+            element "Operations" {
+                background "#485c6d"
+                colour "#ffffff"
+            }
+            element "Data" {
+                background "#485c6d"
+                colour "#ffffff"
+                shape Cylinder
+            }
+            relationship "REST" {
+                dashed false
+                thickness 2
+            }
+        }
+    }
+
+    configuration {
+        properties {
+            structurizr.cli.version "2024.03.01"
+        }
+        branding {
+            logo "../images/diagram_06_structurizr_overview.png"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a curated Structurizr workspace example with supporting README to accelerate onboarding
- document the repository-backed contribution workflow and enablement patterns for Structurizr diagram updates
- outline evolutionary architecture fitness functions that keep Structurizr views accurate during ongoing change

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: Mermaid conversions and XeLaTeX are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690118c997248330bfe699e10009edc7