### PR TITLE
Strengthen microservices maintainability guidance

### DIFF
--- a/docs/08_microservices.md
+++ b/docs/08_microservices.md
@@ -77,9 +77,21 @@ jobs:
 
 Such pipelines capture the architectural intent, flag drift immediately, and keep every service aligned with centrally defined guardrails.
 
+### Policy-as-code guardrails for maintainability
+
+Declarative policies keep microservice estates maintainable by enforcing approved integration patterns and blocking unauthorised dependencies before they entrench. Encode cross-service dependency limits, schema versioning rules, and data classification controls in engines such as Open Policy Agent or HashiCorp Sentinel so that every pull request executes the same objective assessment ([Source [10]](33_references.md#source-10)). Guardrail repositories should expose reusable policy modules—one for inbound contracts, another for outbound data sharing, and a third for infrastructure entitlements—so teams can adopt the right set through configuration rather than copying logic. Publishing those modules through package registries or Git submodules ensures each service can pin to a tested release whilst the platform team can distribute updates rapidly when regulations or architectural standards evolve.
+
+Complement policy execution with attestation artefacts. Delivery pipelines ought to publish signed evidence that contract checks, dependency allow-list validation, and cost guardrails all passed. Store the attestations alongside build artefacts and surface them in dashboards used by architecture review boards so that maintainability conversations reference recent, machine-verifiable data instead of tribal memory. The same attestations become the gating mechanism for progressive delivery: without a current policy pass, staging and production promotions automatically halt, focusing attention on defects before they propagate.
+
 ### Runtime observability as code
 
 Codify dashboards, alerting policies, and runbooks so that operability remains consistent across the fleet. Use tools such as Grafana configuration as code or Prometheus recording rules stored in Git. Tie alert routing to the ownership data held in each service repository so incidents reach the responsible team.
+
+### Service contract catalogues and coupling telemetry
+
+Treat service contracts as long-lived assets that require their own catalogue. A lightweight metadata schema—covering owning team, lifecycle stage, change cadence, consumer roster, and deprecation policy—lets automation assemble a searchable inventory and keeps discovery costs low for new teams ([Source [2]](33_references.md#source-2)). Repository templates should prompt engineers to update the catalogue entry whenever schemas change, with pull-request bots comparing the declared version to the OpenAPI or AsyncAPI documents committed in the same branch. When discrepancies arise, reviewers receive targeted comments explaining which metadata fields need revision.
+
+Maintainability improves further when coupling signals are harvested automatically. Parse event subscriptions, REST dependencies, and shared library imports to populate a dependency graph that surfaces fan-in and fan-out metrics. Highlight services whose consumer counts spike unexpectedly or whose API change frequency exceeds the agreed envelope so that architecture leads can intervene early. Feed these metrics into team dashboards and quarterly architecture reviews to decide when to invest in domain resegmentation, consumer education, or contract hardening.
 
 ## Coordinating shared capabilities
 
@@ -109,6 +121,12 @@ Define failure injection experiments alongside service definitions. Tools such a
 
 Automate reporting on resource consumption, carbon intensity, and idle workloads. When services codify budgets and scaling thresholds, platform automation can alert owners when utilisation deviates from expected norms. Embedding sustainability objectives into Architecture as Code keeps environmental considerations visible during design and runtime.
 
+### Escalation playbooks for failed guardrails
+
+Automated checks occasionally surface non-compliance that cannot be remediated immediately. Codify escalation playbooks within each service repository so that governance breaches trigger predictable responses rather than ad-hoc firefighting. The playbook should identify the accountable owner, the supporting platform or governance contacts, and the time-bound actions required to restore compliance—whether that is rolling back a release, applying a compensating policy, or executing a hotfix ([Source [10]](33_references.md#source-10)). Integrate ChatOps commands that allow responders to acknowledge an incident, apply temporary waivers, or request expedited reviews while ensuring every step is logged.
+
+Policy tooling can emit enriched alerts that include the affected service contract, recent change history, and coupling metrics drawn from the catalogue so responders understand the blast radius before taking action ([Source [2]](33_references.md#source-2)). Escalations that breach agreed response windows should automatically notify architecture leadership and post-mortem facilitators, feeding lessons learned back into the guardrail backlog. Publishing the closed-loop results keeps the maintainability programme transparent and reassures stakeholders that automated controls drive genuine behavioural change.
+
 ## Migration considerations
 
 Many organisations evolve from monoliths or service-oriented architectures. Architecture as Code accelerates this journey by:
@@ -123,3 +141,9 @@ By treating migration playbooks as code, teams can rehearse transitions safely a
 ## Summary
 
 Microservices amplify organisational agility when paired with disciplined automation. Architecture as Code gives leaders a shared source of truth for service contracts, platform guardrails, and operational posture. Investing in reusable templates, policy automation, and comprehensive observability enables teams to innovate quickly whilst preserving the resilience, compliance, and sustainability that modern enterprises demand.
+
+## Sources
+
+Sources:
+- [Cloud Native Computing Foundation – Policy as Code Whitepaper (2021)](https://github.com/cncf/tag-app-delivery/blob/main/policy-as-code-whitepaper.md) ([Source [10]](33_references.md#source-10))
+- [Sam Newman – *Building Microservices*, 2nd Edition (2021)](https://www.oreilly.com/library/view/building-microservices-2nd/9781492034018/) ([Source [2]](33_references.md#source-2))

--- a/docs/11_governance_as_code.md
+++ b/docs/11_governance_as_code.md
@@ -32,6 +32,12 @@ Empowering non-developers starts with approachable policy editors that generate 
 
 Documentation-as-code portals and ChatOps integrations keep contributors in their preferred environments. Rendered documentation provides a friendly view of pending changes, while Microsoft Teams or Slack integrations surface review notifications, allow approvals, and trigger governance checks without forcing users into the terminal. Automated policy explainers complete the toolkit by translating code into natural language summaries, giving decision makers clarity without diluting the precision of code-based guardrails.
 
+## Maintaining catalogues and escalation playbooks
+
+Governance repositories should act as the clearing house for service contract metadata, coupling telemetry, and the escalation rules that accompany automated checks. By ingesting the catalogues curated by microservice teams, governance owners can cross-reference consumer counts, schema versions, and deprecation timelines to spot where policy updates or additional enablement is required ([Source [2]](33_references.md#source-2)). Dashboards layered over the repository data highlight bounded contexts that flirt with dependency sprawl or breach agreed cadence limits, allowing governance forums to focus on proactive architecture stewardship rather than retrospective firefighting.
+
+Policy-as-code platforms also need explicit incident playbooks so non-compliance is handled consistently. Each rule should define the responsible owner, compensating controls, and the window for remediation, with ChatOps actions and ticket templates bundled into the repository for rapid execution when a check fails ([Source [10]](33_references.md#source-10)). Scheduled reviews of closed incidents confirm that escalations were resolved within the expected time frame and feed continuous improvements into both the policy set and the supporting enablement materials.
+
 ## Key Takeaways
 
 Governance as Code modernises policy management by placing guardrails alongside the systems they protect. Using pull requests to orchestrate approvals strengthens auditability and responsiveness, while deliberate enablement, training, and supportive tooling ensure that governance professionals can thrive in a code-based ecosystem.
@@ -39,6 +45,8 @@ Governance as Code modernises policy management by placing guardrails alongside 
 ## Sources
 
 Sources:
+- [Cloud Native Computing Foundation – Policy as Code Whitepaper (2021)](https://github.com/cncf/tag-app-delivery/blob/main/policy-as-code-whitepaper.md) ([Source [10]](33_references.md#source-10))
 - [GitHub Docs – About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
 - [Open Policy Agent – Policy as Code Overview](https://www.openpolicyagent.org/docs/latest/)
 - [Thoughtworks Technology Radar – Governance as Code](https://www.thoughtworks.com/radar/techniques/governance-as-code)
+- [Sam Newman – *Building Microservices*, 2nd Edition (2021)](https://www.oreilly.com/library/view/building-microservices-2nd/9781492034018/) ([Source [2]](33_references.md#source-2))

--- a/docs/33_references.md
+++ b/docs/33_references.md
@@ -4,7 +4,9 @@ This section provides a comprehensive list of all sources and references cited t
 
 ## Numbered source index
 
+- <a id="source-2"></a>**Source [2]:** Newman, Sam. *Building Microservices* (2nd ed.). O'Reilly Media, 2021. Referenced in: [Chapter 08: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md).
 - <a id="source-7"></a>**Source [7]:** Cloud Native Computing Foundation. *State of Cloud Native Development 2024.* Cloud Native Computing Foundation, 2024. Referenced in: [Chapter 7: Containerisation and Orchestration as Code](07_containerization.md).
+- <a id="source-10"></a>**Source [10]:** Cloud Native Computing Foundation. *Policy as Code Whitepaper.* TAG App Delivery, 2021. Referenced in: [Chapter 08: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md).
 - <a id="source-15"></a>**Source [15]:** Pulumi. *Testing Infrastructure as Code Programs.* Pulumi Blog, 2024. Referenced in: [Chapter 13: Testing Strategies for Infrastructure as Code](13_testing_strategies.md).
 - <a id="source-16"></a>**Source [16]:** HashiCorp. *Securing Terraform State.* HashiCorp Developer Documentation, 2024. Referenced in: [Chapter 9a: Security Fundamentals for Architecture as Code](09a_security_fundamentals.md), [Chapter 9b: Advanced Security Patterns and Implementation](09b_security_patterns.md).
 - <a id="source-17"></a>**Source [17]:** HashiCorp. *Backend Type: s3.* HashiCorp Developer Documentation, 2024. Referenced in: [Chapter 9a: Security Fundamentals for Architecture as Code](09a_security_fundamentals.md), [Chapter 9b: Advanced Security Patterns and Implementation](09b_security_patterns.md).
@@ -41,7 +43,10 @@ This section provides a comprehensive list of all sources and references cited t
 **Cloud Native Computing Foundation.** "State of Cloud Native Development 2024." Cloud Native Computing Foundation, 2024. (Source [7])
 *Referenced in: [Chapter 1: Introduction](01_introduction.md), [Chapter 7: Containerisation](07_containerization.md)*
 
-**FINOS.** "CALM: Common Architecture Language Model." FINOS Architecture as Code Community, 2024. [https://calm.finos.org/](https://calm.finos.org/)  
+**Cloud Native Computing Foundation.** "Policy as Code Whitepaper." TAG App Delivery, 2021. (Source [10])
+*Referenced in: [Chapter 8: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md)*
+
+**FINOS.** "CALM: Common Architecture Language Model." FINOS Architecture as Code Community, 2024. [https://calm.finos.org/](https://calm.finos.org/)
 *Referenced in: [Chapter 22: Documentation as Code vs Architecture as Code](22_documentation_vs_architecture.md)*
 
 **Ford, Neal et al.** "Building Evolutionary Architectures." O'Reilly Media, 2017.  
@@ -83,10 +88,13 @@ This section provides a comprehensive list of all sources and references cited t
 **Mermaid.** "Mermaid: Diagramming and Charting Tool." Mermaid Documentation, 2024. [https://mermaid.js.org/](https://mermaid.js.org/)  
 *Referenced in: [Chapter 22: Documentation as Code vs Architecture as Code](22_documentation_vs_architecture.md)*
 
-**NIST.** "Requirements Engineering for Secure Systems." NIST Special Publication 800-160, 2023.  
+**NIST.** "Requirements Engineering for Secure Systems." NIST Special Publication 800-160, 2023.
 *Referenced in: [Chapter 2: Fundamental Principles](02_fundamental_principles.md)*
 
-**Nygard, M.** "Documenting Architecture Decisions." 2011.  
+**Newman, S.** "Building Microservices." O'Reilly Media, 2021. (Source [2])
+*Referenced in: [Chapter 8: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md)*
+
+**Nygard, M.** "Documenting Architecture Decisions." 2011.
 *Referenced in: [Chapter 4: Architecture Decision Records](04_adr.md)*
 
 **Open Policy Agent.** "Policy as Code: Expressing Requirements as Code." CNCF OPA Project, 2024.  


### PR DESCRIPTION
## Summary
- expand Chapter 08 with policy-as-code guardrails, service contract catalogues, and escalation playbooks backed by new sources
- extend Chapter 11 to manage shared catalogues and consistent escalation responses to failed policy checks
- register Sources [2] and [10] in the references chapter and link them to the updated guidance

## Testing
- python3 generate_book.py
- docs/build_book.sh *(fails: missing xelatex in container)*

------
https://chatgpt.com/codex/tasks/task_e_69011be74b2c833093527b1091d6df2a