### PR TITLE
Fix maturity radar axis text overflow

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -85,6 +85,16 @@
       padding: 1.5rem;
       background-color: #ffffff;
       box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+      overflow-x: auto;
+    }
+
+    #radarDiagram svg {
+      max-width: 100%;
+      height: auto;
+    }
+
+    #radarDiagram text {
+      font-size: 0.85rem;
     }
 
     .diagram-error {
@@ -1140,6 +1150,33 @@
 
       const escapedLabel = (label) => label.replace(/"/g, '\"');
 
+      const wrapLabel = (label, maxLineLength = 24) => {
+        if (typeof label !== "string" || !label.trim()) {
+          return label;
+        }
+
+        const words = label.trim().split(/\s+/);
+        const lines = [];
+        let currentLine = [];
+
+        words.forEach((word) => {
+          const prospectiveLine = [...currentLine, word].join(" ");
+
+          if (prospectiveLine.length > maxLineLength && currentLine.length) {
+            lines.push(currentLine.join(" "));
+            currentLine = [word];
+          } else {
+            currentLine.push(word);
+          }
+        });
+
+        if (currentLine.length) {
+          lines.push(currentLine.join(" "));
+        }
+
+        return lines.join("<br/>");
+      };
+
       const axes = results.map((result) => {
         const normalisedScore = result.totalQuestions
           ? (result.yesCount / result.totalQuestions) * 5
@@ -1147,7 +1184,7 @@
 
         return {
           key: result.aspectKey,
-          label: result.aspectName,
+          label: wrapLabel(result.aspectName),
           value: Number(normalisedScore.toFixed(2))
         };
       });


### PR DESCRIPTION
## Summary
- wrap long maturity radar axis labels so Mermaid can render multi-line text within the maturity radar
- adjust the radar container styling to keep the diagram responsive and reduce label font size

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_69032bd3b7a08330952f94899b2a1feb