### PR TITLE
Include risks and mitigations in radar export

### DIFF
--- a/docs/maturity_model_radar.html
+++ b/docs/maturity_model_radar.html
@@ -1129,13 +1129,34 @@
       renderRadar(radarDefinition);
       const suggestions = collectImprovementSuggestions(detailedResults);
 
+      const exportPayload = {
+        ...resultPayload,
+        suggestions: suggestions.map(
+          ({
+            aspectKey,
+            aspectName,
+            question,
+            risk,
+            recommendation,
+            reference
+          }) => ({
+            aspectKey,
+            aspectName,
+            question,
+            risk,
+            mitigation: recommendation,
+            reference
+          })
+        )
+      };
+
       const jsonOutput = document.getElementById("jsonOutput");
-      jsonOutput.value = JSON.stringify(resultPayload, null, 2);
+      jsonOutput.value = JSON.stringify(exportPayload, null, 2);
 
       latestAssessment = {
         detailedResults,
         suggestions,
-        resultPayload
+        resultPayload: exportPayload
       };
 
       renderSummaryTable(detailedResults);
@@ -1341,6 +1362,7 @@
           }
 
           suggestions.push({
+            aspectKey: result.aspectKey,
             aspectName: result.aspectName,
             question: answer.question,
             risk: suggestionDefinition.risk,


### PR DESCRIPTION
## Summary
- extend the maturity radar export payload to include improvement suggestions alongside assessment metrics
- surface risk and mitigation details for each recommendation so they appear in the JSON download

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903502751408330963e9400fe18eea9