### PR TITLE
Fix inconsistent figure numbering in compliance chapter

### DIFF
--- a/docs/12_compliance.md
+++ b/docs/12_compliance.md
@@ -4,7 +4,7 @@
 
 *Figure 12.1 illustrates how regulatory intelligence flows into policy templates, automated controls, monitoring, evidence collection, and governance feedback loops.*
 
-Architecture as Code is central to meeting the expanding scope of compliance requirements and regulatory expectations. As introduced in [Chapter 10 on policy and security](10_policy_and_security.md), codified policies allow teams to translate legislation into repeatable controls. Figure 12-1 shows how that translation depends on a closed feedback loop. This chapter focuses on the organisational and process-oriented aspects that keep this loop healthy in large-scale environments.
+Architecture as Code is central to meeting the expanding scope of compliance requirements and regulatory expectations. As introduced in [Chapter 10 on policy and security](10_policy_and_security.md), codified policies allow teams to translate legislation into repeatable controls. Figure 12.1 shows how that translation depends on a closed feedback loop. This chapter focuses on the organisational and process-oriented aspects that keep this loop healthy in large-scale environments.
 
 | Compliance Loop Stage | Activities | Outputs | Feedback Mechanism |
 |----------------------|------------|---------|-------------------|


### PR DESCRIPTION
## Summary
- update the compliance chapter to reference Figure 12.1 using the dot numbering style
- ensure figure numbering remains consistent across the book by removing the lone hyphenated instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905d7c115f083309cb2757fb219476d