### PR TITLE
Integrate Evidence as Code chapter into navigation and build

### DIFF
--- a/BOOK_REQUIREMENTS.md
+++ b/BOOK_REQUIREMENTS.md
@@ -381,7 +381,8 @@ Readers should understand cloud platforms (AWS, Azure or GCP), be comfortable wi
 | Chapter 12 | 12_compliance.md | Compliance and Regulatory Adherence | Security and Governance | Yes |
 | Chapter 13 | 13_testing_strategies.md | Testing Strategies for Infrastructure as Code | Delivery and Operations | Yes |
 | Chapter 14 | 14_practical_implementation.md | Architecture as Code in Practice | Delivery and Operations | Yes |
-| Chapter 15 | 15_cost_optimization.md | Cost Optimisation and Resource Management | Delivery and Operations | Yes |
+| Chapter 15A | 15_evidence_as_code.md | Evidence as Code and Continuous Assurance | Delivery and Operations | Yes |
+| Chapter 15B | 15_cost_optimization.md | Cost Optimisation and Resource Management | Delivery and Operations | Yes |
 | Chapter 16 | 16_migration.md | Migration from Traditional Infrastructure | Delivery and Operations | Yes |
 | Chapter 17 | 17_organisational_change.md | Organisational Change and Team Structures | Organisation and Leadership | Yes |
 | Chapter 18 | 18_team_structure.md | Team Structure and Competency Development for Architecture as Code | Organisation and Leadership | Yes |

--- a/docs/book_structure.md
+++ b/docs/book_structure.md
@@ -68,13 +68,14 @@ Reference material, author information, technical enablers, and the Architecture
 
 ### Part 4: Delivery & Operations (Chapters 13-16)
 
-**Focus:** Testing strategies, delivery patterns, financial optimisation, and migration approaches
+**Focus:** Testing strategies, delivery patterns, evidence automation, financial optimisation, and migration approaches
 
 | Chapter | File | Title | Description |
 |---------|------|-------|-------------|
 | 13 | `13_testing_strategies.md` | Testing Strategies for Infrastructure as Code | Testing of IaC and architecture code |
 | 14 | `14_practical_implementation.md` | Architecture as Code in Practice | Practical implementation examples |
-| 15 | `15_cost_optimization.md` | Cost Optimisation and Resource Management | Economic optimisation of resources |
+| 15A | `15_evidence_as_code.md` | Evidence as Code and Continuous Assurance | Automated evidence pipelines that connect policy automation to operational reporting |
+| 15B | `15_cost_optimization.md` | Cost Optimisation and Resource Management | Economic optimisation of resources |
 | 16 | `16_migration.md` | Migration from Traditional Infrastructure | Migration strategies and best practices |
 
 ### Part 5: Organisation & Leadership (Chapters 17-21)

--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -421,6 +421,7 @@ CHAPTER_FILES=(
     "part_d_delivery_operations.md"
     "13_testing_strategies.md"
     "14_practical_implementation.md"
+    "15_evidence_as_code.md"
     "15_cost_optimization.md"
     "16_migration.md"
     "part_e_organisation_leadership.md"

--- a/docs/part_d_delivery_operations.md
+++ b/docs/part_d_delivery_operations.md
@@ -10,6 +10,8 @@ Testing Infrastructure as Code requires a distinct approach from traditional sof
 
 Practical implementation brings Architecture as Code principles into real-world projects. Organisations must balance ideal patterns with existing constraints, legacy systems, and transitional states. This part provides concrete guidance for navigating these challenges whilst maintaining the [security controls](09_security_fundamentals.md) and [governance frameworks](11_governance_as_code.md) established in earlier sections.
 
+Sustainable operations also depend on demonstrable compliance. Evidence pipelines translate automated policies into auditable artefacts that regulators, risk managers, and stakeholders can trust without manual rework. The dedicated chapter on [Evidence as Code](15_evidence_as_code.md) shows how to package these artefacts so they can be replayed across frameworks, closing the feedback loop between automation and assurance.
+
 Financial considerations directly influence architectural decisions. Cost optimisation in cloud environments demands visibility into resource consumption, proactive management of waste, and alignment between technical choices and business value. Architecture as Code enables this through automated cost tracking, policy-based budget enforcement, and resource right-sizing.
 
 Migration from traditional infrastructure to Architecture as Code represents a significant organisational journey. Success depends on phased approaches, risk management, and maintaining service continuity throughout the transition. The strategies presented here draw on proven patterns whilst acknowledging that every organisation's starting point and constraints differ.
@@ -18,6 +20,7 @@ Migration from traditional infrastructure to Architecture as Code represents a s
 
 - Comprehensive testing strategies from unit tests to full system validation
 - Practical implementation patterns that balance principles with pragmatism
+- Evidence automation practices that keep compliance artefacts reusable and trustworthy
 - Cost optimisation techniques using automated monitoring and policy enforcement
 - Migration approaches that reduce risk whilst accelerating transformation
 - Operational excellence practices for Architecture as Code at scale

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - index: part_d_delivery_operations.md
       - Testing Strategies for Infrastructure as Code: 13_testing_strategies.md
       - Architecture as Code in Practice: 14_practical_implementation.md
+      - Evidence as Code and Continuous Assurance: 15_evidence_as_code.md
       - Cost Optimisation and Resource Management: 15_cost_optimization.md
       - Migration from Traditional Infrastructure: 16_migration.md
   - Part E – Organisation & Leadership:


### PR DESCRIPTION
## Summary
- add the Evidence as Code chapter to the MkDocs navigation and the build script
- document the chapter in the book structure and publishing requirements
- highlight evidence automation in the Part D introduction to reinforce the chapter’s scope

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: xelatex not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905e7ee5e088330ba8658db6cad7189