### PR TITLE
Clarify build script location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ python3 build_all_orchestrator.py --zip
 
 ```
 
+> **Where is the build script?** The helper referenced above lives at `docs/build_book.sh`, is checked into source control, and ships with executable permissions so it can be invoked directly from the repository root (`./docs/build_book.sh`). The high-level orchestrator (`build_all_orchestrator.py`) calls the same entry point internally, keeping the README instructions and the automated workflow in lockstep.
+
 The GitHub Actions pipeline (`.github/workflows/unified-build-release.yml`) mirrors these commands to produce release artifacts whenever book content or automation scripts change.【F:build_release.sh】
 
 ### MkDocs Documentation Site


### PR DESCRIPTION
## Summary
- highlight that the documented helper script lives at `docs/build_book.sh` with execute permissions
- note that the Python orchestrator uses the same entry point to keep workflows aligned

## Testing
- not run (documentation update only)


------
https://chatgpt.com/codex/tasks/task_e_69063e6ffd308330978731a2ddfd6d2e