### PR TITLE
Align MkDocs configuration with custom domain metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ mkdocs build   # render static site into the site/ directory
 
 Continuous integration enforces successful builds through the `Build MkDocs Site` workflow, which runs whenever `docs/` sources or the MkDocs configuration change.【F:mkdocs.yml】【F:.github/workflows/build-mkdocs.yml】
 
-> **Live URL:** The GitHub Pages deployment uses the custom domain `https://aac.geon.se`, and GitHub automatically redirects the default `https://geonitab.github.io/architecture_as_code/` address to that hostname. Requests to `aac.github.com` will appear blank because that domain is not owned by this project and is therefore outside of the configured Pages setup.【F:CNAME】
+## 🌐 Website
+
+- **Public URL:** The documentation site is published at [https://aac.geon.se](https://aac.geon.se), matching the custom domain stored in the repository `CNAME` file to keep canonical links stable.【F:CNAME】【F:mkdocs.yml】
+- **Deployment pipeline:** The `Build MkDocs Site` GitHub Actions workflow builds the site with `mkdocs build`, stages the generated artefacts (including `CNAME` and `.nojekyll`), and force-pushes the result to the `gh-pages` branch for GitHub Pages to serve.【F:.github/workflows/build-mkdocs.yml】
+- **Local validation:** Run `mkdocs serve` for a preview or `mkdocs build` to recreate the static site locally before triggering a deployment, ensuring the hosted content mirrors the book manuscript.【F:mkdocs.yml】
 
 ## 📦 Release Deliverables
 - **Book formats:** `architecture_as_code.pdf`, `.epub`, and `.docx` generated via Pandoc with the Eisvogel template.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Architecture as Code
+site_name: Architecture as Code at aac.geon.se
 site_description: "Architecture as Code book content published as a browsable documentation site."
-site_url: http://aac.geon.se/
+site_url: https://aac.geon.se/
 repo_url: https://github.com/geonitab/architecture_as_code
 repo_name: architecture_as_code
 nav:


### PR DESCRIPTION
## Summary
- update the MkDocs site name and canonical URL so they match the custom domain configured in the CNAME file
- document the public website location and GitHub Pages deployment workflow in the README for easier verification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69063e516cac8330acb67bfae802e120