### PR TITLE
Add CI validation for chapter numbering

### DIFF
--- a/.github/workflows/validate-doc-numbering.yml
+++ b/.github/workflows/validate-doc-numbering.yml
@@ -1,0 +1,32 @@
+name: Validate Chapter Numbering
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/*.md'
+      - 'scripts/check_doc_numbering.py'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/*.md'
+      - 'scripts/check_doc_numbering.py'
+  workflow_dispatch: {}
+
+jobs:
+  numbering-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v5
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: 🔍 Validate chapter numbering
+        run: |
+          python3 scripts/check_doc_numbering.py

--- a/scripts/check_doc_numbering.py
+++ b/scripts/check_doc_numbering.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate numbering of book chapter files in docs/ directory."""
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+import re
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+PATTERN = re.compile(r"^(?P<number>\d+)(?P<suffix>[a-z]*)_.*\.md$", re.IGNORECASE)
+
+
+def collect_numbered_files() -> dict[int, list[tuple[str, Path]]]:
+    numbered: dict[int, list[tuple[str, Path]]] = defaultdict(list)
+
+    for path in DOCS_DIR.glob("*.md"):
+        match = PATTERN.match(path.name)
+        if not match:
+            continue
+
+        number = int(match.group("number"))
+        suffix = match.group("suffix").lower()
+        numbered[number].append((suffix, path))
+
+    return numbered
+
+
+def find_numeric_gaps(sorted_numbers: list[int]) -> list[tuple[int, int]]:
+    gaps: list[tuple[int, int]] = []
+    for current, nxt in zip(sorted_numbers, sorted_numbers[1:]):
+        if nxt - current > 1:
+            gaps.append((current, nxt))
+    return gaps
+
+
+def find_numeric_duplicates(entries: dict[int, list[tuple[str, Path]]]) -> list[str]:
+    duplicates: list[str] = []
+    for number, suffixes in entries.items():
+        seen: dict[str, Path] = {}
+        for suffix, path in suffixes:
+            key = f"{number}{suffix}"
+            if key in seen:
+                duplicates.append(
+                    "Duplicate entry for "
+                    f"{key}: {seen[key].name} and {path.name}"
+                )
+            else:
+                seen[key] = path
+    return duplicates
+
+
+def check_suffix_sequences(number: int, suffix_entries: list[tuple[str, Path]]) -> list[str]:
+    errors: list[str] = []
+
+    base_present = any(suffix == "" for suffix, _ in suffix_entries)
+    letters = sorted({suffix for suffix, _ in suffix_entries if suffix})
+
+    if len(letters) != len([suffix for suffix, _ in suffix_entries if suffix]):
+        errors.append(f"Duplicate appendix suffix detected for {number:02d}")
+
+    if not letters:
+        return errors
+
+    expected_start = "a" if not base_present else letters[0]
+    expected_ord = ord(expected_start)
+
+    for letter in letters:
+        if ord(letter) != expected_ord:
+            expected_label = chr(expected_ord).upper()
+            errors.append(
+                "Missing appendix label for "
+                f"{number:02d}: expected suffix '{expected_label}' before '{letter.upper()}'"
+            )
+            expected_ord = ord(letter)
+        expected_ord += 1
+
+    return errors
+
+
+def main() -> int:
+    numbered = collect_numbered_files()
+    if not numbered:
+        print("No numbered chapters found in docs/ directory.")
+        return 0
+
+    sorted_numbers = sorted(numbered)
+
+    errors: list[str] = []
+
+    gaps = find_numeric_gaps(sorted_numbers)
+    for previous_number, next_number in gaps:
+        errors.append(
+            "Gap detected between numbered chapters: "
+            f"{previous_number:02d} is followed by {next_number:02d}."
+        )
+
+    errors.extend(find_numeric_duplicates(numbered))
+
+    for number, suffix_entries in numbered.items():
+        errors.extend(check_suffix_sequences(number, suffix_entries))
+
+    if errors:
+        print("Numbering validation failed:")
+        for message in errors:
+            print(f" - {message}")
+        return 1
+
+    print("Numbering validation passed with no gaps or duplicates detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Python script that validates numbered chapter files for gaps, duplicate prefixes, and appendix suffix order
- introduce a GitHub Actions workflow to run the numbering validation on pushes and pull requests touching numbered docs

## Testing
- python3 scripts/check_doc_numbering.py

------
https://chatgpt.com/codex/tasks/task_e_690645003b8083308ea37e7cf1a9ffac