### PR TITLE
Document Mermaid diagram policy and automate checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat generated diagram assets as binary to avoid noisy diffs
+/docs/images/*.png binary

--- a/.github/workflows/verify-mermaid-diagrams.yml
+++ b/.github/workflows/verify-mermaid-diagrams.yml
@@ -1,0 +1,48 @@
+name: Verify Mermaid Diagrams
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/images/**/*.mmd'
+      - 'docs/images/**/*.png'
+      - 'docs/mermaid-kvadrat-theme.json'
+      - 'scripts/check_mermaid_diagrams.py'
+      - '.github/workflows/verify-mermaid-diagrams.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/images/**/*.mmd'
+      - 'docs/images/**/*.png'
+      - 'docs/mermaid-kvadrat-theme.json'
+      - 'scripts/check_mermaid_diagrams.py'
+      - '.github/workflows/verify-mermaid-diagrams.yml'
+  workflow_dispatch: {}
+
+jobs:
+  diagram-consistency:
+    name: Ensure Mermaid diagrams are up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: 🔧 Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.1'
+
+      - name: 📦 Install Node.js dependencies
+        run: npm ci
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: 🔍 Verify Mermaid diagrams
+        run: python3 scripts/check_mermaid_diagrams.py

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ releases/                 # Git-ignored distribution bundles populated by build 
 
 The canonical ordering of these chapters is published in `docs/book_index.json`, enabling automation and quality checks to consume a single, machine-readable source of truth.【F:docs/book_index.json】
 
+## 🖼️ Diagram Workflow
+
+Mermaid diagrams live in `docs/images/` with the source (`*.mmd`) and the rendered PNG committed together. Keeping both artefacts in version control ensures offline readers, document reviewers, and downstream automations can rely on stable diagrams without regenerating assets. The PNG files are marked as binary in `.gitattributes` so pull requests stay tidy even when large diagrams change.【F:.gitattributes†L1-L2】
+
+When you adjust or add diagrams:
+
+- Run `npm ci` once per workspace to install the locked Mermaid CLI toolchain.
+- Execute `python3 scripts/check_mermaid_diagrams.py` to confirm every committed PNG still matches its Mermaid source. The helper renders each diagram using the same parameters as the book build and fails fast if an image is missing or outdated.【F:scripts/check_mermaid_diagrams.py†L1-L138】
+- If the check reports that Chromium cannot start, install the headless browser dependencies listed in the error output or point `PUPPETEER_EXECUTABLE_PATH` to an existing Chrome binary before rerunning the command.【F:scripts/check_mermaid_diagrams.py†L94-L138】
+
+Continuous integration reinforces this policy via the **Verify Mermaid Diagrams** workflow, which installs the toolchain and runs the same check on every push or pull request that touches the diagram set.【F:.github/workflows/verify-mermaid-diagrams.yml†L1-L53】
+
 ## 🚀 Build and Automation Workflow
 
 ### Prerequisites

--- a/scripts/check_mermaid_diagrams.py
+++ b/scripts/check_mermaid_diagrams.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate that committed Mermaid diagrams reflect their sources."""
+
+from __future__ import annotations
+
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+
+
+def _resolve_mmdc(root: Path) -> Path:
+    """Locate the Mermaid CLI executable."""
+
+    local_mmdc = root / "node_modules" / ".bin" / "mmdc"
+    if local_mmdc.is_file():
+        return local_mmdc
+
+    fallback = shutil.which("mmdc")
+    if fallback:
+        return Path(fallback)
+
+    raise FileNotFoundError(
+        "Mermaid CLI (mmdc) is unavailable. Run 'npm ci' before executing this check."
+    )
+
+
+def _build_command(
+    mmdc_path: Path, source: Path, target: Path, theme: Path | None
+) -> List[str]:
+    command = [
+        str(mmdc_path),
+        "-i",
+        str(source),
+        "-o",
+        str(target),
+        "-t",
+        "default",
+        "-b",
+        "transparent",
+        "--width",
+        "1400",
+        "--height",
+        "900",
+    ]
+
+    if theme and theme.is_file():
+        command.extend(["-c", str(theme)])
+
+    return command
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    images_dir = repo_root / "docs" / "images"
+    theme_file = repo_root / "docs" / "mermaid-kvadrat-theme.json"
+
+    if not images_dir.is_dir():
+        print("No diagram directory found; nothing to validate.")
+        return 0
+
+    try:
+        mmdc_path = _resolve_mmdc(repo_root)
+    except FileNotFoundError as exc:  # pragma: no cover - direct exit path
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    sources = sorted(images_dir.glob("*.mmd"))
+    if not sources:
+        print("No Mermaid sources discovered; nothing to validate.")
+        return 0
+
+    failures: List[str] = []
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        for source in sources:
+            target = source.with_suffix(".png")
+
+            if not target.is_file():
+                failures.append(
+                    f"❌ Missing rendered diagram for {source.relative_to(repo_root)}"
+                )
+                continue
+
+            candidate = tmp_path / target.name
+            command = _build_command(mmdc_path, source, candidate, theme_file)
+
+            result = subprocess.run(
+                command,
+                check=False,
+                env=os.environ,
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "").strip()
+                if "libatk-1.0.so.0" in detail:
+                    failures.append(
+                        "❌ Mermaid CLI could not launch a headless browser. Install the "
+                        "GTK/ATK runtime (e.g. libatk-1.0-0, libgtk-3-0, libnss3, libxss1) "
+                        "or point PUPPETEER_EXECUTABLE_PATH to an existing Chrome binary "
+                        "before running the check."
+                    )
+                    break
+
+                failures.append(
+                    "❌ Failed to render "
+                    f"{source.relative_to(repo_root)} via Mermaid CLI: {detail}"
+                )
+                continue
+
+            if not candidate.is_file() or candidate.stat().st_size == 0:
+                failures.append(
+                    f"❌ Mermaid CLI did not produce output for {source.relative_to(repo_root)}"
+                )
+                continue
+
+            if not filecmp.cmp(candidate, target, shallow=False):
+                failures.append(
+                    "❌ Rendered output diverges from committed PNG: "
+                    f"{target.relative_to(repo_root)}"
+                )
+
+    if failures:
+        print("Mermaid diagram validation failed:")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("✅ All Mermaid diagrams match their committed PNG counterparts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- document the committed source-and-image policy for Mermaid diagrams in the README
- mark generated PNG diagrams as binary assets and add a helper to verify they match their Mermaid sources
- introduce a GitHub Actions workflow that runs the new verification script on diagram changes

## Testing
- python3 scripts/check_mermaid_diagrams.py *(fails: Mermaid CLI requires libatk-1.0-0 and related system libraries in this container)*

------
https://chatgpt.com/codex/tasks/task_e_69064f1a9f8c8330a79c981a2c96bed1