### PR TITLE
Add stable anchors and configure MkDocs redirects

### DIFF
--- a/docs/01_introduction.md
+++ b/docs/01_introduction.md
@@ -1,4 +1,4 @@
-# Introduction to Architecture as Code
+# Introduction to Architecture as Code {#introduction}
 
 Architecture as Code represents a paradigm shift in system development where the entire system architecture is defined, version-controlled, and managed through code. This approach enables organisations to apply the same methodologies as traditional software development across their whole technical landscape.
 

--- a/docs/02_fundamental_principles.md
+++ b/docs/02_fundamental_principles.md
@@ -1,4 +1,4 @@
-# Fundamental Principles of Architecture as Code
+# Fundamental Principles of Architecture as Code {#fundamental-principles}
 
 Architecture as Code is founded on core principles that enable successful implementation of codified system architecture. These principles span the entire system landscape and provide a holistic view of architecture management.
 

--- a/docs/03_version_control.md
+++ b/docs/03_version_control.md
@@ -1,4 +1,4 @@
-# Version Control and Code Structure
+# Version Control and Code Structure {#version-control}
 
 Effective version control forms the backbone of Architecture as Code implementations. Applying the same practices as software development to infrastructure definitions delivers traceability, collaboration opportunities, and quality control.
 

--- a/docs/04_adr.md
+++ b/docs/04_adr.md
@@ -1,4 +1,4 @@
-# Architecture Decision Records (ADR)
+# Architecture Decision Records (ADR) {#adr}
 
 ![ADR Process Flow](images/diagram_04_adr_process.png)
 

--- a/docs/05_automation_devops_cicd.md
+++ b/docs/05_automation_devops_cicd.md
@@ -1,4 +1,4 @@
-# Automation, DevOps and CI/CD for Architecture as Code
+# Automation, DevOps and CI/CD for Architecture as Code {#automation-devops-cicd}
 
 ![Automation and CI/CD pipelines](images/diagram_04_chapter3.png)
 

--- a/docs/06_structurizr.md
+++ b/docs/06_structurizr.md
@@ -1,4 +1,4 @@
-# Structurizr: Architecture Modeling as Code
+# Structurizr: Architecture Modeling as Code {#structurizr}
 
 ![Structurizr Overview](images/diagram_06_structurizr_overview.png)
 

--- a/docs/07_containerisation.md
+++ b/docs/07_containerisation.md
@@ -1,4 +1,4 @@
-# Containerisation and Orchestration as Code
+# Containerisation and Orchestration as Code {#containerisation}
 
 ![Containerisation and Orchestration](images/diagram_11_chapter10.png)
 

--- a/docs/08_microservices.md
+++ b/docs/08_microservices.md
@@ -1,4 +1,4 @@
-# Microservices Architecture as Code
+# Microservices Architecture as Code {#microservices}
 
 ## Introduction
 

--- a/docs/09_security_fundamentals.md
+++ b/docs/09_security_fundamentals.md
@@ -1,4 +1,4 @@
-# Security Fundamentals for Architecture as Code
+# Security Fundamentals for Architecture as Code {#security-fundamentals}
 
 ![Security as code workflow](images/diagram_06_chapter5.png)
 

--- a/docs/09b_security_patterns.md
+++ b/docs/09b_security_patterns.md
@@ -1,4 +1,4 @@
-# Advanced Security Patterns and Implementation
+# Advanced Security Patterns and Implementation {#security-patterns}
 
 ![Security as code workflow](images/diagram_06_chapter5.png)
 

--- a/docs/09c_risk_and_threat_as_code.md
+++ b/docs/09c_risk_and_threat_as_code.md
@@ -1,4 +1,4 @@
-# Risk as Code and Threat Handling as Code
+# Risk as Code and Threat Handling as Code {#risk-and-threat-as-code}
 
 *Risk management is often treated as a paperwork exercise. When executed as code it becomes measurable, testable, and continuously enforceable across every environment.*
 

--- a/docs/10_policy_and_security.md
+++ b/docs/10_policy_and_security.md
@@ -1,4 +1,4 @@
-# Policy and Security as Code in Detail
+# Policy and Security as Code in Detail {#policy-and-security}
 
 ![Policy-as-Code delivery lifecycle](images/diagram_10_policy_lifecycle.png)
 

--- a/docs/11_governance_as_code.md
+++ b/docs/11_governance_as_code.md
@@ -1,4 +1,4 @@
-# Governance as Code
+# Governance as Code {#governance-as-code}
 
 ## Overview
 

--- a/docs/12_compliance.md
+++ b/docs/12_compliance.md
@@ -1,4 +1,4 @@
-# Compliance and Regulatory Adherence
+# Compliance and Regulatory Adherence {#compliance}
 
 ![Compliance automation lifecycle overview](images/diagram_12_compliance.png)
 

--- a/docs/13_testing_strategies.md
+++ b/docs/13_testing_strategies.md
@@ -1,4 +1,4 @@
-# Testing Strategies for Infrastructure as Code
+# Testing Strategies for Infrastructure as Code {#testing-strategies}
 
 ![Test pyramid for architecture as code](images/diagram_13_test_pyramid.png)
 

--- a/docs/14_practical_implementation.md
+++ b/docs/14_practical_implementation.md
@@ -1,4 +1,4 @@
-# Architecture as Code in Practice
+# Architecture as Code in Practice {#practical-implementation}
 
 Architecture as Code succeeds when teams bring organisational ambitions, engineering discipline, and operating constraints together in a single delivery motion. Practical adoption requires a structured roadmap, supportive tooling, and a culture that treats infrastructure change as a product in its own right.
 

--- a/docs/15_cost_optimization.md
+++ b/docs/15_cost_optimization.md
@@ -1,4 +1,4 @@
-# Cost Optimisation and Resource Management
+# Cost Optimisation and Resource Management {#cost-optimization}
 
 ![Cost optimisation workflow](images/diagram_16_chapter15.png)
 

--- a/docs/15_evidence_as_code.md
+++ b/docs/15_evidence_as_code.md
@@ -1,4 +1,4 @@
-# Evidence as Code
+# Evidence as Code {#evidence-as-code}
 
 Evidence is the currency that allows Architecture as Code to demonstrate trustworthiness at scale. Treating evidence as code means the artefacts that prove compliance are generated automatically, stored alongside the controls they verify, and versioned so that their provenance is unquestionable. Combined with the **assure once, comply many** principle, evidence captured for a single control objective can be replayed across multiple regulatory frameworks without repeating manual audits.
 

--- a/docs/16_migration.md
+++ b/docs/16_migration.md
@@ -1,4 +1,4 @@
-# Migration from Traditional Infrastructure
+# Migration from Traditional Infrastructure {#migration}
 
 ![Migrationsprocess](images/diagram_18_kapitel17.png)
 

--- a/docs/17_organisational_change.md
+++ b/docs/17_organisational_change.md
@@ -1,4 +1,4 @@
-# Organisational Change and Team Structures
+# Organisational Change and Team Structures {#organisational-change}
 
 Architecture as Code changes far more than tooling. It demands new habits, shared language, and organisational structures that keep pace with automated delivery. Sustainable transformation happens when leadership connects strategy, culture, and day-to-day practices so teams can deliver infrastructure with the same confidence and cadence as software.
 

--- a/docs/18_team_structure.md
+++ b/docs/18_team_structure.md
@@ -1,4 +1,4 @@
-# Team Structure and Competency Development for Architecture as Code
+# Team Structure and Competency Development for Architecture as Code {#team-structure}
 
 ![Team collaboration ecosystem showing leadership, platform enablement, shared services, and feedback loops](images/diagram_18_team_collaboration.png)
 

--- a/docs/19_management_as_code.md
+++ b/docs/19_management_as_code.md
@@ -1,4 +1,4 @@
-# Management as Code
+# Management as Code {#management-as-code}
 
 ## Introduction
 Management as Code (MaC) extends the well-established principles of Infrastructure as Code and Architecture as Code into the realm of organisational leadership. It treats management intent, governance routines, and decision frameworks as executable artefacts that can be versioned, tested, automated, and refined. In organisations where the entire delivery pipeline is codified, management practices that remain trapped in meetings, slide decks, or undocumented intuition quickly become bottlenecks. A MaC discipline eliminates that bottleneck by encoding strategic direction, operational constraints, and cultural values into the same repositories that power the technology stack. This chapter explores how MaC manifests in fully code-based environments, how management roles adapt to DevOps loops, and how tooling such as GitHub can embed leadership into the change lifecycle while addressing budgeting, capability development, and the orchestration of multiple teams or teams-of-teams.

--- a/docs/20_ai_agent_team.md
+++ b/docs/20_ai_agent_team.md
@@ -1,4 +1,4 @@
-# AI Agent Team for the Architecture as Code Initiative
+# AI Agent Team for the Architecture as Code Initiative {#ai-agent-team}
 
 The Architecture as Code initiative relies on a cohesive ensemble of AI agents that operate as a digital delivery team. Each agent contributes specialised expertise while adhering to a single backlog, common documentation practices, and shared quality thresholds. This chapter reframes the agent ecosystem in British English, translating previous checklists into narrative guidance that emphasises collaboration, accountability, and the continual refinement of project artefacts.
 

--- a/docs/21_digitalisation.md
+++ b/docs/21_digitalisation.md
@@ -1,4 +1,4 @@
-# Digital Transformation through Code-Based Infrastructure
+# Digital Transformation through Code-Based Infrastructure {#digitalisation}
 
 ![Figure 21.1 – Digital transformation journey for Architecture as Code](images/diagram_21_digitalisation_process.png)
 

--- a/docs/22_documentation_vs_architecture.md
+++ b/docs/22_documentation_vs_architecture.md
@@ -1,4 +1,4 @@
-# Documentation as Code vs Architecture as Code
+# Documentation as Code vs Architecture as Code {#documentation-vs-architecture}
 
 ## Introduction
 

--- a/docs/23_soft_as_code_interplay.md
+++ b/docs/23_soft_as_code_interplay.md
@@ -1,4 +1,4 @@
-# The Interplay Between Soft "as code" Disciplines
+# The Interplay Between Soft "as code" Disciplines {#soft-as-code-interplay}
 
 ## Introduction
 

--- a/docs/24_best_practices.md
+++ b/docs/24_best_practices.md
@@ -1,4 +1,4 @@
-# Modern Best Practices and Lessons Learned
+# Modern Best Practices and Lessons Learned {#best-practices}
 
 Architecture as Code practices evolve rapidly as teams balance platform stability, compliance expectations, and product agility. The most successful organisations pair disciplined engineering routines with human-centred ways of working, ensuring that automation never removes context or accountability. This chapter distils contemporary lessons learned from teams operating at scale across finance, public services, healthcare, media, and high-growth technology sectors. Every section emphasises globally applicable guidance while using British English terminology.
 

--- a/docs/25_future_trends.md
+++ b/docs/25_future_trends.md
@@ -1,4 +1,4 @@
-# Future Trends and Development in Architecture as Code
+# Future Trends and Development in Architecture as Code {#future-trends}
 
 ## Introduction
 

--- a/docs/26a_prerequisites_for_aac.md
+++ b/docs/26a_prerequisites_for_aac.md
@@ -1,4 +1,4 @@
-# Prerequisites for Architecture as Code Adoption
+# Prerequisites for Architecture as Code Adoption {#prerequisites-for-aac}
 
 Successful Architecture as Code (AaC) programmes are never accidents. They emerge when an organisation’s cultural habits, technical capabilities, and economic discipline align with the philosophy set out in the [introduction](01_introduction.md) and the [fundamental principles](02_fundamental_principles.md). This chapter distils the readiness signals hinted at across earlier chapters—from the organisational narratives in [Chapters 17 to 20](17_organisational_change.md) to the delivery mechanics in [Chapters 5, 14, and 23](05_automation_devops_cicd.md) and the financial guardrails in [Chapter 15](15_cost_optimization.md). Readiness is not a gate to appease governance; it is evidence that the organisation can wield AaC responsibly.
 

--- a/docs/26b_aac_anti_patterns.md
+++ b/docs/26b_aac_anti_patterns.md
@@ -1,4 +1,4 @@
-# Anti-Patterns in Architecture as Code Programmes
+# Anti-Patterns in Architecture as Code Programmes {#aac-anti-patterns}
 
 Architecture as Code (AaC) brings architectural thinking into the same disciplined delivery processes that teams already apply to software and infrastructure. Yet programmes stumble when they copy technical mechanisms without reshaping culture, governance, and operational rhythms. This chapter examines recurring anti-patterns that undermine AaC initiatives across diverse industries. Understanding these pitfalls helps organisations design early safeguards, establish healthier feedback loops, and sustain momentum beyond the initial transformation campaign.
 

--- a/docs/27_conclusion.md
+++ b/docs/27_conclusion.md
@@ -1,4 +1,4 @@
-# Chapter 27 – Conclusion
+# Chapter 27 – Conclusion {#conclusion}
 
 Architecture as Code has transformed how organisations design, deliver, and evolve their technology estates. By managing
 architectural artefacts as executable code we realise the same precision, repeatability, and governance controls that software

--- a/docs/30_appendix_code_examples.md
+++ b/docs/30_appendix_code_examples.md
@@ -1,6 +1,6 @@
 \appendix
 
-# Code examples and technical architecture as code implementations
+# Code examples and technical architecture as code implementations {#appendix-code-examples}
 
 Appendix A collects every code example, configuration file, and technical implementation referenced throughout the book. The examples are organised by theme so that readers can quickly locate the implementation that matches their current need.
 

--- a/docs/32_finos_project_blueprint.md
+++ b/docs/32_finos_project_blueprint.md
@@ -1,4 +1,4 @@
-# FINOS Project Blueprint: Operationalising Architecture as Code
+# FINOS Project Blueprint: Operationalising Architecture as Code {#finos-project-blueprint}
 
 The FINOS Project Blueprint initiative exists to prove that open collaboration can harden architectural practice without adding bureaucracy. It inherits the "Architecture as Code" ethos that this repository documents in depth, treating every artefact—from design rationale to production telemetry—as code subject to automated governance. By combining the automation foundations described in the book's technical chapters with the Common Architecture Language Model (CALM), the blueprint offers a reusable playbook for regulated financial organisations that want to modernise safely and transparently.【F:docs/05_automation_devops_cicd.md】【F:references/calm_what_is_excerpt.txt】
 

--- a/docs/33_references.md
+++ b/docs/33_references.md
@@ -1,4 +1,4 @@
-# References and Sources
+# References and Sources {#references}
 
 This section provides a comprehensive list of all sources and references cited throughout the book, compiled in alphabetical order for ease of reference. Each entry includes information about which chapters reference the source.
 

--- a/docs/34_control_mapping_matrix_template.md
+++ b/docs/34_control_mapping_matrix_template.md
@@ -1,4 +1,4 @@
-# Control Mapping Matrix Template
+# Control Mapping Matrix Template {#control-mapping-matrix-template}
 
 The Control Mapping Matrix provides a reusable structure for cataloguing how each control satisfies multiple regulatory frameworks. Populate the table below from your governance repository so that auditors, risk managers, and engineering teams can navigate the same source of truth. Combine the matrix with the evidence manifests defined in [Evidence as Code](15_evidence_as_code.md) to ensure every mapping references a verifiable artefact.
 

--- a/docs/BOOK_COVER_DESIGN.md
+++ b/docs/BOOK_COVER_DESIGN.md
@@ -1,4 +1,4 @@
-# Book Cover design - "Architecture as Code"
+# Book Cover design - "Architecture as Code" {#book-cover-design}
 
 ## Overview
 Professional book cover design for Kvadrat's "Architecture as Code" publication. The design follows Kvadrat's brand guidelines and incorporates modern visual elements that reflect the theme of code architecture.

--- a/docs/CHAPTER_AUDIT.md
+++ b/docs/CHAPTER_AUDIT.md
@@ -1,4 +1,4 @@
-# Docs Folder Audit
+# Docs Folder Audit {#chapter-audit}
 
 This audit summarises the current structure of the `docs/` directory, highlights which markdown files participate in the automated build, and identifies content that has been archived for later review.
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# Architecture as Code Editorial Style Guide
+# Architecture as Code Editorial Style Guide {#style-guide}
 
 ## Purpose
 This guide defines the editorial standards for all reader-facing content in the Architecture as Code repository. It ensures that every manuscript chapter, supporting document, and diagram text is written in consistent British English while respecting technical terminology and brand language.

--- a/docs/VALIDATION_SCRIPTS.md
+++ b/docs/VALIDATION_SCRIPTS.md
@@ -1,4 +1,4 @@
-# Content Validation Scripts
+# Content Validation Scripts {#validation-scripts}
 
 This document describes the automated validation scripts used to maintain content quality and consistency throughout the Architecture as Code book.
 

--- a/docs/about_the_author.md
+++ b/docs/about_the_author.md
@@ -1,4 +1,4 @@
-# About the Author {.unnumbered}
+# About the Author {.unnumbered} {#about-the-author}
 
 This book represents the culmination of extensive experience in architecture, infrastructure, and systems development, bringing together theoretical foundations with practical expertise to create a comprehensive resource for organisations embracing Architecture as Code.
 

--- a/docs/appendix_b_technical_architecture.md
+++ b/docs/appendix_b_technical_architecture.md
@@ -1,4 +1,4 @@
-# Appendix B: Technical Architecture for Book Production {.unnumbered}
+# Appendix B: Technical Architecture for Book Production {.unnumbered} {#appendix-b-technical-architecture}
 
 This appendix describes the technical infrastructure and workflow that produce, build, and publish "Architecture as Code". The system is a practical demonstration of Architecture as Code principles, showing how code defines and automates the entire book production process.
 

--- a/docs/architecture_as_code_maturity_model.md
+++ b/docs/architecture_as_code_maturity_model.md
@@ -1,4 +1,4 @@
-# Architecture as Code Maturity Model
+# Architecture as Code Maturity Model {#architecture-as-code-maturity-model}
 
 ## Maturity model for implementing architecture as code
 

--- a/docs/book_structure.md
+++ b/docs/book_structure.md
@@ -1,4 +1,4 @@
-# Architecture as Code - Book Structure
+# Architecture as Code - Book Structure {#book-structure}
 
 This document describes the logical structure for the book "Architecture as Code" which is organised into seven narrative parts plus extended appendices. Thirty-eight chapters, appendices, and structured templates build upon each other to provide a complete understanding of Architecture as Code and Infrastructure as Code for organisations operating in diverse global contexts.
 

--- a/docs/documentation_workflow.md
+++ b/docs/documentation_workflow.md
@@ -1,4 +1,4 @@
-# Documentation Workflow Guide
+# Documentation Workflow Guide {#documentation-workflow}
 
 ## Purpose
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,4 @@
-# Glossary {.unnumbered}
+# Glossary {.unnumbered} {#glossary}
 
 ![Architecture as Code Core Concepts Class Diagram](images/diagram_23_glossary_class.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Architecture as Code Documentation
+# Architecture as Code Documentation {#index}
 
 Welcome to the Architecture as Code documentation portal. This site publishes the complete manuscript of the Architecture as Code book in a web-friendly format so you can explore the chapters, diagrams, and appendices directly in your browser. If you want to see the source code and files they are available in the repository at [GitHub](https://github.com/Geonitab/architecture_as_code/)
 

--- a/docs/part_a_foundations.md
+++ b/docs/part_a_foundations.md
@@ -2,7 +2,7 @@
 \part{Foundations}
 \setbookpart{Foundations}
 
-# Part A: Foundations
+# Part A: Foundations {#part-a-foundations}
 
 Architecture as Code represents a fundamental shift in how organisations manage their technical landscapes. Before diving into specific practices and technologies, it is essential to establish a solid conceptual foundation that will guide the journey through this book.
 

--- a/docs/part_b_platform.md
+++ b/docs/part_b_platform.md
@@ -2,7 +2,7 @@
 \part{Architecture Platform}
 \setbookpart{Architecture Platform}
 
-# Part B: Architecture Platform
+# Part B: Architecture Platform {#part-b-platform}
 
 With the foundational principles established, we now turn to the technical building blocks that enable Architecture as Code in practice. This part explores the automation, tooling, and platform capabilities that transform architectural intent into executable reality.
 

--- a/docs/part_c_security.md
+++ b/docs/part_c_security.md
@@ -2,7 +2,7 @@
 \part{Security and Governance}
 \setbookpart{Security and Governance}
 
-# Part C: Security and Governance
+# Part C: Security and Governance {#part-c-security}
 
 Building on the technical platform capabilities from Part B, we now address the critical concerns that protect organisations and ensure Architecture as Code practices align with regulatory expectations and internal policies.
 

--- a/docs/part_d_delivery.md
+++ b/docs/part_d_delivery.md
@@ -2,7 +2,7 @@
 \part{Delivery and Operations}
 \setbookpart{Delivery and Operations}
 
-# Part D: Delivery and Operations
+# Part D: Delivery and Operations {#part-d-delivery}
 
 With secure, governed platforms in place, we now focus on the practical delivery and operational excellence that transforms Architecture as Code from concept into sustainable practice. This part bridges technical capabilities with business outcomes through disciplined testing, pragmatic implementation patterns, financial optimisation, and migration strategies.
 

--- a/docs/part_e_leadership.md
+++ b/docs/part_e_leadership.md
@@ -2,7 +2,7 @@
 \part{Organisation and Leadership}
 \setbookpart{Organisation and Leadership}
 
-# Part E: Organisation and Leadership
+# Part E: Organisation and Leadership {#part-e-leadership}
 
 Technical excellence alone cannot sustain Architecture as Code transformation. This part examines the organisational structures, cultural shifts, and leadership practices that enable teams to thrive in code-based delivery environments.
 

--- a/docs/part_f_practices.md
+++ b/docs/part_f_practices.md
@@ -2,7 +2,7 @@
 \part{Experience and Best Practices}
 \setbookpart{Experience and Best Practices}
 
-# Part F: Experience and Best Practices
+# Part F: Experience and Best Practices {#part-f-practices}
 
 Theory and practice intersect when organisations apply Architecture as Code principles across diverse contexts. This part synthesises lessons learned from real-world implementations, cross-disciplinary collaboration, and mature practices that span multiple domains.
 

--- a/docs/part_g_future.md
+++ b/docs/part_g_future.md
@@ -2,7 +2,7 @@
 \part{Future and Wrap-up}
 \setbookpart{Future and Wrap-up}
 
-# Part G: Future and Wrap-up
+# Part G: Future and Wrap-up {#part-g-future}
 
 Architecture as Code continues to evolve as new technologies emerge and organisational practices mature. This concluding part explores emerging trends, long-term developments, and synthesises the journey through this book into actionable guidance for the path ahead.
 

--- a/docs/part_h_appendices.md
+++ b/docs/part_h_appendices.md
@@ -2,7 +2,7 @@
 \part{Appendices and Reference}
 \setbookpart{Appendices and Reference}
 
-# Part H: Appendices and Reference
+# Part H: Appendices and Reference {#part-h-appendices}
 
 The appendices provide essential reference material, technical implementations, and background context that complement the main narrative. These resources support practitioners as they apply Architecture as Code principles in their own environments.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,15 @@ theme:
 markdown_extensions:
   - toc
   - tables
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        28_glossary.md: glossary.md
+        29_about_the_author.md: about_the_author.md
+        31_appendix_b_technical_architecture.md: appendix_b_technical_architecture.md
+        32_architecture_as_code_maturity_model.md: architecture_as_code_maturity_model.md
+        33_maturity_model_radar_tool.md: maturity_model_radar.html
 extra_css:
   - stylesheets/code-dark.css
 extra_javascript:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -27,6 +27,7 @@ mkdocs-material>=9.5.25
 mkdocs-material-extensions>=1.3.1
 mkdocs-git-revision-date-localized-plugin>=1.2.5
 mkdocs-minify-plugin>=0.8.0
+mkdocs-redirects>=1.2.1
 
 # Optional: useful for processing and manipulating structured data
 pandas>=2.2.3


### PR DESCRIPTION
## Summary
- add explicit slug anchors to each documentation chapter heading to provide stable intra-site links
- enable the MkDocs redirects plugin with mappings that preserve legacy appendix URLs during renames
- include the redirects plugin in the documentation build requirements for parity with CI automation

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_69064ecb1f108330a3325595f736c65b