### PR TITLE
Reclassify control mapping template within appendices

### DIFF
--- a/BOOK_REQUIREMENTS.md
+++ b/BOOK_REQUIREMENTS.md
@@ -303,7 +303,11 @@ book:
       title: "Front Cover"
       description: "Cover artwork and release metadata maintained outside the numbered manuscript."
       required: true
-    - filename: "34_control_mapping_matrix_template.md"
+    - filename: "appendix_templates_and_tools.md"
+      title: "Templates and Tools"
+      description: "Directory linking to the book's reusable maturity and compliance assets."
+      required: false
+    - filename: "appendix_d_control_mapping_matrix_template.md"
       title: "Control Mapping Matrix Template"
       description: "Template reference maintained alongside the appendices for governance programmes."
       required: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Lettered companion chapters (9B, 9C, 15A, 15B, 26A, and 26B) provide deeper dive
 - **Supplement – Architecture as Code Maturity Model:** Progressive adoption guidance and assessment structure.
 - **Supplement – Maturity Radar Tool:** Visual companion for the maturity model.
 - **Chapter 33 – References and Sources:** Comprehensive bibliography and citations.
-- **Chapter 34 – Control Mapping Matrix Template:** Compliance acceleration template that complements the maturity guidance.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/34_control_mapping_matrix_template.md】
+- **Appendix D – Templates and Tools:** Central directory linking to the Architecture as Code Maturity Model, Maturity Radar Tool, and Control Mapping Matrix template.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/appendix_templates_and_tools.md】
+- **Control Mapping Matrix Template:** Compliance acceleration template that complements the maturity guidance.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/appendix_d_control_mapping_matrix_template.md】
 
 ### Archived Drafts
 - Retired drafts, translations, and case studies are catalogued in `docs/archive/README.md`, which records when and why each manuscript left the live build. Current entries cover Swedish-language drafts of Chapters 6, 8, 20, 25, and 26, along with guidance for handling the former Chapter 32 on code-oriented organisations.【F:docs/book_structure.md】【F:docs/archive/README.md】
@@ -50,7 +51,7 @@ Lettered companion chapters (9B, 9C, 15A, 15B, 26A, and 26B) provide deeper dive
 
 ```
 docs/                     # Manuscript chapters, diagrams, and publishing assets
-├── *.md                  # Numbered chapters and appendices (01_introduction.md … 34_control_mapping_matrix_template.md)
+├── *.md                  # Numbered chapters and appendices (01_introduction.md … appendix_d_control_mapping_matrix_template.md)
 ├── archive/              # Retired chapter drafts kept for reference (e.g., former Chapter 32)
 ├── images/               # Mermaid sources (*.mmd) and generated PNG diagrams
 ├── build_book.sh         # Local helper for PDF/EPUB/DOCX generation

--- a/docs/12_compliance.md
+++ b/docs/12_compliance.md
@@ -38,7 +38,7 @@ Architecture as Code operationalises the **assure once, comply many** principle 
 |------------|---------------|-----------------------|-----------|-------|--------------|------|----------|
 | SEC-ID-001 | Enforce MFA for human identities | `ci/policy-report.json`, `evidence/mfa-snapshot-YYYYMM.json` | A.5 / A.8 | CC6.1 / CC6.6 | IA-2(1), AC-2 | Article 32 | IAM-01 |
 
-In this worked example, the [policy module](10_policy_and_security.md#assure-once-comply-many-in-policy-design) and [evidence pipeline](15_evidence_as_code.md#pipeline-example-exporting-mfa-evidence) each execute once yet satisfy multiple attestations. Compliance specialists extend the matrix as new frameworks emerge, while automation regenerates evidence on every pipeline run. The template used here is documented in the [Control Mapping Matrix appendix](34_control_mapping_matrix_template.md) so organisations can adapt it to their own environments.
+In this worked example, the [policy module](10_policy_and_security.md#assure-once-comply-many-in-policy-design) and [evidence pipeline](15_evidence_as_code.md#pipeline-example-exporting-mfa-evidence) each execute once yet satisfy multiple attestations. Compliance specialists extend the matrix as new frameworks emerge, while automation regenerates evidence on every pipeline run. The template used here is documented in the [Control Mapping Matrix appendix](appendix_d_control_mapping_matrix_template.md) so organisations can adapt it to their own environments.
 
 ## Cloud-native and Serverless Compliance Controls
 

--- a/docs/15_evidence_as_code.md
+++ b/docs/15_evidence_as_code.md
@@ -53,7 +53,7 @@ jobs:
           path: artefacts/
 ```
 
-The job produces a manifest and two evidence files. Governance and compliance teams consume the manifest to update the [Control Mapping Matrix](34_control_mapping_matrix_template.md) and to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues. Because the artefacts live alongside the policy, they can be retrieved for regulator-specific attestations without re-running the control unless configuration changes occur.
+The job produces a manifest and two evidence files. Governance and compliance teams consume the manifest to update the [Control Mapping Matrix](appendix_d_control_mapping_matrix_template.md) and to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues. Because the artefacts live alongside the policy, they can be retrieved for regulator-specific attestations without re-running the control unless configuration changes occur.
 
 ## Integrating with governance and blueprints
 

--- a/docs/32_finos_project_blueprint.md
+++ b/docs/32_finos_project_blueprint.md
@@ -44,7 +44,7 @@ Automation extends beyond code correctness. The blueprint prescribes cost-monito
 
 ### Evidence export for reuse
 
-Project Blueprint repositories include opinionated evidence pipelines that align with the **assure once, comply many** principle. Every change triggers automated policy evaluations, configuration snapshots, and CALM metadata diffs. Artefacts are stamped with control identifiers and linked to framework mappings so that downstream consumers—risk teams, auditors, or regulator portals—can re-use the same evidence package instead of requesting bespoke exports. Evidence manifests follow the conventions described in [Evidence as Code](15_evidence_as_code.md) and feed the [Control Mapping Matrix](34_control_mapping_matrix_template.md), allowing platform teams to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues without duplicating work.
+Project Blueprint repositories include opinionated evidence pipelines that align with the **assure once, comply many** principle. Every change triggers automated policy evaluations, configuration snapshots, and CALM metadata diffs. Artefacts are stamped with control identifiers and linked to framework mappings so that downstream consumers—risk teams, auditors, or regulator portals—can re-use the same evidence package instead of requesting bespoke exports. Evidence manifests follow the conventions described in [Evidence as Code](15_evidence_as_code.md) and feed the [Control Mapping Matrix](appendix_d_control_mapping_matrix_template.md), allowing platform teams to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues without duplicating work.
 
 ## Governance, Risk, and Financial Stewardship
 

--- a/docs/appendix_d_control_mapping_matrix_template.md
+++ b/docs/appendix_d_control_mapping_matrix_template.md
@@ -1,5 +1,7 @@
 # Control Mapping Matrix Template
 
+*Part of Appendix D – Templates and Tools.*
+
 The Control Mapping Matrix provides a reusable structure for cataloguing how each control satisfies multiple regulatory frameworks. Populate the table below from your governance repository so that auditors, risk managers, and engineering teams can navigate the same source of truth. Combine the matrix with the evidence manifests defined in [Evidence as Code](15_evidence_as_code.md) to ensure every mapping references a verifiable artefact.
 
 | Control ID | Control Title | Assurance Artefact(s) | ISO 27001 | SOC 2 | NIST 800-53 | GDPR | Other Frameworks / Internal |

--- a/docs/appendix_templates_and_tools.md
+++ b/docs/appendix_templates_and_tools.md
@@ -1,0 +1,21 @@
+# Appendix D: Templates and Tools {.unnumbered}
+
+Architecture as Code initiatives rely on reusable templates and interactive tools to keep governance, maturity assessments, and compliance evidence consistent. This appendix curates the canonical assets published alongside the book so that practitioners can embed them directly into their delivery workflows.
+
+## Architecture as Code Maturity Model
+
+The [Architecture as Code Maturity Model](architecture_as_code_maturity_model.md) describes six adoption levels spanning foundational automation through to fully codified enterprise governance. Each level contains assessment prompts, operating model guidance, and measurable outcomes that help teams benchmark their progress.
+
+## Architecture as Code Maturity Radar Tool
+
+The [Maturity Radar Tool](maturity_model_radar.html) offers an interactive visualisation of the maturity model. It enables leadership teams to capture current-state and target-state indicators, compare trajectories across business units, and export radar charts for strategy reviews.
+
+## Control Mapping Matrix Template
+
+The [Control Mapping Matrix Template](appendix_d_control_mapping_matrix_template.md) provides a reusable table for expressing "assure once, comply many" evidence flows. Use it to link automated assurance artefacts to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal policies so that governance teams can reuse validated outputs without bespoke reporting.
+
+## Implementation Guidance
+
+1. **Version the artefacts:** Store local copies of the templates in version control so changes trigger peer review and automated validation.
+2. **Integrate with pipelines:** Reference the templates from CI/CD jobs to keep evidence manifests, maturity assessments, and control mappings synchronised with production systems.
+3. **Tailor for context:** Extend the templates with sector-specific obligations or additional metrics, but retain the canonical structure to preserve comparability across programmes.

--- a/docs/book_index.json
+++ b/docs/book_index.json
@@ -5,87 +5,252 @@
       "id": "part_a",
       "title": "Foundations",
       "chapters": [
-        {"identifier": "1", "file": "docs/01_introduction.md", "title": "Introduction to Architecture as Code"},
-        {"identifier": "2", "file": "docs/02_fundamental_principles.md", "title": "Fundamental Principles of Architecture as Code"},
-        {"identifier": "3", "file": "docs/03_version_control.md", "title": "Version Control and Code Structure"},
-        {"identifier": "4", "file": "docs/04_adr.md", "title": "Architecture Decision Records (ADR)"}
+        {
+          "identifier": "1",
+          "file": "docs/01_introduction.md",
+          "title": "Introduction to Architecture as Code"
+        },
+        {
+          "identifier": "2",
+          "file": "docs/02_fundamental_principles.md",
+          "title": "Fundamental Principles of Architecture as Code"
+        },
+        {
+          "identifier": "3",
+          "file": "docs/03_version_control.md",
+          "title": "Version Control and Code Structure"
+        },
+        {
+          "identifier": "4",
+          "file": "docs/04_adr.md",
+          "title": "Architecture Decision Records (ADR)"
+        }
       ]
     },
     {
       "id": "part_b",
       "title": "Architecture Platform",
       "chapters": [
-        {"identifier": "5", "file": "docs/05_automation_devops_cicd.md", "title": "Automation, DevOps and CI/CD for Infrastructure as Code"},
-        {"identifier": "6", "file": "docs/06_structurizr.md", "title": "Structurizr: Architecture Modeling as Code"},
-        {"identifier": "7", "file": "docs/07_containerisation.md", "title": "Containerisation and Orchestration as Code"},
-        {"identifier": "8", "file": "docs/08_microservices.md", "title": "Microservices Architecture as Code"}
+        {
+          "identifier": "5",
+          "file": "docs/05_automation_devops_cicd.md",
+          "title": "Automation, DevOps and CI/CD for Infrastructure as Code"
+        },
+        {
+          "identifier": "6",
+          "file": "docs/06_structurizr.md",
+          "title": "Structurizr: Architecture Modeling as Code"
+        },
+        {
+          "identifier": "7",
+          "file": "docs/07_containerisation.md",
+          "title": "Containerisation and Orchestration as Code"
+        },
+        {
+          "identifier": "8",
+          "file": "docs/08_microservices.md",
+          "title": "Microservices Architecture as Code"
+        }
       ]
     },
     {
       "id": "part_c",
       "title": "Security & Governance",
       "chapters": [
-        {"identifier": "9", "file": "docs/09_security_fundamentals.md", "title": "Security Fundamentals for Architecture as Code"},
-        {"identifier": "9B", "file": "docs/09b_security_patterns.md", "title": "Advanced Security Patterns and Implementation"},
-        {"identifier": "9C", "file": "docs/09c_risk_and_threat_as_code.md", "title": "Risk as Code and Threat Handling as Code"},
-        {"identifier": "10", "file": "docs/10_policy_and_security.md", "title": "Policy and Security as Code in Detail"},
-        {"identifier": "11", "file": "docs/11_governance_as_code.md", "title": "Governance as Code"},
-        {"identifier": "12", "file": "docs/12_compliance.md", "title": "Compliance and Regulatory Adherence"}
+        {
+          "identifier": "9",
+          "file": "docs/09_security_fundamentals.md",
+          "title": "Security Fundamentals for Architecture as Code"
+        },
+        {
+          "identifier": "9B",
+          "file": "docs/09b_security_patterns.md",
+          "title": "Advanced Security Patterns and Implementation"
+        },
+        {
+          "identifier": "9C",
+          "file": "docs/09c_risk_and_threat_as_code.md",
+          "title": "Risk as Code and Threat Handling as Code"
+        },
+        {
+          "identifier": "10",
+          "file": "docs/10_policy_and_security.md",
+          "title": "Policy and Security as Code in Detail"
+        },
+        {
+          "identifier": "11",
+          "file": "docs/11_governance_as_code.md",
+          "title": "Governance as Code"
+        },
+        {
+          "identifier": "12",
+          "file": "docs/12_compliance.md",
+          "title": "Compliance and Regulatory Adherence"
+        }
       ]
     },
     {
       "id": "part_d",
       "title": "Delivery & Operations",
       "chapters": [
-        {"identifier": "13", "file": "docs/13_testing_strategies.md", "title": "Testing Strategies for Infrastructure as Code"},
-        {"identifier": "14", "file": "docs/14_practical_implementation.md", "title": "Architecture as Code in Practice"},
-        {"identifier": "15A", "file": "docs/15_evidence_as_code.md", "title": "Evidence as Code and Continuous Assurance"},
-        {"identifier": "15B", "file": "docs/15_cost_optimization.md", "title": "Cost Optimisation and Resource Management"},
-        {"identifier": "16", "file": "docs/16_migration.md", "title": "Migration from Traditional Infrastructure"}
+        {
+          "identifier": "13",
+          "file": "docs/13_testing_strategies.md",
+          "title": "Testing Strategies for Infrastructure as Code"
+        },
+        {
+          "identifier": "14",
+          "file": "docs/14_practical_implementation.md",
+          "title": "Architecture as Code in Practice"
+        },
+        {
+          "identifier": "15A",
+          "file": "docs/15_evidence_as_code.md",
+          "title": "Evidence as Code and Continuous Assurance"
+        },
+        {
+          "identifier": "15B",
+          "file": "docs/15_cost_optimization.md",
+          "title": "Cost Optimisation and Resource Management"
+        },
+        {
+          "identifier": "16",
+          "file": "docs/16_migration.md",
+          "title": "Migration from Traditional Infrastructure"
+        }
       ]
     },
     {
       "id": "part_e",
       "title": "Organisation & Leadership",
       "chapters": [
-        {"identifier": "17", "file": "docs/17_organisational_change.md", "title": "Organisational Change and Team Structures"},
-        {"identifier": "18", "file": "docs/18_team_structure.md", "title": "Team Structure and Competency Development for IaC"},
-        {"identifier": "19", "file": "docs/19_management_as_code.md", "title": "Management as Code"},
-        {"identifier": "20", "file": "docs/20_ai_agent_team.md", "title": "AI Agent Team for Architecture as Code Initiatives"},
-        {"identifier": "21", "file": "docs/21_digitalisation.md", "title": "Digitalisation through Code-based Infrastructure"}
+        {
+          "identifier": "17",
+          "file": "docs/17_organisational_change.md",
+          "title": "Organisational Change and Team Structures"
+        },
+        {
+          "identifier": "18",
+          "file": "docs/18_team_structure.md",
+          "title": "Team Structure and Competency Development for IaC"
+        },
+        {
+          "identifier": "19",
+          "file": "docs/19_management_as_code.md",
+          "title": "Management as Code"
+        },
+        {
+          "identifier": "20",
+          "file": "docs/20_ai_agent_team.md",
+          "title": "AI Agent Team for Architecture as Code Initiatives"
+        },
+        {
+          "identifier": "21",
+          "file": "docs/21_digitalisation.md",
+          "title": "Digitalisation through Code-based Infrastructure"
+        }
       ]
     },
     {
       "id": "part_f",
       "title": "Experience & Best Practices",
       "chapters": [
-        {"identifier": "22", "file": "docs/22_documentation_vs_architecture.md", "title": "Documentation as Code vs Architecture as Code"},
-        {"identifier": "23", "file": "docs/23_soft_as_code_interplay.md", "title": "The Interplay Between Soft As Code Disciplines"},
-        {"identifier": "24", "file": "docs/24_best_practices.md", "title": "Best Practices and Lessons Learned"}
+        {
+          "identifier": "22",
+          "file": "docs/22_documentation_vs_architecture.md",
+          "title": "Documentation as Code vs Architecture as Code"
+        },
+        {
+          "identifier": "23",
+          "file": "docs/23_soft_as_code_interplay.md",
+          "title": "The Interplay Between Soft As Code Disciplines"
+        },
+        {
+          "identifier": "24",
+          "file": "docs/24_best_practices.md",
+          "title": "Best Practices and Lessons Learned"
+        }
       ]
     },
     {
       "id": "part_g",
       "title": "Future & Wrap-up",
       "chapters": [
-        {"identifier": "25", "file": "docs/25_future_trends.md", "title": "Future Trends in Architecture as Code"},
-        {"identifier": "26A", "file": "docs/26a_prerequisites_for_aac.md", "title": "Prerequisites for Architecture as Code Adoption"},
-        {"identifier": "26B", "file": "docs/26b_aac_anti_patterns.md", "title": "Anti-Patterns in Architecture as Code Programmes"},
-        {"identifier": "27", "file": "docs/27_conclusion.md", "title": "Conclusion"}
+        {
+          "identifier": "25",
+          "file": "docs/25_future_trends.md",
+          "title": "Future Trends in Architecture as Code"
+        },
+        {
+          "identifier": "26A",
+          "file": "docs/26a_prerequisites_for_aac.md",
+          "title": "Prerequisites for Architecture as Code Adoption"
+        },
+        {
+          "identifier": "26B",
+          "file": "docs/26b_aac_anti_patterns.md",
+          "title": "Anti-Patterns in Architecture as Code Programmes"
+        },
+        {
+          "identifier": "27",
+          "file": "docs/27_conclusion.md",
+          "title": "Conclusion"
+        }
       ]
     }
   ],
   "appendices": [
-    {"identifier": "28", "file": "docs/glossary.md", "title": "Glossary"},
-    {"identifier": "29", "file": "docs/about_the_author.md", "title": "About the Author"},
-    {"identifier": "30", "file": "docs/30_appendix_code_examples.md", "title": "Appendix A: Code Examples and Technical Implementations"},
-    {"identifier": "31", "file": "docs/appendix_b_technical_architecture.md", "title": "Appendix B: Technical Architecture for Book Production"},
-    {"identifier": "32", "file": "docs/32_finos_project_blueprint.md", "title": "Appendix C: FINOS Project Blueprint"},
-    {"identifier": "33", "file": "docs/33_references.md", "title": "References and Sources"},
-    {"identifier": "34", "file": "docs/34_control_mapping_matrix_template.md", "title": "Appendix D: Control Mapping Matrix Template"}
+    {
+      "identifier": "28",
+      "file": "docs/glossary.md",
+      "title": "Glossary"
+    },
+    {
+      "identifier": "29",
+      "file": "docs/about_the_author.md",
+      "title": "About the Author"
+    },
+    {
+      "identifier": "30",
+      "file": "docs/30_appendix_code_examples.md",
+      "title": "Appendix A: Code Examples and Technical Implementations"
+    },
+    {
+      "identifier": "31",
+      "file": "docs/appendix_b_technical_architecture.md",
+      "title": "Appendix B: Technical Architecture for Book Production"
+    },
+    {
+      "identifier": "32",
+      "file": "docs/32_finos_project_blueprint.md",
+      "title": "Appendix C: FINOS Project Blueprint"
+    },
+    {
+      "identifier": "33",
+      "file": "docs/33_references.md",
+      "title": "References and Sources"
+    },
+    {
+      "identifier": "34",
+      "file": "docs/appendix_templates_and_tools.md",
+      "title": "Appendix D: Templates and Tools"
+    }
   ],
   "supplements": [
-    {"identifier": "maturity_model", "file": "docs/architecture_as_code_maturity_model.md", "title": "Architecture as Code Maturity Model"},
-    {"identifier": "maturity_radar", "file": "docs/maturity_model_radar.html", "title": "Architecture as Code Maturity Radar Tool"}
+    {
+      "identifier": "maturity_model",
+      "file": "docs/architecture_as_code_maturity_model.md",
+      "title": "Architecture as Code Maturity Model"
+    },
+    {
+      "identifier": "maturity_radar",
+      "file": "docs/maturity_model_radar.html",
+      "title": "Architecture as Code Maturity Radar Tool"
+    },
+    {
+      "identifier": "control_mapping_matrix_template",
+      "file": "docs/appendix_d_control_mapping_matrix_template.md",
+      "title": "Control Mapping Matrix Template"
+    }
   ]
 }

--- a/docs/book_structure.md
+++ b/docs/book_structure.md
@@ -122,9 +122,10 @@ Reference material, author information, technical enablers, and the Architecture
 | Appendix B | `appendix_b_technical_architecture.md` | Appendix B: Technical Architecture for Book Production | Technical book production infrastructure |
 | 32 | `32_finos_project_blueprint.md` | Appendix C: FINOS Project Blueprint | Operational blueprint demonstrating governance as code alignment |
 | 33 | `33_references.md` | References and Sources | Citations supporting the manuscript |
-| 34 | `34_control_mapping_matrix_template.md` | Appendix D: Control Mapping Matrix Template | Compliance acceleration template that complements the maturity model |
+| 34 | `appendix_templates_and_tools.md` | Appendix D: Templates and Tools | Directory of reusable maturity and compliance artefacts |
 | Appendix – Maturity Model | `architecture_as_code_maturity_model.md` | Architecture as Code Maturity Model | Progressive maturity staircase linking “as code” disciplines |
 | Appendix – Maturity Radar | `maturity_model_radar.html` | Architecture as Code Maturity Radar Tool | Interactive radar visualisation accompanying the maturity model |
+| Appendix – Control Mapping Matrix | `appendix_d_control_mapping_matrix_template.md` | Control Mapping Matrix Template | Compliance acceleration template that complements the maturity model |
 
 ---
 

--- a/docs/part_h_appendices.md
+++ b/docs/part_h_appendices.md
@@ -14,9 +14,11 @@ The [glossary](glossary.md) defines key terms and concepts used throughout this 
 
 [Appendix B: Technical Architecture for Book Production](appendix_b_technical_architecture.md) documents the infrastructure and automation used to produce this book itself. This meta-example demonstrates Architecture as Code principles applied to documentation delivery, showing how the same practices scale from infrastructure to content pipelines.
 
+[Appendix D: Templates and Tools](appendix_templates_and_tools.md) curates the reusable assets that support maturity assessments and governance workflows. It links directly to the Architecture as Code Maturity Model, the interactive Maturity Radar Tool, and the Control Mapping Matrix template so teams can adopt the artefacts without hunting through the repository.
+
 The [Architecture as Code Maturity Model](architecture_as_code_maturity_model.md) consolidates insights from across the manuscript into a staircase-style progression model. It summarises how infrastructure, governance, policy, testing, and cultural practices evolve together when organisations embrace Architecture as Code.
 
-The [Control Mapping Matrix Template](34_control_mapping_matrix_template.md) offers a reusable table structure that underpins the "assure once, comply many" approach. It documents how evidence artefacts map to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues so that teams maintain a single source of truth for compliance coverage.
+The [Control Mapping Matrix Template](appendix_d_control_mapping_matrix_template.md) offers a reusable table structure that underpins the "assure once, comply many" approach. It documents how evidence artefacts map to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues so that teams maintain a single source of truth for compliance coverage.
 
 **What you will find in this section:**
 
@@ -25,5 +27,6 @@ The [Control Mapping Matrix Template](34_control_mapping_matrix_template.md) off
 - Complete code examples and technical implementations
 - Book production infrastructure as a working Architecture as Code example
 - A maturity model that ties the “as code” disciplines together with practical adoption guidance
+- Reusable templates, interactive tools, and compliance accelerators ready for integration into delivery pipelines
 
 These references serve as quick-access resources to support the concepts explored in Parts A through G, ensuring that theoretical understanding translates into practical implementation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,10 +60,11 @@ nav:
       - Appendix A – Code Examples and Technical Implementations: 30_appendix_code_examples.md
       - Appendix B – Technical Architecture for Book Production: appendix_b_technical_architecture.md
       - Appendix C – FINOS Project Blueprint: 32_finos_project_blueprint.md
-      - Appendix D – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
-      - Appendix E – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
+      - Appendix D – Templates and Tools: appendix_templates_and_tools.md
+      - Appendix E – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
+      - Appendix F – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
       - References and Sources: 33_references.md
-      - Appendix F – Control Mapping Matrix Template: 34_control_mapping_matrix_template.md
+      - Control Mapping Matrix Template: appendix_d_control_mapping_matrix_template.md
   - Prezi Deck: prezi/index.html
 docs_dir: docs
 use_directory_urls: true

--- a/tests/test_numbered_chapter_bounds.py
+++ b/tests/test_numbered_chapter_bounds.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import re
+
+
+def test_numbered_chapters_do_not_exceed_bounds() -> None:
+    docs_dir = Path(__file__).resolve().parents[1] / "docs"
+    max_allowed = 33
+    offending = []
+
+    for entry in docs_dir.iterdir():
+        if not entry.is_file():
+            continue
+        match = re.match(r"^(\d+)_", entry.name)
+        if match and int(match.group(1)) > max_allowed:
+            offending.append(entry.name)
+
+    assert not offending, (
+        "Numbered chapter filenames must not exceed "
+        f"{max_allowed:02d}_*. Found: {', '.join(sorted(offending))}"
+    )


### PR DESCRIPTION
## Summary
- add an Appendix D "Templates and Tools" page and update the appendices index
- rename the control mapping matrix template file and refresh all repository references
- add a pytest guard that blocks new numbered chapter filenames beyond the agreed range

## Testing
- pytest tests/test_numbered_chapter_bounds.py

------
https://chatgpt.com/codex/tasks/task_e_69064ee835808330a96b9e9a3faa3a18