### PR TITLE
Reorganise control mapping appendix under templates index

### DIFF
--- a/BOOK_REQUIREMENTS.md
+++ b/BOOK_REQUIREMENTS.md
@@ -303,7 +303,11 @@ book:
       title: "Front Cover"
       description: "Cover artwork and release metadata maintained outside the numbered manuscript."
       required: true
-    - filename: "34_control_mapping_matrix_template.md"
+    - filename: "appendix_templates_and_tools.md"
+      title: "Templates and Tools"
+      description: "Directory linking to the book's reusable maturity and compliance assets."
+      required: false
+    - filename: "appendix_d_control_mapping_matrix_template.md"
       title: "Control Mapping Matrix Template"
       description: "Template reference maintained alongside the appendices for governance programmes."
       required: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Lettered companion chapters (9B, 9C, 15A, 15B, 26A, and 26B) provide deeper dive
 - **Supplement – Architecture as Code Maturity Model:** Progressive adoption guidance and assessment structure.
 - **Supplement – Maturity Radar Tool:** Visual companion for the maturity model.
 - **Chapter 33 – References and Sources:** Comprehensive bibliography and citations.
-- **Chapter 34 – Control Mapping Matrix Template:** Compliance acceleration template that complements the maturity guidance.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/34_control_mapping_matrix_template.md】
+- **Appendix D – Templates and Tools:** Central directory linking to the Architecture as Code Maturity Model, Maturity Radar Tool, and Control Mapping Matrix template.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/appendix_templates_and_tools.md】
+- **Control Mapping Matrix Template:** Compliance acceleration template that complements the maturity guidance.【F:docs/book_structure.md】【F:docs/part_h_appendices.md】【F:docs/appendix_d_control_mapping_matrix_template.md】
 
 ### Archived Drafts
 - Retired drafts, translations, and case studies are catalogued in `docs/archive/README.md`, which records when and why each manuscript left the live build. Current entries cover Swedish-language drafts of Chapters 6, 8, 20, 25, and 26, along with guidance for handling the former Chapter 32 on code-oriented organisations.【F:docs/book_structure.md】【F:docs/archive/README.md】
@@ -50,7 +51,7 @@ Lettered companion chapters (9B, 9C, 15A, 15B, 26A, and 26B) provide deeper dive
 
 ```
 docs/                     # Manuscript chapters, diagrams, and publishing assets
-├── *.md                  # Numbered chapters and appendices (01_introduction.md … 34_control_mapping_matrix_template.md)
+├── *.md                  # Numbered chapters and appendices (01_introduction.md … appendix_d_control_mapping_matrix_template.md)
 ├── archive/              # Retired chapter drafts kept for reference (e.g., former Chapter 32)
 ├── images/               # Mermaid sources (*.mmd) and generated PNG diagrams
 ├── build_book.sh         # Local helper for PDF/EPUB/DOCX generation

--- a/docs/12_compliance.md
+++ b/docs/12_compliance.md
@@ -38,7 +38,7 @@ Architecture as Code operationalises the **assure once, comply many** principle 
 |------------|---------------|-----------------------|-----------|-------|--------------|------|----------|
 | SEC-ID-001 | Enforce MFA for human identities | `ci/policy-report.json`, `evidence/mfa-snapshot-YYYYMM.json` | A.5 / A.8 | CC6.1 / CC6.6 | IA-2(1), AC-2 | Article 32 | IAM-01 |
 
-In this worked example, the [policy module](10_policy_and_security.md#assure-once-comply-many-in-policy-design) and [evidence pipeline](15_evidence_as_code.md#pipeline-example-exporting-mfa-evidence) each execute once yet satisfy multiple attestations. Compliance specialists extend the matrix as new frameworks emerge, while automation regenerates evidence on every pipeline run. The template used here is documented in the [Control Mapping Matrix appendix](34_control_mapping_matrix_template.md) so organisations can adapt it to their own environments.
+In this worked example, the [policy module](10_policy_and_security.md#assure-once-comply-many-in-policy-design) and [evidence pipeline](15_evidence_as_code.md#pipeline-example-exporting-mfa-evidence) each execute once yet satisfy multiple attestations. Compliance specialists extend the matrix as new frameworks emerge, while automation regenerates evidence on every pipeline run. The template used here is documented in the [Control Mapping Matrix appendix](appendix_d_control_mapping_matrix_template.md) so organisations can adapt it to their own environments.
 
 ## Cloud-native and Serverless Compliance Controls
 

--- a/docs/15_evidence_as_code.md
+++ b/docs/15_evidence_as_code.md
@@ -53,7 +53,7 @@ jobs:
           path: artefacts/
 ```
 
-The job produces a manifest and two evidence files. Governance and compliance teams consume the manifest to update the [Control Mapping Matrix](34_control_mapping_matrix_template.md) and to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues. Because the artefacts live alongside the policy, they can be retrieved for regulator-specific attestations without re-running the control unless configuration changes occur.
+The job produces a manifest and two evidence files. Governance and compliance teams consume the manifest to update the [Control Mapping Matrix](appendix_d_control_mapping_matrix_template.md) and to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues. Because the artefacts live alongside the policy, they can be retrieved for regulator-specific attestations without re-running the control unless configuration changes occur.
 
 ## Integrating with governance and blueprints
 

--- a/docs/32_finos_project_blueprint.md
+++ b/docs/32_finos_project_blueprint.md
@@ -44,7 +44,7 @@ Automation extends beyond code correctness. The blueprint prescribes cost-monito
 
 ### Evidence export for reuse
 
-Project Blueprint repositories include opinionated evidence pipelines that align with the **assure once, comply many** principle. Every change triggers automated policy evaluations, configuration snapshots, and CALM metadata diffs. Artefacts are stamped with control identifiers and linked to framework mappings so that downstream consumers—risk teams, auditors, or regulator portals—can re-use the same evidence package instead of requesting bespoke exports. Evidence manifests follow the conventions described in [Evidence as Code](15_evidence_as_code.md) and feed the [Control Mapping Matrix](34_control_mapping_matrix_template.md), allowing platform teams to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues without duplicating work.
+Project Blueprint repositories include opinionated evidence pipelines that align with the **assure once, comply many** principle. Every change triggers automated policy evaluations, configuration snapshots, and CALM metadata diffs. Artefacts are stamped with control identifiers and linked to framework mappings so that downstream consumers—risk teams, auditors, or regulator portals—can re-use the same evidence package instead of requesting bespoke exports. Evidence manifests follow the conventions described in [Evidence as Code](15_evidence_as_code.md) and feed the [Control Mapping Matrix](appendix_d_control_mapping_matrix_template.md), allowing platform teams to demonstrate coverage across ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues without duplicating work.
 
 ## Governance, Risk, and Financial Stewardship
 

--- a/docs/appendix_d_control_mapping_matrix_template.md
+++ b/docs/appendix_d_control_mapping_matrix_template.md
@@ -1,5 +1,7 @@
 # Control Mapping Matrix Template {#control-mapping-matrix-template}
 
+*Part of Appendix D – Templates and Tools.*
+
 The Control Mapping Matrix provides a reusable structure for cataloguing how each control satisfies multiple regulatory frameworks. Populate the table below from your governance repository so that auditors, risk managers, and engineering teams can navigate the same source of truth. Combine the matrix with the evidence manifests defined in [Evidence as Code](15_evidence_as_code.md) to ensure every mapping references a verifiable artefact.
 
 | Control ID | Control Title | Assurance Artefact(s) | ISO 27001 | SOC 2 | NIST 800-53 | GDPR | Other Frameworks / Internal |

--- a/docs/appendix_templates_and_tools.md
+++ b/docs/appendix_templates_and_tools.md
@@ -1,0 +1,21 @@
+# Appendix D: Templates and Tools {.unnumbered}
+
+Architecture as Code initiatives rely on reusable templates and interactive tools to keep governance, maturity assessments, and compliance evidence consistent. This appendix curates the canonical assets published alongside the book so that practitioners can embed them directly into their delivery workflows.
+
+## Architecture as Code Maturity Model
+
+The [Architecture as Code Maturity Model](architecture_as_code_maturity_model.md) describes six adoption levels spanning foundational automation through to fully codified enterprise governance. Each level contains assessment prompts, operating model guidance, and measurable outcomes that help teams benchmark their progress.
+
+## Architecture as Code Maturity Radar Tool
+
+The [Maturity Radar Tool](maturity_model_radar.html) offers an interactive visualisation of the maturity model. It enables leadership teams to capture current-state and target-state indicators, compare trajectories across business units, and export radar charts for strategy reviews.
+
+## Control Mapping Matrix Template
+
+The [Control Mapping Matrix Template](appendix_d_control_mapping_matrix_template.md) provides a reusable table for expressing "assure once, comply many" evidence flows. Use it to link automated assurance artefacts to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal policies so that governance teams can reuse validated outputs without bespoke reporting.
+
+## Implementation Guidance
+
+1. **Version the artefacts:** Store local copies of the templates in version control so changes trigger peer review and automated validation.
+2. **Integrate with pipelines:** Reference the templates from CI/CD jobs to keep evidence manifests, maturity assessments, and control mappings synchronised with production systems.
+3. **Tailor for context:** Extend the templates with sector-specific obligations or additional metrics, but retain the canonical structure to preserve comparability across programmes.

--- a/docs/book_index.json
+++ b/docs/book_index.json
@@ -1,5 +1,5 @@
 {
-  "total_units": 38,
+  "total_units": 39,
   "parts": [
     {
       "id": "part_a",
@@ -82,10 +82,11 @@
     {"identifier": "31", "file": "docs/appendix_b_technical_architecture.md", "title": "Appendix B: Technical Architecture for Book Production"},
     {"identifier": "32", "file": "docs/32_finos_project_blueprint.md", "title": "Appendix C: FINOS Project Blueprint"},
     {"identifier": "33", "file": "docs/33_references.md", "title": "References and Sources"},
-    {"identifier": "34", "file": "docs/34_control_mapping_matrix_template.md", "title": "Appendix D: Control Mapping Matrix Template"}
+    {"identifier": "34", "file": "docs/appendix_templates_and_tools.md", "title": "Appendix D: Templates and Tools"}
   ],
   "supplements": [
     {"identifier": "maturity_model", "file": "docs/architecture_as_code_maturity_model.md", "title": "Architecture as Code Maturity Model"},
-    {"identifier": "maturity_radar", "file": "docs/maturity_model_radar.html", "title": "Architecture as Code Maturity Radar Tool"}
+    {"identifier": "maturity_radar", "file": "docs/maturity_model_radar.html", "title": "Architecture as Code Maturity Radar Tool"},
+    {"identifier": "control_mapping_matrix_template", "file": "docs/appendix_d_control_mapping_matrix_template.md", "title": "Control Mapping Matrix Template"}
   ]
 }

--- a/docs/book_structure.md
+++ b/docs/book_structure.md
@@ -122,9 +122,10 @@ Reference material, author information, technical enablers, and the Architecture
 | Appendix B | `appendix_b_technical_architecture.md` | Appendix B: Technical Architecture for Book Production | Technical book production infrastructure |
 | 32 | `32_finos_project_blueprint.md` | Appendix C: FINOS Project Blueprint | Operational blueprint demonstrating governance as code alignment |
 | 33 | `33_references.md` | References and Sources | Citations supporting the manuscript |
-| 34 | `34_control_mapping_matrix_template.md` | Appendix D: Control Mapping Matrix Template | Compliance acceleration template that complements the maturity model |
+| 34 | `appendix_templates_and_tools.md` | Appendix D: Templates and Tools | Directory of reusable maturity and compliance artefacts |
 | Appendix – Maturity Model | `architecture_as_code_maturity_model.md` | Architecture as Code Maturity Model | Progressive maturity staircase linking “as code” disciplines |
 | Appendix – Maturity Radar | `maturity_model_radar.html` | Architecture as Code Maturity Radar Tool | Interactive radar visualisation accompanying the maturity model |
+| Appendix – Control Mapping Matrix | `appendix_d_control_mapping_matrix_template.md` | Control Mapping Matrix Template | Compliance acceleration template that complements the maturity model |
 
 ---
 

--- a/docs/part_h_appendices.md
+++ b/docs/part_h_appendices.md
@@ -14,9 +14,11 @@ The [glossary](glossary.md) defines key terms and concepts used throughout this 
 
 [Appendix B: Technical Architecture for Book Production](appendix_b_technical_architecture.md) documents the infrastructure and automation used to produce this book itself. This meta-example demonstrates Architecture as Code principles applied to documentation delivery, showing how the same practices scale from infrastructure to content pipelines.
 
+[Appendix D: Templates and Tools](appendix_templates_and_tools.md) curates the reusable assets that support maturity assessments and governance workflows. It links directly to the Architecture as Code Maturity Model, the interactive Maturity Radar Tool, and the Control Mapping Matrix template so teams can adopt the artefacts without hunting through the repository.
+
 The [Architecture as Code Maturity Model](architecture_as_code_maturity_model.md) consolidates insights from across the manuscript into a staircase-style progression model. It summarises how infrastructure, governance, policy, testing, and cultural practices evolve together when organisations embrace Architecture as Code.
 
-The [Control Mapping Matrix Template](34_control_mapping_matrix_template.md) offers a reusable table structure that underpins the "assure once, comply many" approach. It documents how evidence artefacts map to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues so that teams maintain a single source of truth for compliance coverage.
+The [Control Mapping Matrix Template](appendix_d_control_mapping_matrix_template.md) offers a reusable table structure that underpins the "assure once, comply many" approach. It documents how evidence artefacts map to ISO 27001, SOC 2, NIST 800-53, GDPR, and internal catalogues so that teams maintain a single source of truth for compliance coverage.
 
 **What you will find in this section:**
 
@@ -25,5 +27,6 @@ The [Control Mapping Matrix Template](34_control_mapping_matrix_template.md) off
 - Complete code examples and technical implementations
 - Book production infrastructure as a working Architecture as Code example
 - A maturity model that ties the “as code” disciplines together with practical adoption guidance
+- Reusable templates, interactive tools, and compliance accelerators ready for integration into delivery pipelines
 
 These references serve as quick-access resources to support the concepts explored in Parts A through G, ensuring that theoretical understanding translates into practical implementation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,10 +60,11 @@ nav:
       - Appendix A – Code Examples and Technical Implementations: 30_appendix_code_examples.md
       - Appendix B – Technical Architecture for Book Production: appendix_b_technical_architecture.md
       - Appendix C – FINOS Project Blueprint: 32_finos_project_blueprint.md
-      - Appendix D – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
-      - Appendix E – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
+      - Appendix D – Templates and Tools: appendix_templates_and_tools.md
+      - Appendix E – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
+      - Appendix F – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
       - References and Sources: 33_references.md
-      - Appendix F – Control Mapping Matrix Template: 34_control_mapping_matrix_template.md
+      - Control Mapping Matrix Template: appendix_d_control_mapping_matrix_template.md
   - Prezi Deck: prezi/index.html
 docs_dir: docs
 use_directory_urls: true

--- a/tests/test_numbered_chapter_bounds.py
+++ b/tests/test_numbered_chapter_bounds.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import re
+
+
+def test_numbered_chapters_do_not_exceed_bounds() -> None:
+    docs_dir = Path(__file__).resolve().parents[1] / "docs"
+    max_allowed = 33
+    offending = []
+
+    for entry in docs_dir.iterdir():
+        if not entry.is_file():
+            continue
+        match = re.match(r"^(\d+)_", entry.name)
+        if match and int(match.group(1)) > max_allowed:
+            offending.append(entry.name)
+
+    assert not offending, (
+        "Numbered chapter filenames must not exceed "
+        f"{max_allowed:02d}_*. Found: {', '.join(sorted(offending))}"
+    )


### PR DESCRIPTION
## Summary
- rename the control mapping matrix appendix to sit under an appendix D templates directory
- add an appendix catalogue for templates and update navigation, requirements, and references
- add a regression test to enforce numbered chapter bounds and update the book index totals

## Testing
- pytest *(fails: existing repository issues such as missing Issues/source_catalogue.json, diagram coverage gaps, and reference catalogue mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6906764661f083309ef128255cde8de6