### PR TITLE
Mark Part F introduction as unnumbered

### DIFF
--- a/docs/part_f_practices.md
+++ b/docs/part_f_practices.md
@@ -2,7 +2,7 @@
 \part{Experience and Best Practices}
 \setbookpart{Experience and Best Practices}
 
-# Part F: Experience and Best Practices {#part-f-practices}
+# Part F: Experience and Best Practices {#part-f-practices .unnumbered}
 
 Theory and practice intersect when organisations apply Architecture as Code principles across diverse contexts. This part synthesises lessons learned from real-world implementations, cross-disciplinary collaboration, and mature practices that span multiple domains.
 


### PR DESCRIPTION
## Summary
- mark the Part F introduction heading as unnumbered so it is not rendered as a numbered chapter in the generated book

## Testing
- python3 generate_book.py && docs/build_book.sh *(fails: missing xelatex in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_69083bc1f68c8330a5bd19fadf81e2cb