### PR TITLE
Strengthen microservices maintainability guardrails

### DIFF
--- a/docs/08_microservices.md
+++ b/docs/08_microservices.md
@@ -77,6 +77,18 @@ jobs:
 
 Such pipelines capture the architectural intent, flag drift immediately, and keep every service aligned with centrally defined guardrails.
 
+### Maintainability guardrails as code
+
+Policy-as-code engines such as [Open Policy Agent (OPA)](33_references.md#source-10), Conftest, or service mesh admission controllers translate governance rules into executable checks that run on every change. Teams should codify boundary rules—permitted dependency directions, latency budgets between domains, or constraints on data residency—alongside the service. Pipelines fail fast when a merge request proposes an illegal dependency, and the same rules can execute in staging clusters to block ad-hoc configuration drift. Thoughtworks' Governance as Code guidance stresses that automating these controls is the sustainable path to consistent service quality across federated teams ([Thoughtworks Technology Radar – "Governance as Code"](33_references.md#source-2)).
+
+### Cataloguing contracts and coupling telemetry
+
+Maintain an executable catalogue that indexes every API specification, event schema, and data contract. Architecture automation should update the catalogue after each merge, derive dependency graphs, and flag hotspots where a service has many synchronous consumers or repeatedly changes its schema. CNCF's *State of Cloud Native Development 2024* report highlights how sprawling integration surfaces create maintainability pressure unless organisations observe coupling signals in real time ([Source [7]](33_references.md#source-7)). Teams can codify heuristics such as "alert when more than five downstream systems consume a synchronous endpoint" or "notify when an event schema changes more than once per sprint". These metrics help platform leads schedule refactoring and guide investment in stabilising interfaces.
+
+### Escalation playbooks for failed checks
+
+Store runbooks and escalation trees beside the service so that automated failures trigger predictable responses. When a policy gate fails, the pipeline should raise a ticket or ChatOps alert to the owning team, include links to the failing rule, and enumerate the expected resolution timeframe. If repeated violations occur, an architecture council rota can be paged to review whether the guardrail or the service boundary needs adjustment. Capturing these playbooks as code keeps governance transparent and gives auditors evidence that breaches are handled systematically.
+
 ### Runtime observability as code
 
 Codify dashboards, alerting policies, and runbooks so that operability remains consistent across the fleet. Use tools such as Grafana configuration as code or Prometheus recording rules stored in Git. Tie alert routing to the ownership data held in each service repository so incidents reach the responsible team.
@@ -123,3 +135,11 @@ By treating migration playbooks as code, teams can rehearse transitions safely a
 ## Summary
 
 Microservices amplify organisational agility when paired with disciplined automation. Architecture as Code gives leaders a shared source of truth for service contracts, platform guardrails, and operational posture. Investing in reusable templates, policy automation, and comprehensive observability enables teams to innovate quickly whilst preserving the resilience, compliance, and sustainability that modern enterprises demand.
+
+## Sources
+
+Sources:
+- [Cloud Native Computing Foundation – *State of Cloud Native Development 2024*](33_references.md#source-7)
+- [Open Policy Agent – Policy as Code Overview](33_references.md#source-10)
+- [Thoughtworks Technology Radar – Governance as Code](33_references.md#source-2)
+

--- a/docs/33_references.md
+++ b/docs/33_references.md
@@ -4,6 +4,8 @@ This section provides a comprehensive list of all sources and references cited t
 
 ## Numbered source index
 
+- <a id="source-2"></a>**Source [2]:** Thoughtworks Technology Radar. *Governance as Code.* Thoughtworks, 2024. Referenced in: [Chapter 08: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md), [Chapter 23: Software as Code Interplay](23_soft_as_code_interplay.md).
+- <a id="source-10"></a>**Source [10]:** Open Policy Agent. *Policy as Code Overview.* CNCF OPA Project, 2024. Referenced in: [Chapter 02: Fundamental Principles](02_fundamental_principles.md), [Chapter 08: Microservices Architecture as Code](08_microservices.md), [Chapter 11: Governance as Code](11_governance_as_code.md), [Chapter 23: Software as Code Interplay](23_soft_as_code_interplay.md).
 - <a id="source-4"></a>**Source [4]:** GitHub Docs. *About protected branches.* GitHub Documentation, 2024. Referenced in: [Chapter 03: Version Control and Code Structure](03_version_control.md), [Chapter 11: Governance as Code](11_governance_as_code.md), [Chapter 14: Practical Implementation](14_practical_implementation.md), [Chapter 23: Software as Code Interplay](23_soft_as_code_interplay.md).
 - <a id="source-7"></a>**Source [7]:** Cloud Native Computing Foundation. *State of Cloud Native Development 2024.* Cloud Native Computing Foundation, 2024. Referenced in: [Chapter 7: Containerisation and Orchestration as Code](07_containerisation.md).
 - <a id="source-8"></a>**Source [8]:** Google Cloud. *The Site Reliability Workbook: Practical Ways to Implement SRE.* O'Reilly Media, 2018. Referenced in: [Chapter 05: Automation, DevOps and CI/CD](05_automation_devops_cicd.md).
@@ -96,7 +98,7 @@ This section provides a comprehensive list of all sources and references cited t
 **Open Policy Agent.** "Policy as Code: Expressing Requirements as Code." CNCF OPA Project, 2024.  
 *Referenced in: [Chapter 2: Fundamental Principles](02_fundamental_principles.md)*
 
-**Open Policy Agent.** "Policy as Code Overview." [https://www.openpolicyagent.org/docs/latest/](https://www.openpolicyagent.org/docs/latest/)  
+**Open Policy Agent.** "Policy as Code Overview." [https://www.openpolicyagent.org/docs/latest/](https://www.openpolicyagent.org/docs/latest/) (Source [10])  
 *Referenced in: [Chapter 11: Governance as Code](11_governance_as_code.md), [Chapter 23: Software as Code Interplay](23_soft_as_code_interplay.md)*
 
 **OMG.** "Model Driven Architecture (MDA)." Object Management Group White Paper, 2001.  
@@ -132,7 +134,7 @@ This section provides a comprehensive list of all sources and references cited t
 **ThoughtWorks.** "Architecture Decision Records." Technology Radar, 2023.  
 *Referenced in: [Chapter 4: Architecture Decision Records](04_adr.md)*
 
-**Thoughtworks Technology Radar.** "Governance as Code." [https://www.thoughtworks.com/radar/techniques/governance-as-code](https://www.thoughtworks.com/radar/techniques/governance-as-code)  
+**Thoughtworks Technology Radar.** "Governance as Code." [https://www.thoughtworks.com/radar/techniques/governance-as-code](https://www.thoughtworks.com/radar/techniques/governance-as-code) (Source [2])  
 *Referenced in: [Chapter 11: Governance as Code](11_governance_as_code.md)*
 
 ## Industry Research and Reports


### PR DESCRIPTION
## Summary
- expand Chapter 08 with policy-as-code guardrails, contract catalogue telemetry, and escalation guidance to close maintainability gaps
- register Source [2] and Source [10] in the references chapter so the new guidance cites the curated material consistently

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_69084902a040833095448c9238da9ecd