### PR TITLE
Automate ADR metadata validation and publish catalogue outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,14 @@ Key workflows include:
    python3 generate_book.py
    docs/build_book.sh
    ```
-4. If changes affect release collateral, run `./build_release.sh` to confirm presentation, whitepaper, and website builds succeed.
-5. Commit changes with clear messages and submit a pull request following the shared
+4. When ADRs are added or updated, run:
+   ```bash
+   python3 scripts/validate_adrs.py
+   python3 scripts/generate_adr_catalogue.py
+   ```
+   These checks confirm the metadata links to chapters, diagrams, and backlog items whilst refreshing the MkDocs catalogue.
+5. If changes affect release collateral, run `./build_release.sh` to confirm presentation, whitepaper, and website builds succeed.
+6. Commit changes with clear messages and submit a pull request following the shared
    Git-based review workflow so automation validates heading and link conventions.
 
 ## ✍️ Editorial Style

--- a/adr/ADR-0003-selection-of-terraform.md
+++ b/adr/ADR-0003-selection-of-terraform.md
@@ -1,0 +1,62 @@
+---
+adr_id: ADR-0003
+title: Selection of Terraform for Architecture as Code
+status: Accepted
+date: "2023-01-12"
+last_reviewed: "2024-11-15"
+next_review_due: "2025-05-15"
+deciders:
+  - Architecture Steering Council
+  - Platform Reliability Guild
+reviewers:
+  - Alice Patel
+  - Gustav Lindström
+  - Priya Banerjee
+related_chapters:
+  - docs/04_adr.md
+  - docs/05_automation_devops_cicd.md
+  - docs/06_structurizr.md
+related_diagrams:
+  - docs/images/diagram_04_adr_process.png
+  - docs/images/diagram_04_adr_lifecycle.png
+related_backlog_items:
+  - AAC-1182
+  - AAC-1305
+summary: Terraform standardises multi-cloud infrastructure for the Architecture as Code platform whilst enabling British English compliant policy automation.
+automation_hooks:
+  - Terraform plan enforcement integrated with the governance-as-code pipeline.
+  - Policy-as-code checks ensure mandatory tagging and remote state controls remain enabled.
+change_notes:
+  - 2024-11-15 – Review confirmed remote state encryption controls are functioning and no successor ADR is required yet.
+---
+
+# Decision
+
+Adopt HashiCorp Terraform as the strategic Infrastructure as Code tool for implementing the Architecture as Code operating model. Terraform’s provider ecosystem, mature state handling, and compatibility with policy enforcement frameworks allow the platform teams to codify infrastructure, compliance, and security standards without diverging across cloud estates.
+
+# Context
+
+Prior to this decision, teams managed AWS and Azure workloads through bespoke scripts and ad-hoc console operations. The inconsistency produced fragile environments, limited observability, and protracted audit preparation. Multiple delivery squads experimented with different IaC frameworks, increasing the risk of knowledge silos and inconsistent governance. The Architecture as Code initiative required a common foundation that respected existing investments whilst raising the automation baseline.
+
+# Decision Drivers
+
+- Multi-cloud parity to support both AWS and Azure product lines.
+- First-class policy integration so architectural guardrails are enforced automatically.
+- Strong ecosystem support for Terragrunt, Atlantis, and automated change approvals.
+- Ability to integrate with Structurizr diagrams to document platform topology changes alongside ADRs.
+
+# Consequences
+
+- **Positive**
+  - Consistent remote state encryption and versioned state back-ups across environments.
+  - Shared module registry reduces duplicated infrastructure patterns.
+  - Terraform plans provide audit-ready change evidence that links directly to ADR metadata.
+- **Negative**
+  - Teams must invest in Terraform training and migrate away from home-grown scripts.
+  - Upgrade cadence needs central coordination to avoid provider drift.
+
+# Follow-up Actions
+
+- Align backlog items AAC-1182 and AAC-1305 with the migration plan outlined in `docs/adr/migration_plan.md`.
+- Extend the Structurizr workspace example in Chapter 6 to reference Terraform modules tagged with this ADR identifier.
+- Monitor the policy-as-code checks recorded in the automation pipeline to ensure exceptions are documented through successor ADRs when required.

--- a/adr/ADR-0007-selection-of-postgresql.md
+++ b/adr/ADR-0007-selection-of-postgresql.md
@@ -1,0 +1,60 @@
+---
+adr_id: ADR-0007
+title: Selection of PostgreSQL for the Primary Database
+status: Accepted
+date: "2023-03-04"
+last_reviewed: "2024-10-02"
+next_review_due: "2025-04-02"
+deciders:
+  - Data Services Forum
+  - Architecture Steering Council
+reviewers:
+  - Elena Kowalski
+  - Michael Onwudiwe
+related_chapters:
+  - docs/04_adr.md
+  - docs/08_microservices.md
+  - docs/15_cost_optimization.md
+related_diagrams:
+  - docs/images/diagram_04_adr_structure.png
+related_backlog_items:
+  - AAC-1224
+  - DATA-947
+summary: PostgreSQL anchors transactional workloads for the multi-tenant platform, aligning ADR guidance with resilience and cost optimisation chapters.
+automation_hooks:
+  - Database migration pipelines annotate change logs with the ADR identifier.
+  - Observability dashboards surface ADR review dates in the data platform status page.
+change_notes:
+  - 2024-10-02 – Added operational readiness checklist and updated observability automation references.
+---
+
+# Decision
+
+Standardise on managed PostgreSQL services for all primary transactional workloads within the Architecture as Code platform. PostgreSQL’s extensibility, replication options, and community tooling provide a balance between reliability and flexibility whilst integrating smoothly with the automated governance controls mandated across the estate.
+
+# Context
+
+The programme previously relied on a mixture of MySQL, SQL Server, and ad-hoc document stores. The inconsistency complicated cross-domain reporting and created unnecessary operational risk. The Architecture as Code principles require a coherent data backbone that can be managed, versioned, and observed as code alongside infrastructure modules and ADR metadata.
+
+# Key Considerations
+
+- Native support for JSON, geospatial data, and advanced indexing to cover diverse product requirements.
+- Compatibility with managed services (Amazon RDS, Azure Database for PostgreSQL) for automated patching and backups.
+- Alignment with cost optimisation narratives in Chapter 15 through storage tiering and read replica strategies.
+- Strong ecosystem for migration tooling, including Sqitch and Liquibase integrations with CI pipelines.
+
+# Consequences
+
+- **Positive**
+  - Simplified operational model with standard backup, retention, and encryption controls.
+  - Unified observability dashboards referencing ADR-0007 to contextualise latency or failover alerts.
+  - Easier data governance audits because schema migrations are linked to ADR metadata.
+- **Negative**
+  - Specialist teams using niche database features require exceptions backed by successor ADRs.
+  - Training investment required for squads transitioning from SQL Server stored procedure heavy workloads.
+
+# Mitigations
+
+- Provide migration runbooks that map SQL Server constructs to PostgreSQL equivalents.
+- Extend the cost modelling accelerators in Chapter 15 to include PostgreSQL reserved instance guidance.
+- Capture exceptions in backlog item DATA-947 so review cadences align with `docs/adr/adr_catalogue.md` and the automation dashboards.

--- a/docs/04_adr.md
+++ b/docs/04_adr.md
@@ -50,9 +50,33 @@ documentation practice.
 
 *Figure 4.2 highlights the four core sections every ADR should capture before the template is populated with project-specific information.*
 
-Each ADR follows a consistent structure that ensures all relevant information is captured systematically:
+Each ADR follows a consistent structure that ensures all relevant information is captured systematically. The YAML front matter keeps the automated catalogue aligned with the manuscript and CI pipeline by recording review cadences, linked chapters, diagrams, and backlog work items. The Markdown body then presents the narrative context and decision rationale used throughout the book:
 
 ```markdown
+---
+adr_id: ADR-XXXX
+title: [Short Description of the Decision]
+status: Proposed
+date: "2025-01-15"
+last_reviewed: "2025-01-15"
+next_review_due: "2025-07-15"
+deciders:
+  - [Named decision authority]
+reviewers:
+  - [Reviewer ensuring technical accuracy]
+related_chapters:
+  - docs/04_adr.md
+related_diagrams:
+  - docs/images/diagram_04_adr_process.png
+related_backlog_items:
+  - AAC-1305
+summary: Concise statement explaining why the decision matters.
+automation_hooks:
+  - Optional list of CI jobs or tooling integrations triggered by the ADR metadata.
+change_notes:
+  - YYYY-MM-DD – Short description of adjustments or supersessions.
+---
+
 # ADR-XXXX: [Short Description of the Decision]
 
 Status: [Proposed | Accepted | Deprecated | Superseded]
@@ -80,6 +104,8 @@ Review and Documentation Workflow:
 - Reference the shared workflow in [docs/documentation_workflow.md](documentation_workflow.md)
   so future readers understand how the decision was reviewed and validated
 ```
+
+Run `python3 scripts/validate_adrs.py` after authoring or updating an ADR to confirm the metadata is complete. The companion `python3 scripts/generate_adr_catalogue.py` command rebuilds the catalogue that powers MkDocs navigation, ensuring new decisions appear automatically alongside the manuscript.
 
 ### Numbering and Versioning
 

--- a/docs/adr/adr_catalogue.md
+++ b/docs/adr/adr_catalogue.md
@@ -1,0 +1,74 @@
+# Architecture Decision Record Catalogue {#adr-catalogue}
+
+This catalogue is generated from the structured ADR metadata committed to the repository. It keeps the documentation site, book manuscript, and automation backlog aligned by ensuring every referenced ADR includes links to chapters, diagrams, and delivery work items.
+
+## Summary overview
+
+| ADR | Title | Status | Linked chapters | Backlog items | Next review |
+| --- | ----- | ------ | --------------- | ------------- | ----------- |
+| ADR-0003 | Selection of Terraform for Architecture as Code | Accepted | docs/04_adr.md<br>docs/05_automation_devops_cicd.md<br>docs/06_structurizr.md | AAC-1182<br>AAC-1305 | 2025-05-15 |
+| ADR-0007 | Selection of PostgreSQL for the Primary Database | Accepted | docs/04_adr.md<br>docs/08_microservices.md<br>docs/15_cost_optimization.md | AAC-1224<br>DATA-947 | 2025-04-02 |
+
+## Detailed records
+
+### ADR-0003 – Selection of Terraform for Architecture as Code
+
+Terraform standardises multi-cloud infrastructure for the Architecture as Code platform whilst enabling British English compliant policy automation.
+
+**Status:** Accepted — initial decision recorded on 2023-01-12.
+**Review cadence:** Last reviewed on 2024-11-15; next review due 2025-05-15.
+
+**Deciders:** Architecture Steering Council, Platform Reliability Guild
+**Reviewers:** Alice Patel, Gustav Lindström, Priya Banerjee
+
+**Linked chapters**
+- `docs/04_adr.md`
+- `docs/05_automation_devops_cicd.md`
+- `docs/06_structurizr.md`
+
+**Supporting diagrams**
+- `docs/images/diagram_04_adr_process.png`
+- `docs/images/diagram_04_adr_lifecycle.png`
+
+**Backlog alignment**
+- AAC-1182
+- AAC-1305
+
+**Automation hooks**
+- Terraform plan enforcement integrated with the governance-as-code pipeline.
+- Policy-as-code checks ensure mandatory tagging and remote state controls remain enabled.
+
+**Change log**
+- 2024-11-15 – Review confirmed remote state encryption controls are functioning and no successor ADR is required yet.
+
+### ADR-0007 – Selection of PostgreSQL for the Primary Database
+
+PostgreSQL anchors transactional workloads for the multi-tenant platform, aligning ADR guidance with resilience and cost optimisation chapters.
+
+**Status:** Accepted — initial decision recorded on 2023-03-04.
+**Review cadence:** Last reviewed on 2024-10-02; next review due 2025-04-02.
+
+**Deciders:** Data Services Forum, Architecture Steering Council
+**Reviewers:** Elena Kowalski, Michael Onwudiwe
+
+**Linked chapters**
+- `docs/04_adr.md`
+- `docs/08_microservices.md`
+- `docs/15_cost_optimization.md`
+
+**Supporting diagrams**
+- `docs/images/diagram_04_adr_structure.png`
+
+**Backlog alignment**
+- AAC-1224
+- DATA-947
+
+**Automation hooks**
+- Database migration pipelines annotate change logs with the ADR identifier.
+- Observability dashboards surface ADR review dates in the data platform status page.
+
+**Change log**
+- 2024-10-02 – Added operational readiness checklist and updated observability automation references.
+
+---
+*Generated automatically via `python3 scripts/generate_adr_catalogue.py`. Do not edit manually.*

--- a/docs/adr/migration_plan.md
+++ b/docs/adr/migration_plan.md
@@ -1,0 +1,55 @@
+# Legacy ADR Migration Plan {#adr-migration-plan}
+
+Migrating historical Architecture Decision Records (ADRs) into the structured format introduced by issue #1305 requires a combination of metadata enrichment, automated verification, and collaborative review. This plan provides a reusable blueprint for transforming existing decision logs—whether stored in wikis, shared drives, or dated Markdown files—into the codified workflow that now powers the Architecture as Code documentation suite.
+
+## Objectives
+
+1. **Preserve historical intent** so design rationale remains discoverable alongside the automated Architecture as Code assets.
+2. **Enrich legacy records with required metadata** (`adr_id`, review cadence, linked chapters, diagrams, and backlog references).
+3. **Ensure continuous integration coverage** by validating that every migrated ADR passes `python3 scripts/validate_adrs.py`.
+4. **Synchronise navigation and change logs** via `python3 scripts/generate_adr_catalogue.py` to keep MkDocs and book builds aligned.
+
+## Migration Waves
+
+| Wave | Scope | Activities | Exit Criteria |
+| ---- | ----- | ---------- | -------------- |
+| Wave 1 | Top 10 most-referenced ADRs | Inventory legacy files, assign canonical identifiers, capture missing metadata | ADR catalogue displays migrated entries with next review dates |
+| Wave 2 | Compliance-critical decisions | Cross-link to policy diagrams, capture backlog remediation items, schedule reviews with governance teams | CI validation passes; automation dashboards ingest metadata |
+| Wave 3 | Remaining historical records | Standardise tone, link to relevant chapters, and archive superseded entries with successor references | All references in `docs/` resolve to committed ADR files |
+
+## Detailed Steps
+
+1. **Catalogue existing material**
+   - Export legacy ADRs from previous repositories, wiki spaces, or document stores.
+   - Map each decision to the new identifier schema (`ADR-XXXX`) and track the source location for audit purposes.
+
+2. **Enrich metadata**
+   - Populate YAML front matter with review cadences, diagram links, and backlog identifiers.
+   - Use British English for all narrative sections to stay consistent with the manuscript style.
+
+3. **Peer review updates**
+   - Raise a pull request per migration wave.
+   - Include evidence that `python3 scripts/validate_adrs.py` and `python3 scripts/generate_adr_catalogue.py` have been executed.
+   - Request reviewers from architecture, governance, and operations to confirm accuracy.
+
+4. **Automate catalogue regeneration**
+   - Run `python3 scripts/generate_adr_catalogue.py` after each merge to refresh `docs/adr/adr_catalogue.md`.
+   - Confirm MkDocs navigation highlights the new entries and that change notes appear in the automatically generated table.
+
+5. **Archive superseded artefacts**
+   - Move deprecated or redundant ADRs into `docs/archive/` with cross-links to their successors.
+   - Record the migration context within the `change_notes` list so future readers understand the rationale behind supersessions.
+
+## Tooling Checklist
+
+- `python3 scripts/validate_adrs.py` — confirms metadata completeness and cross-references manuscript mentions.
+- `python3 scripts/generate_adr_catalogue.py` — regenerates the catalogue consumed by the documentation site and book build.
+- `pytest tests/test_adr_metadata.py` — keeps the CI suite aligned with manual checks.
+
+## Communication Plan
+
+- Announce the migration schedule during the weekly Architecture as Code stand-up.
+- Track progress against backlog items referenced within each ADR (`AAC-1182`, `AAC-1305`, `AAC-1224`, `DATA-947`).
+- Share the regenerated catalogue with governance stakeholders to evidence continuous improvement.
+
+By following this plan, teams can transition legacy architecture decisions into the automated, reviewable workflow without losing historical context or creating documentation drift.

--- a/docs/documentation_workflow.md
+++ b/docs/documentation_workflow.md
@@ -19,6 +19,8 @@ h established terminology.
 
 - **Continuous integration** executes `python3 generate_book.py && docs/build_book.sh` to rebuild the book, regenerate diagrams,
   and surface linting feedback.
+- **ADR validation** runs `python3 scripts/validate_adrs.py` followed by `python3 scripts/generate_adr_catalogue.py` so that new
+  decisions automatically populate the MkDocs navigation and change-log-friendly catalogue.
 - **Link validation** ensures Markdown references resolve correctly. Update links or add redirect stubs whenever file paths chan
 ge.
 - **Diagram generation** leverages Mermaid CLI during the build to refresh PNG artefacts. Never commit outdated diagram renders.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,8 @@ nav:
       - Appendix B – Technical Architecture for Book Production: appendix_b_technical_architecture.md
       - Appendix C – FINOS Project Blueprint: 32_finos_project_blueprint.md
       - Appendix D – Templates and Tools: appendix_templates_and_tools.md
+      - ADR Catalogue: adr/adr_catalogue.md
+      - Legacy ADR Migration Plan: adr/migration_plan.md
       - Appendix E – Architecture as Code Maturity Model: architecture_as_code_maturity_model.md
       - Appendix F – Architecture as Code Maturity Radar Tool: maturity_model_radar.html
       - References and Sources: 33_references.md

--- a/scripts/generate_adr_catalogue.py
+++ b/scripts/generate_adr_catalogue.py
@@ -1,0 +1,150 @@
+"""Generate documentation assets derived from ADR metadata."""
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import indent
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:  # pragma: no cover - defensive guard for CLI execution
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validate_adrs import AdrRecord, AdrValidationError, load_adr_records
+
+CATALOGUE_PATH = REPO_ROOT / "docs" / "adr" / "adr_catalogue.md"
+
+
+def _format_list(values: list[str]) -> str:
+    return "<br>".join(values)
+
+
+def _summarise_records(records: list[AdrRecord]) -> str:
+    lines: list[str] = []
+    lines.append("| ADR | Title | Status | Linked chapters | Backlog items | Next review |")
+    lines.append("| --- | ----- | ------ | --------------- | ------------- | ----------- |")
+    for record in records:
+        chapter_values = [path.relative_to(REPO_ROOT).as_posix() for path in record.related_chapters]
+        backlog_values = list(record.related_backlog_items)
+        lines.append(
+            "| {adr} | {title} | {status} | {chapters} | {backlog} | {review} |".format(
+                adr=record.adr_id,
+                title=record.title,
+                status=record.status,
+                chapters=_format_list(chapter_values),
+                backlog=_format_list(backlog_values),
+                review=record.next_review_due.strftime("%Y-%m-%d"),
+            )
+        )
+    return "\n".join(lines)
+
+
+def _detailed_section(record: AdrRecord) -> str:
+    lines: list[str] = [f"### {record.adr_id} – {record.title}"]
+    lines.append("")
+    summary = record.front_matter.get("summary")
+    if summary:
+        lines.append(summary)
+        lines.append("")
+
+    lines.append("**Status:** {status} — initial decision recorded on {date:%Y-%m-%d}.".format(
+        status=record.status,
+        date=record.date,
+    ))
+    lines.append("**Review cadence:** Last reviewed on {last:%Y-%m-%d}; next review due {due:%Y-%m-%d}.".format(
+        last=record.last_reviewed,
+        due=record.next_review_due,
+    ))
+
+    lines.append("")
+    lines.append("**Deciders:** " + ", ".join(record.deciders))
+    lines.append("**Reviewers:** " + ", ".join(record.reviewers))
+    lines.append("")
+
+    chapter_lines = "\n".join(
+        f"- `{path.relative_to(REPO_ROOT).as_posix()}`" for path in record.related_chapters
+    )
+    diagram_lines = "\n".join(
+        f"- `{path.relative_to(REPO_ROOT).as_posix()}`" for path in record.related_diagrams
+    )
+    backlog_lines = "\n".join(f"- {item}" for item in record.related_backlog_items)
+
+    lines.append("**Linked chapters**\n" + indent(chapter_lines, ""))
+    lines.append("")
+    lines.append("**Supporting diagrams**\n" + indent(diagram_lines, ""))
+    lines.append("")
+    lines.append("**Backlog alignment**\n" + indent(backlog_lines, ""))
+
+    automation = record.front_matter.get("automation_hooks")
+    if automation:
+        lines.append("")
+        lines.append("**Automation hooks**")
+        if isinstance(automation, list):
+            lines.extend(f"- {entry}" for entry in automation)
+        else:
+            lines.append(str(automation))
+
+    history = record.front_matter.get("change_notes")
+    if history:
+        lines.append("")
+        lines.append("**Change log**")
+        if isinstance(history, list):
+            lines.extend(f"- {entry}" for entry in history)
+        else:
+            lines.append(f"- {history}")
+
+    return "\n".join(lines)
+
+
+def render_catalogue(records: list[AdrRecord]) -> str:
+    """Return the markdown catalogue for the supplied ADR records."""
+
+    sorted_records = sorted(records, key=lambda record: record.adr_id)
+
+    lines: list[str] = ["# Architecture Decision Record Catalogue {#adr-catalogue}", ""]
+    lines.append(
+        "This catalogue is generated from the structured ADR metadata committed to the repository. "
+        "It keeps the documentation site, book manuscript, and automation backlog aligned by ensuring "
+        "every referenced ADR includes links to chapters, diagrams, and delivery work items."
+    )
+    lines.append("")
+    lines.append("## Summary overview")
+    lines.append("")
+    lines.append(_summarise_records(sorted_records))
+    lines.append("")
+    lines.append("## Detailed records")
+    lines.append("")
+
+    for record in sorted_records:
+        lines.append(_detailed_section(record))
+        lines.append("")
+
+    lines.append(
+        "---\n"
+        "*Generated automatically via `python3 scripts/generate_adr_catalogue.py`. Do not edit manually.*"
+    )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_catalogue(destination: Path = CATALOGUE_PATH) -> Path:
+    """Generate the ADR catalogue and write it to disk."""
+
+    try:
+        records = load_adr_records()
+    except AdrValidationError as exc:  # pragma: no cover - CLI guard
+        raise SystemExit(f"Unable to load ADR metadata: {exc}") from exc
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    content = render_catalogue(records)
+    destination.write_text(content, encoding="utf-8")
+    return destination
+
+
+def main() -> int:
+    write_catalogue()
+    print(f"ADR catalogue updated at {CATALOGUE_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI passthrough
+    raise SystemExit(main())

--- a/scripts/validate_adrs.py
+++ b/scripts/validate_adrs.py
@@ -1,0 +1,284 @@
+"""Utility functions for validating Architecture Decision Records."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import re
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADR_DIRECTORY = REPO_ROOT / "adr"
+DOCS_DIRECTORY = REPO_ROOT / "docs"
+
+ADR_ID_PATTERN = re.compile(r"^ADR-(?P<number>\d{4})$")
+REFERENCED_ADR_PATTERN = re.compile(r"\bADR-(?P<number>\d{4})\b")
+
+SAMPLE_ADR_IDENTIFIERS = {"ADR-XXXX", "ADR-0001", "ADR-0002"}
+
+REQUIRED_LIST_FIELDS = {
+    "deciders",
+    "reviewers",
+    "related_chapters",
+    "related_diagrams",
+    "related_backlog_items",
+}
+
+REQUIRED_SCALAR_FIELDS = {
+    "adr_id",
+    "title",
+    "status",
+    "date",
+    "last_reviewed",
+    "next_review_due",
+}
+
+ALLOWED_STATUS = {"Proposed", "Accepted", "Deprecated", "Superseded"}
+
+
+class AdrValidationError(RuntimeError):
+    """Raised when ADR metadata fails validation."""
+
+
+@dataclass(frozen=True)
+class AdrRecord:
+    """Container for parsed ADR metadata."""
+
+    adr_id: str
+    title: str
+    status: str
+    date: date
+    last_reviewed: date
+    next_review_due: date
+    deciders: Sequence[str]
+    reviewers: Sequence[str]
+    related_chapters: Sequence[Path]
+    related_diagrams: Sequence[Path]
+    related_backlog_items: Sequence[str]
+    source_path: Path
+    front_matter: dict
+    body: str
+
+
+def _split_front_matter(text: str, *, source: Path) -> tuple[str, str]:
+    """Split Markdown text into YAML front matter and body."""
+
+    if not text.startswith("---\n"):
+        raise AdrValidationError(f"{source} is missing YAML front matter header.")
+
+    end_marker = text.find("\n---", 4)
+    if end_marker == -1:
+        raise AdrValidationError(f"{source} front matter is not terminated with '---'.")
+
+    front_matter = text[4:end_marker]
+    body_start = end_marker + 4
+    body = text[body_start:].lstrip("\n")
+    return front_matter, body
+
+
+def _parse_date(value: str, *, field: str, source: Path) -> date:
+    try:
+        year, month, day = (int(part) for part in value.split("-"))
+        return date(year, month, day)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise AdrValidationError(
+            f"{source} field '{field}' must be formatted as YYYY-MM-DD."
+        ) from exc
+
+
+def _validate_required_fields(front_matter: dict, *, source: Path) -> None:
+    missing_scalar = [key for key in REQUIRED_SCALAR_FIELDS if key not in front_matter]
+    missing_list = [key for key in REQUIRED_LIST_FIELDS if key not in front_matter]
+
+    if missing_scalar or missing_list:
+        problems: List[str] = []
+        if missing_scalar:
+            problems.append(f"missing scalar fields: {', '.join(sorted(missing_scalar))}")
+        if missing_list:
+            problems.append(f"missing list fields: {', '.join(sorted(missing_list))}")
+        raise AdrValidationError(f"{source} metadata incomplete ({'; '.join(problems)}).")
+
+    for key in REQUIRED_LIST_FIELDS:
+        if not isinstance(front_matter[key], list) or not front_matter[key]:
+            raise AdrValidationError(
+                f"{source} field '{key}' must be a non-empty list."
+            )
+
+    for key in REQUIRED_SCALAR_FIELDS:
+        if not isinstance(front_matter[key], str) or not front_matter[key].strip():
+            raise AdrValidationError(
+                f"{source} field '{key}' must be a populated string."
+            )
+
+
+def _normalise_paths(paths: Iterable[str], *, base: Path, source: Path) -> list[Path]:
+    resolved: list[Path] = []
+    for entry in paths:
+        candidate = Path(entry)
+        if candidate.is_absolute():
+            raise AdrValidationError(
+                f"{source} field contains absolute path '{candidate}'. Use repository relative paths."
+            )
+        full = (base / candidate).resolve()
+        if not full.exists():
+            raise AdrValidationError(
+                f"{source} references missing artefact '{candidate.as_posix()}'."
+            )
+        resolved.append(full)
+    return resolved
+
+
+def load_adr_records(directory: Path | None = None) -> list[AdrRecord]:
+    """Parse and validate ADR files from the repository."""
+
+    adr_directory = directory or ADR_DIRECTORY
+    if not adr_directory.exists():
+        raise AdrValidationError(f"ADR directory not found at {adr_directory}.")
+
+    records: list[AdrRecord] = []
+    for path in sorted(adr_directory.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        front_matter_text, body = _split_front_matter(text, source=path)
+        try:
+            front_matter = yaml.safe_load(front_matter_text) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - YAML errors are rare
+            raise AdrValidationError(f"{path} front matter could not be parsed.") from exc
+
+        _validate_required_fields(front_matter, source=path)
+
+        adr_id = front_matter["adr_id"].strip()
+        if ADR_ID_PATTERN.fullmatch(adr_id) is None:
+            raise AdrValidationError(
+                f"{path} field 'adr_id' must match pattern ADR-0000."
+            )
+
+        expected_stem = adr_id.replace("-", "-")
+        if not path.name.startswith(adr_id):
+            raise AdrValidationError(
+                f"{path.name} should start with '{adr_id}' to aid discoverability."
+            )
+
+        status = front_matter["status"].strip()
+        if status not in ALLOWED_STATUS:
+            raise AdrValidationError(
+                f"{path} has unsupported status '{status}'. Allowed: {', '.join(sorted(ALLOWED_STATUS))}."
+            )
+
+        adr_date = _parse_date(front_matter["date"], field="date", source=path)
+        last_reviewed = _parse_date(
+            front_matter["last_reviewed"], field="last_reviewed", source=path
+        )
+        next_review_due = _parse_date(
+            front_matter["next_review_due"], field="next_review_due", source=path
+        )
+
+        if last_reviewed < adr_date:
+            raise AdrValidationError(
+                f"{path} field 'last_reviewed' ({last_reviewed:%Y-%m-%d}) cannot precede 'date' ({adr_date:%Y-%m-%d})."
+            )
+
+        if next_review_due <= last_reviewed:
+            raise AdrValidationError(
+                f"{path} field 'next_review_due' ({next_review_due:%Y-%m-%d}) must be after 'last_reviewed' ({last_reviewed:%Y-%m-%d})."
+            )
+
+        related_chapters = _normalise_paths(
+            front_matter["related_chapters"], base=REPO_ROOT, source=path
+        )
+        related_diagrams = _normalise_paths(
+            front_matter["related_diagrams"], base=REPO_ROOT, source=path
+        )
+
+        backlog_items = front_matter["related_backlog_items"]
+        backlog_pattern = re.compile(r"^[A-Z][A-Z0-9_-]+-\d+")
+        for entry in backlog_items:
+            if not isinstance(entry, str) or not entry.strip():
+                raise AdrValidationError(
+                    f"{path} field 'related_backlog_items' must contain reference strings."
+                )
+            if backlog_pattern.fullmatch(entry.strip()) is None:
+                raise AdrValidationError(
+                    f"{path} backlog reference '{entry}' must follow KEY-1234 format."
+                )
+
+        deciders = [str(value).strip() for value in front_matter["deciders"]]
+        reviewers = [str(value).strip() for value in front_matter["reviewers"]]
+
+        if any(not entry for entry in deciders):
+            raise AdrValidationError(f"{path} deciders list contains blank entries.")
+        if any(not entry for entry in reviewers):
+            raise AdrValidationError(f"{path} reviewers list contains blank entries.")
+
+        records.append(
+            AdrRecord(
+                adr_id=adr_id,
+                title=front_matter["title"].strip(),
+                status=status,
+                date=adr_date,
+                last_reviewed=last_reviewed,
+                next_review_due=next_review_due,
+                deciders=tuple(deciders),
+                reviewers=tuple(reviewers),
+                related_chapters=tuple(related_chapters),
+                related_diagrams=tuple(related_diagrams),
+                related_backlog_items=tuple(entry.strip() for entry in backlog_items),
+                source_path=path,
+                front_matter=front_matter,
+                body=body,
+            )
+        )
+
+    if not records:
+        raise AdrValidationError("No ADR files were found for validation.")
+
+    return records
+
+
+def find_referenced_adrs(docs_directory: Path | None = None) -> set[str]:
+    """Return the set of ADR identifiers referenced across the manuscript."""
+
+    docs_path = docs_directory or DOCS_DIRECTORY
+    referenced: set[str] = set()
+
+    for markdown_path in docs_path.rglob("*.md"):
+        text = markdown_path.read_text(encoding="utf-8")
+        for match in REFERENCED_ADR_PATTERN.finditer(text):
+            referenced.add(match.group(0))
+
+    return referenced
+
+
+def ensure_references_have_records(
+    *, records: Sequence[AdrRecord], referenced_ids: Iterable[str]
+) -> None:
+    """Ensure every referenced ADR has a corresponding record."""
+
+    available = {record.adr_id for record in records}
+    referenced = set(referenced_ids) - SAMPLE_ADR_IDENTIFIERS
+    missing = sorted(referenced - available)
+    if missing:
+        raise AdrValidationError(
+            "Missing ADR files for referenced identifiers: " + ", ".join(missing)
+        )
+
+
+def main() -> int:
+    """Command-line entry point that validates ADR metadata."""
+
+    try:
+        records = load_adr_records()
+        ensure_references_have_records(
+            records=records, referenced_ids=find_referenced_adrs()
+        )
+    except AdrValidationError as exc:
+        print(f"ADR validation failed: {exc}")
+        return 1
+
+    print(f"Validated {len(records)} ADR files with consistent metadata.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI passthrough
+    raise SystemExit(main())

--- a/tests/test_adr_metadata.py
+++ b/tests/test_adr_metadata.py
@@ -1,0 +1,32 @@
+"""Validation tests for Architecture Decision Records."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.generate_adr_catalogue import render_catalogue
+from scripts.validate_adrs import (
+    ensure_references_have_records,
+    find_referenced_adrs,
+    load_adr_records,
+)
+
+
+def test_adr_records_are_valid() -> None:
+    """All ADR files must parse and satisfy metadata expectations."""
+
+    records = load_adr_records()
+    assert records, "At least one ADR record must be present for validation."
+    ensure_references_have_records(records=records, referenced_ids=find_referenced_adrs())
+
+
+def test_catalogue_is_in_sync() -> None:
+    """The committed ADR catalogue must match the generated output."""
+
+    records = load_adr_records()
+    expected = render_catalogue(records)
+    catalogue_path = Path("docs/adr/adr_catalogue.md")
+    assert catalogue_path.exists(), "ADR catalogue should exist in docs/adr/."
+    observed = catalogue_path.read_text(encoding="utf-8")
+    assert (
+        observed == expected
+    ), "Run `python3 scripts/generate_adr_catalogue.py` to refresh the ADR catalogue."


### PR DESCRIPTION
## Summary
- add scripts to validate ADR front matter and generate a navigable catalogue that links chapters, diagrams, and backlog items
- seed the repository with structured ADR examples, an automated migration plan, and documentation updates referencing the new workflow
- wire MkDocs navigation and CI tests so ADR references are continuously verified

## Testing
- pytest tests/test_adr_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_690848f0561483309ac3033522c999cb