### PR TITLE
Reorder chapters for improved narrative coherence

### DIFF
--- a/docs/book_index.json
+++ b/docs/book_index.json
@@ -6,6 +6,7 @@
       "title": "Foundations",
       "chapters": [
         {"identifier": "1", "file": "docs/01_introduction.md", "title": "Introduction to Architecture as Code"},
+        {"identifier": "26A", "file": "docs/26a_prerequisites_for_aac.md", "title": "Prerequisites for Architecture as Code Adoption"},
         {"identifier": "2", "file": "docs/02_fundamental_principles.md", "title": "Fundamental Principles of Architecture as Code"},
         {"identifier": "3", "file": "docs/03_version_control.md", "title": "Version Control and Code Structure"},
         {"identifier": "4", "file": "docs/04_adr.md", "title": "Architecture Decision Records (ADR)"}
@@ -23,14 +24,15 @@
     },
     {
       "id": "part_c",
-      "title": "Security & Governance",
+      "title": "Security, Governance & Assurance",
       "chapters": [
         {"identifier": "9", "file": "docs/09_security_fundamentals.md", "title": "Security Fundamentals for Architecture as Code"},
         {"identifier": "9B", "file": "docs/09b_security_patterns.md", "title": "Advanced Security Patterns and Implementation"},
         {"identifier": "9C", "file": "docs/09c_risk_and_threat_as_code.md", "title": "Risk as Code and Threat Handling as Code"},
         {"identifier": "10", "file": "docs/10_policy_and_security.md", "title": "Policy and Security as Code in Detail"},
         {"identifier": "11", "file": "docs/11_governance_as_code.md", "title": "Governance as Code"},
-        {"identifier": "12", "file": "docs/12_compliance.md", "title": "Compliance and Regulatory Adherence"}
+        {"identifier": "12", "file": "docs/12_compliance.md", "title": "Compliance and Regulatory Adherence"},
+        {"identifier": "15A", "file": "docs/15_evidence_as_code.md", "title": "Evidence as Code and Continuous Assurance"}
       ]
     },
     {
@@ -39,7 +41,6 @@
       "chapters": [
         {"identifier": "13", "file": "docs/13_testing_strategies.md", "title": "Testing Strategies for Infrastructure as Code"},
         {"identifier": "14", "file": "docs/14_practical_implementation.md", "title": "Architecture as Code in Practice"},
-        {"identifier": "15A", "file": "docs/15_evidence_as_code.md", "title": "Evidence as Code and Continuous Assurance"},
         {"identifier": "15B", "file": "docs/15_cost_optimization.md", "title": "Cost Optimisation and Resource Management"},
         {"identifier": "16", "file": "docs/16_migration.md", "title": "Migration from Traditional Infrastructure"}
       ]
@@ -51,6 +52,7 @@
         {"identifier": "17", "file": "docs/17_organisational_change.md", "title": "Organisational Change and Team Structures"},
         {"identifier": "18", "file": "docs/18_team_structure.md", "title": "Team Structure and Competency Development for IaC"},
         {"identifier": "19", "file": "docs/19_management_as_code.md", "title": "Management as Code"},
+        {"identifier": "23", "file": "docs/23_soft_as_code_interplay.md", "title": "The Interplay Between Soft As Code Disciplines"},
         {"identifier": "20", "file": "docs/20_ai_agent_team.md", "title": "AI Agent Team for Architecture as Code Initiatives"},
         {"identifier": "21", "file": "docs/21_digitalisation.md", "title": "Digitalisation through Code-based Infrastructure"}
       ]
@@ -60,7 +62,6 @@
       "title": "Experience & Best Practices",
       "chapters": [
         {"identifier": "22", "file": "docs/22_documentation_vs_architecture.md", "title": "Documentation as Code vs Architecture as Code"},
-        {"identifier": "23", "file": "docs/23_soft_as_code_interplay.md", "title": "The Interplay Between Soft As Code Disciplines"},
         {"identifier": "24", "file": "docs/24_best_practices.md", "title": "Best Practices and Lessons Learned"}
       ]
     },
@@ -69,7 +70,6 @@
       "title": "Future & Wrap-up",
       "chapters": [
         {"identifier": "25", "file": "docs/25_future_trends.md", "title": "Future Trends in Architecture as Code"},
-        {"identifier": "26A", "file": "docs/26a_prerequisites_for_aac.md", "title": "Prerequisites for Architecture as Code Adoption"},
         {"identifier": "26B", "file": "docs/26b_aac_anti_patterns.md", "title": "Anti-Patterns in Architecture as Code Programmes"},
         {"identifier": "27", "file": "docs/27_conclusion.md", "title": "Conclusion"}
       ]


### PR DESCRIPTION
Three structural changes based on content analysis:

1. Move ch 26A (Prerequisites for AaC Adoption) from Part G to Part A
   - Prerequisites belong at the start, not in the Future & Wrap-up section

2. Move ch 15A (Evidence as Code) from Part D to end of Part C
   - Evidence as Code completes the assurance arc (Security → Governance →
     Compliance → Evidence); Part C retitled to "Security, Governance & Assurance"

3. Move ch 23 (Soft As Code Interplay) from Part F to Part E after ch 19
   - Introduces Soft as Code concepts alongside Management as Code rather than
     leaving them until the Experience section

https://claude.ai/code/session_01E8arS7LMSVqokwtFcevuHR