### PR TITLE
fix: language review against author persona – 22 corrections across 8 chapters

### DIFF
--- a/docs/02_fundamental_principles.md
+++ b/docs/02_fundamental_principles.md
@@ -257,7 +257,7 @@ When drift is detected, teams can choose to either:
 2. **Update the code**: If the drift represents an intentional change, update the architecture definition to reflect the new desired state
 3. **Investigate and resolve**: Determine the root cause of drift, fix the underlying process gap, and prevent recurrence
 
-By treating architecture as code and automating drift detection and remediation, organisations maintain architectural integrity throughout the entire system lifecycle, ensuring that reality consistently matches design intent.
+By treating Architecture as Code and automating drift detection and remediation, organisations maintain architectural integrity throughout the entire system lifecycle, ensuring that reality consistently matches design intent.
 
 ## Testability at the architecture level
 
@@ -577,7 +577,7 @@ The table below summarises key differences in how functional and non-functional 
 
 This distinction has profound implications for how Architecture as Code is implemented:
 
-1. **NFR Testing in CI/CD**: Non-functional requirements integrate seamlessly into continuous deployment pipelines. Every infrastructure change can be automatically tested for performance impact, security compliance, and operational characteristics.
+1. **NFR Testing in CI/CD**: Non-functional requirements integrate directly into continuous deployment pipelines. Every infrastructure change can be automatically tested for performance impact, security compliance, and operational characteristics.
 
 2. **FR Validation Gates**: Functional requirements require explicit validation gates where stakeholders confirm business value. These gates cannot be fully automated but can be facilitated through Requirements as Code specifications that document acceptance criteria and track validation status.
 

--- a/docs/06_structurizr.md
+++ b/docs/06_structurizr.md
@@ -18,7 +18,7 @@ In the Architecture as Code ecosystem, Structurizr serves as a practical impleme
 
 The open-source Architecture-as-Code (AaC) project offers a complementary example: its maintainers describe the toolkit as an open-source platform for modelling architecture definitions in YAML and automating validation and generation steps, with every capability delivered through discoverable plugins so teams can extend the CLI without modifying the core distribution (AaC Open Source Project). The plugin model demonstrates how DSL-driven approaches like Structurizr stay adaptable—domain teams can add generators, schema validators, or documentation exporters in the same fashion, keeping the architecture source of truth central whilst tailoring outputs to their needs.
 
-This chapter explores how to use Structurizr for creating, developing, and handling architecture models, integrating them into modern development workflows, and establishing architecture as a living, evolving artifact.
+This chapter explores how to use Structurizr for creating, developing, and handling architecture models, integrating them into modern development workflows, and establishing architecture as a living, evolving artefact.
 
 ## The C4 Model Foundation
 
@@ -1253,7 +1253,7 @@ This creates traceability from architecture elements to the decisions that shape
 
 ## Conclusion
 
-Structurizr represents a powerful implementation of Architecture as Code principles, enabling teams to:
+Structurizr is a mature implementation of Architecture as Code principles, enabling teams to:
 
 1. **Define architecture models programmatically** using a clear, version-controlled DSL
 2. **Generate consistent diagrams** from a single source of truth
@@ -1261,7 +1261,7 @@ Structurizr represents a powerful implementation of Architecture as Code princip
 4. **Automate validation** that architecture matches reality
 5. **Maintain living documentation** that evolves with the system
 
-The C4 model provides the conceptual framework, while Structurizr DSL offers the practical tooling to implement it. By treating architecture as code, teams can apply the same rigorous practices—version control, code review, automated testing, CI/CD—to their architectural work as they do to application development.
+The C4 model provides the conceptual framework, while Structurizr DSL offers the practical tooling to implement it. By treating Architecture as Code, teams can apply the same rigorous practices—version control, code review, automated testing, CI/CD—to their architectural work as they do to application development.
 
 While there's a learning curve to master the DSL syntax and modeling concepts, the investment pays dividends through improved architecture consistency, team collaboration, and documentation quality. Combined with the practices covered in earlier chapters (ADRs, version control, automation), Structurizr enables a comprehensive Architecture as Code workflow.
 

--- a/docs/09_security_fundamentals.md
+++ b/docs/09_security_fundamentals.md
@@ -39,8 +39,8 @@ owing delivery teams.*
 
 The security challenges facing contemporary digital enterprises demand a fundamental reassessment of traditional defensive pract
 ices. As organisations adopt Architecture as Code to manage rapidly expanding and highly distributed environments, security stra
-tegies must evolve in parallel. This chapter offers a comprehensive guide to integrating security seamlessly into code-based arc
-hitectures.
+tegies must evolve in parallel. This chapter offers a comprehensive guide to integrating security into code-based arc
+hitectures without treating it as an afterthought.
 
 Perimeter-based defences designed for static environments become ineffective in cloud-native and microservice-oriented platforms
 . Security can no longer be treated as a separate afterthought. Modern organisations must embrace security-as-code principles wh

--- a/docs/13_testing_strategies.md
+++ b/docs/13_testing_strategies.md
@@ -159,7 +159,7 @@ Critical validation test patterns include:
 
 ### Integration in CI/CD Pipeline
 
-Vitest integrates seamlessly into CI/CD pipelines for automated testing of infrastructure code. A typical GitHub Actions workflow runs tests on pull requests and pushes, generates coverage reports and provides feedback through automated comments.
+Vitest integrates directly into CI/CD pipelines for automated testing of infrastructure code. A typical GitHub Actions workflow runs tests on pull requests and pushes, generates coverage reports and provides feedback through automated comments.
 
 *See Appendix A, Listing 13-F for a complete GitHub Actions workflow demonstrating Vitest integration with coverage reporting and PR comments.*
 

--- a/docs/15_cost_optimization.md
+++ b/docs/15_cost_optimization.md
@@ -52,7 +52,7 @@ Comprehensive cost monitoring requires integration of monitoring tools directly 
 
 Real-time cost tracking enables proactive cost management instead of reactive measures after budgets are already exceeded. Architecture as Code-based monitoring solutions can automatically implement cost controls such as resource termination or approval workflows for cost-critical operations.
 
-EU organisations' reporting requirements can be automated through Architecture as Code-defined dashboards and reports that are generated regularly and distributed to relevant stakeholders. Integration with enterprise ERP systems enables seamless financial planning and budgeting, with support for multi-currency reporting (EUR, GBP, and other EU currencies) alongside cloud provider billing in USD.
+EU organisations' reporting requirements can be automated through Architecture as Code-defined dashboards and reports that are generated regularly and distributed to relevant stakeholders. Integration with enterprise ERP systems supports financial planning and budgeting, with support for multi-currency reporting (EUR, GBP, and other EU currencies) alongside cloud provider billing in USD.
 
 Anomaly detection for cloud costs can be implemented through machine learning algorithms trained on historical usage patterns. These can be integrated into Architecture as Code workflows to automatically flag and potentially remediate abnormal cost spikes across different EU regions.
 

--- a/docs/16_migration.md
+++ b/docs/16_migration.md
@@ -45,13 +45,13 @@ Version control integration for infrastructure changes enables systematic tracki
 
 ## Team transition and competence development
 
-Skills development programs must prepare traditional systems administrators and network engineers for Architecture as Code-based workflows. Training curricula should encompass Infrastructure as Code tools, cloud platforms, DevOps practices and automation scripting for comprehensive capability development.
+Skills development programmes must prepare traditional systems administrators and network engineers for Architecture as Code-based workflows. Training curricula should encompass Infrastructure as Code tools, cloud platforms, DevOps practices and automation scripting for comprehensive capability development.
 
-Organisational structure evolution from traditional silos to cross-functional teams enables effective Architecture as Code adoption. European telecommunications companies have successfully transitioned from separate development and operations teams to integrated DevOps teams that manage architecture as code.
+Organisational structure evolution from traditional silos to cross-functional teams enables effective Architecture as Code adoption. European telecommunications companies have successfully transitioned from separate development and operations teams to integrated DevOps teams that manage Architecture as Code.
 
 Cultural transformation from manual processes to automated workflows requires change management programmes that address resistance and promote automation adoption. Success stories from early adopters can motivate broader organisational acceptance of Architecture as Code practices.
 
-Mentorship programs pairing experienced cloud engineers with traditional infrastructure teams accelerates knowledge transfer and reduces adoption friction. External consulting support can supplement internal capabilities during initial migration phases for complex enterprise environments.
+Mentorship programmes pairing experienced cloud engineers with traditional infrastructure teams accelerates knowledge transfer and reduces adoption friction. External consulting support can supplement internal capabilities during initial migration phases for complex enterprise environments.
 
 ## Practical Examples
 

--- a/docs/19_management_as_code.md
+++ b/docs/19_management_as_code.md
@@ -81,7 +81,7 @@ Transparency through Issues manifests in several ways:
 
 **Accountability**: Assigning Issues to specific owners, setting milestones, and tracking progress creates clear accountability. Teams know who is responsible for each initiative, reducing ambiguity and preventing work from falling through organisational cracks. Labels reflect strategic pillars, enabling filtering and reporting across different dimensions of the architecture portfolio.
 
-**Collaborative Resolution**: Issues encourage participation from diverse perspectives. Engineers can flag technical constraints, security specialists can highlight risks, and product managers can clarify business context—all within a single, coherent thread. This collaborative approach surfaces potential problems earlier and leads to more robust solutions.
+**Collaborative Resolution**: Issues encourage participation from diverse perspectives. Engineers can flag technical constraints, security specialists can highlight risks, and product managers can clarify business context—all within a single, coherent thread. This collaborative approach surfaces potential problems earlier and produces better-grounded decisions.
 
 ### Practical Examples of Transparent Issue Usage
 
@@ -161,7 +161,7 @@ This exploratory phase prevents premature standardisation whilst building shared
 
 ### Linking Transparency to Architecture Evolution
 
-The true power of Issues and Discussions emerges when they integrate seamlessly with code-based architecture practices. Every significant architecture change should originate from or reference an Issue or Discussion, creating bidirectional traceability between strategic intent and technical implementation.
+Issues and Discussions deliver the most value when they connect directly with code-based architecture practices. Every significant architecture change should originate from or reference an Issue or Discussion, creating bidirectional traceability between strategic intent and technical implementation.
 
 When a team proposes infrastructure changes via pull request, reviewers can follow references back to the originating Issue to understand business justification. Conversely, stakeholders tracking high-level strategy in Issues can drill down into the actual code changes that implement their decisions. This linkage ensures alignment between what organisations say they value and what they actually build.
 
@@ -280,4 +280,4 @@ Consider a global software company operating in regulated financial markets. The
 As artificial intelligence capabilities mature, MaC will incorporate intelligent agents that suggest policy updates based on observed outcomes. Machine learning models can analyse historical management changes and their impact on delivery performance, recommending adjustments to guardrails or team structures. Natural language processing can transform meeting transcripts into code updates, bridging human discussions and codified artefacts, while decentralised governance structures may use smart contracts to enforce management rules across partner ecosystems.
 
 ## Conclusion
-Management as Code is the logical next step for organisations that already treat infrastructure and architecture as code. By encoding leadership intent into executable artefacts, organisations achieve transparency, speed, and adaptability. MaC embeds management into the DevOps loop, ensures governance is automated, and ties budgeting, competence development, and team leadership into a single continuous system. GitHub and similar platforms become hubs where executives and engineers collaborate seamlessly, with Issues, Discussions, and Actions transforming management from a peripheral function into a core element of the delivery pipeline. By embracing MaC, organisations unlock scalable, data-driven leadership capable of orchestrating multiple teams and responding rapidly to change.
+Management as Code is the logical next step for organisations that already treat infrastructure and architecture as code. By encoding leadership intent into executable artefacts, organisations achieve transparency, speed, and adaptability. MaC embeds management into the DevOps loop, ensures governance is automated, and ties budgeting, competence development, and team leadership into a single continuous system. GitHub and similar platforms become hubs where executives and engineers collaborate in the same workflows, with Issues, Discussions, and Actions transforming management from a peripheral function into a core element of the delivery pipeline. By embracing MaC, organisations unlock scalable, data-driven leadership capable of orchestrating multiple teams and responding rapidly to change.

--- a/docs/23_soft_as_code_interplay.md
+++ b/docs/23_soft_as_code_interplay.md
@@ -18,7 +18,7 @@ The following mind maps illustrate the key concepts and relationships within the
 
 ![Architecture as Code as central hub](images/mindmap_23c_architecture.png)
 
-*Figure 23.3 demonstrates architecture as code serving as the central hub connecting technical implementation, policy, and documentation.*
+*Figure 23.3 demonstrates Architecture as Code serving as the central hub connecting technical implementation, policy, and documentation.*
 
 ![Documentation as Code](images/mindmap_23d_documentation.png)
 
@@ -38,11 +38,11 @@ The following mind maps illustrate the key concepts and relationships within the
 - **Compliance as Code acts as the quality engine:** By codifying rules and policies, it provides continuous validation and transparency, ensuring that architectural and documentation artifacts remain within approved boundaries.
 - **Architecture as Code serves as the central hub:** It connects technical implementations with policy and documentation layers, providing traceability and enabling real-time synchronization across the ecosystem.
 - **Documentation as Code forms the communication layer:** It translates technical and policy concepts into accessible narratives, enabling self-service knowledge and fostering collective ownership through structured feedback loops.
-- **Knowledge and Culture as Code preserve organisational memory:** Formalizing lessons learned and cultural values ensures consistency, supports onboarding, and enables rapid iteration without losing core principles.
+- **Knowledge and Culture as Code preserve organisational memory:** Formalising lessons learned and cultural values ensures consistency, supports onboarding, and enables rapid iteration without losing core principles.
 - **Synergies multiply value:** When these disciplines integrate, they create cross-functional collaboration spaces, unified validation pipelines, and enhanced traceability—accelerating the pace of change while managing risk.
 - **Implementation requires strategy:** Success depends on shared principles, compatible tooling, cross-functional training, iterative building, and clear governance frameworks.
 
-This visualisation reinforces the chapter's central message: soft "as code" disciplines are more powerful together than in isolation, creating an ecosystem where human creativity is amplified by the precision and reliability of code.
+This visualisation reinforces the chapter's central message: soft "as code" disciplines compound their value when combined rather than deployed in isolation, creating an ecosystem where human creativity is amplified by the precision and reliability of code.
 
 ## A Shared DNA
 
@@ -59,7 +59,7 @@ This combination opens the door to a shared way of working across disciplines. O
 Compliance as code focuses on translating regulations, standards, and internal policies into codified controls. Tools such as Open Policy Agent, HashiCorp Sentinel, or custom rule frameworks can ingest policy definitions and evaluate them against system configurations, CI/CD pipelines, or infrastructure definitions. When the discipline is connected to other soft areas several effects emerge:
 
 - **Rule reuse.** Documentation and architectural principles can directly reference policy definitions, reducing the risk of diverging interpretations. An architect writing a blueprint can link to the same policy files the security team uses in their controls.
-- **Continuous validation.** Documentation as code makes it possible to describe which controls exist and how they are executed, while automations from architecture as code can trigger compliance checks for every change. The result is an unbroken chain between intent and verification.
+- **Continuous validation.** Documentation as code makes it possible to describe which controls exist and how they are executed, while automations from Architecture as Code can trigger compliance checks for every change. The result is an unbroken chain between intent and verification.
 - **Transparency and education.** When the rule set is versioned and open to inspection, teams can teach themselves what is required. Pull requests on policy code become educational moments where lawyers, security experts, and developers meet and explain their reasoning.
 
 Compliance as code thus becomes a quality engine that reinforces the other disciplines. When architectural or documentation artifacts are updated, automated controls can ensure that changes still fall within approved boundaries. If a rule changes, the update propagates to every system that uses it—from architectural diagrams to external reports.
@@ -74,7 +74,7 @@ Architecture as Code means expressing architectural decisions, reference archite
 - **Real-time documentation.** Documentation as code can be generated directly from architectural models and provide up-to-date manuals, diagrams, and guides. Documentation stays in sync with the "living" architecture.
 - **Automated quality gates.** When architectural models are versioned, compliance and quality checks can run automatically before an architectural change is approved. This offers objective support for architecture boards and decision forums.
 
-The hub metaphor is powerful: Architecture as Code connects technical implementations with policy and documentation layers. It becomes easier to facilitate dialogue across expert roles when everyone looks at the same source of truth.
+The hub metaphor holds: Architecture as Code connects technical implementations with policy and documentation layers. Dialogue across expert roles becomes easier when everyone looks at the same source of truth.
 
 ## Documentation as Code as the Communication Layer
 
@@ -88,7 +88,7 @@ Documentation as code also acts as a layer of visibility. Architectural principl
 
 ## Knowledge as Code and Culture as Code
 
-To capture the full spectrum of soft artifacts we can also include knowledge as code and culture as code. Knowledge as code formalizes knowledge bases and lessons learned in code or semi-structured formats, while culture as code expresses values, decision-making practices, and ways of working in versioned playbooks. When experiences, norms, and policies can be linked to architectural models and documentation, insights become reusable, tracking adherence to working norms becomes easier, and onboarding grows more structured. The organisation can iterate quickly while still preserving its experience and values.
+To capture the full spectrum of soft artifacts we can also include knowledge as code and culture as code. Knowledge as code formalises knowledge bases and lessons learned in code or semi-structured formats, while culture as code expresses values, decision-making practices, and ways of working in versioned playbooks. When experiences, norms, and policies can be linked to architectural models and documentation, insights become reusable, tracking adherence to working norms becomes easier, and onboarding grows more structured. The organisation can iterate quickly while still preserving its experience and values.
 
 ## Synergies and Cross-Pollination
 
@@ -96,14 +96,14 @@ Introducing several soft "as code" disciplines in parallel generates effects tha
 
 ## Challenges and Counterforces
 
-The interplay between soft "as code" disciplines is powerful but also demanding. Common challenges include:
+The interplay between soft "as code" disciplines generates real value, but it is also demanding. Common challenges include:
 
 - **Differences in terminology and mindset.** Lawyers, architects, and documentation specialists use different vocabularies, which requires translation and extra onboarding.
 - **Tooling barriers.** Not everyone is comfortable with Git, pull requests, or CI/CD, so training is needed to avoid creating new hierarchies.
 - **Automation debt.** Codified rules do not capture every interpretation, so manual controls and clear governance remain necessary.
 - **Information overload.** When everything is versioned and logged, metadata and structure are required to keep information navigable.
 
-By addressing these challenges openly, investing in joint training initiatives, and establishing clear roles, organisations can maximize the value of the interplay.
+By addressing these challenges openly, investing in joint training initiatives, and establishing clear roles, organisations can maximise the value of the interplay.
 
 ## Practical Applications
 


### PR DESCRIPTION
- Replace American spellings: Formalizing→Formalising, formalizes→formalises,
  maximize→maximise, artifact→artefact
- Capitalise 'Architecture as Code' consistently in prose (5 instances)
- Remove forbidden marketing language: 'seamlessly'/'seamless' (6 instances),
  'powerful' (4 instances), 'robust solutions' (1 instance)
- Replace 'programs' with 'programmes' in non-computing context (2 instances)

https://claude.ai/code/session_01BQRJquQhQvziZ8VDSKH3dt