### PR TITLE
fix: ensure PDF is reliably built and uploaded in release pipeline

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -253,7 +253,7 @@ jobs:
                   ./build_book.sh --release &&
                   cd .. &&
                   echo '📝 Step 3: Verifying book files...' &&
-                  ls -la releases/book/ || echo '⚠️ No book files found'
+                  ls -la releases/book/architecture_as_code.pdf || { echo '❌ PDF missing from releases/book/ – aborting'; exit 1; }
                   ;;
                 'presentations-only')
                   echo '🎤 Building presentations only...' &&
@@ -281,7 +281,7 @@ jobs:
                   ./build_book.sh --release &&
                   cd .. &&
                   echo '📝 Verifying book files...' &&
-                  ls -la releases/book/ || echo '⚠️ No book files found' &&
+                  ls -la releases/book/architecture_as_code.pdf || { echo '❌ PDF missing from releases/book/ – aborting'; exit 1; } &&
 
                   # Generate whitepapers
                   echo '📄 Step 2: Generating whitepapers...' &&
@@ -585,6 +585,7 @@ jobs:
             final-release/presentation/architecture_as_code_presentation.pptx
             final-release/whitepapers/whitepapers_combined.pdf
             unified-release-archive.zip
+          fail_on_unmatched_files: true
           draft: false
           prerelease: false
         env:

--- a/Dockerfile.book-builder
+++ b/Dockerfile.book-builder
@@ -65,6 +65,18 @@ RUN npm install -g @mermaid-js/mermaid-cli@${MERMAID_VERSION} --unsafe-perm \
     && mmdc --version
 
 # ------------------------------------------------------------------
+# Eisvogel LaTeX template (pre-installed to avoid runtime network dependency)
+# ------------------------------------------------------------------
+RUN mkdir -p /root/.local/share/pandoc/templates && \
+    wget -q "https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest/download/Eisvogel.tar.gz" \
+         -O /tmp/eisvogel.tar.gz && \
+    tar -xzf /tmp/eisvogel.tar.gz -C /tmp && \
+    find /tmp -name "eisvogel.latex" -print -quit | xargs -I{} cp {} /root/.local/share/pandoc/templates/eisvogel.latex && \
+    rm -f /tmp/eisvogel.tar.gz && \
+    test -f /root/.local/share/pandoc/templates/eisvogel.latex && \
+    echo "✅ Eisvogel template installed"
+
+# ------------------------------------------------------------------
 # Python dependencies
 # ------------------------------------------------------------------
 COPY requirements.txt /tmp/requirements.txt

--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -466,10 +466,11 @@ if [ -f "$OUTPUT_PDF" ] && [ -s "$OUTPUT_PDF" ]; then
     echo "✅ Book generated: $OUTPUT_PDF ($(ls -lh "$OUTPUT_PDF" | awk '{print $5}'))"
 
     # Copy to release directory
-    if cp "$OUTPUT_PDF" "$RELEASE_PDF" 2>/dev/null; then
+    if cp "$OUTPUT_PDF" "$RELEASE_PDF"; then
         echo "✅ Book copied to release directory: $RELEASE_PDF"
     else
-        echo "⚠️  Warning: Could not copy PDF to release directory"
+        echo "❌ Error: Failed to copy PDF to release directory: $RELEASE_PDF"
+        exit 1
     fi
 else
     echo "❌ Error: PDF generation failed with the Eisvogel template"
@@ -488,10 +489,11 @@ else
             echo "✅ Fallback PDF generation succeeded: $OUTPUT_PDF ($(ls -lh "$OUTPUT_PDF" | awk '{print $5}'))"
 
             # Copy to release directory
-            if cp "$OUTPUT_PDF" "$RELEASE_PDF" 2>/dev/null; then
+            if cp "$OUTPUT_PDF" "$RELEASE_PDF"; then
                 echo "✅ Fallback PDF copied to release directory: $RELEASE_PDF"
             else
-                echo "⚠️  Warning: Could not copy fallback PDF to release directory"
+                echo "❌ Error: Failed to copy fallback PDF to release directory: $RELEASE_PDF"
+                exit 1
             fi
         else
             echo "❌ Error: Even fallback PDF generation failed"


### PR DESCRIPTION
Three root causes identified and fixed:

1. Eisvogel LaTeX template was downloaded from GitHub at runtime on every
   build. A network failure or rate limit would cause build_book.sh to exit 1
   and silently skip the PDF. Template is now pre-installed in the Docker
   image during the image-build step, eliminating the runtime dependency.

2. The PDF copy from docs/ to releases/book/ used `2>/dev/null` and only
   printed a warning on failure, allowing the script to exit 0 with no PDF
   in the release directory. Both copy sites now use exit 1 on failure so
   any copy error surfaces immediately.

3. The workflow verified the releases/book/ directory with `ls || echo`
   which always exited 0, masking a missing PDF. Both the 'book-only' and
   'all' cases now hard-fail when architecture_as_code.pdf is absent.
   The release action also sets fail_on_unmatched_files: true so a missing
   deliverable fails the job rather than being silently skipped.

https://claude.ai/code/session_019vELYUaiC2kWL2haJHt4Nb