### PR TITLE
fix: add mkdocs-redirects to MkDocs build workflow

### DIFF
--- a/.github/workflows/build-mkdocs.yml
+++ b/.github/workflows/build-mkdocs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install MkDocs and bootswatch theme
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs pymdown-extensions mkdocs-bootswatch
+          pip install mkdocs pymdown-extensions mkdocs-bootswatch mkdocs-redirects
 
       - name: Build MkDocs site
         run: mkdocs build


### PR DESCRIPTION
The redirects plugin is configured in mkdocs.yml but was not installed
in the CI workflow, causing the build to fail with "The 'redirects'
plugin is not installed".

https://claude.ai/code/session_01LurzFL2xj2hWNxrdfXG3Pq