### PR TITLE
fix: resolve pandoc EPUB build failure in Docker pipeline

### DIFF
--- a/docs/build_book.sh
+++ b/docs/build_book.sh
@@ -550,14 +550,12 @@ generate_other_formats() {
     echo "Generating EPUB format..."
 
     # Generate EPUB with improved metadata
-    if pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" "${NON_LATEX_DEFAULTS_ARGS[@]}" \
+    if pandoc "${NON_LATEX_CHAPTER_FILES[@]}" "${NON_LATEX_DEFAULTS_ARGS[@]}" \
         -t epub \
         -o "$OUTPUT_EPUB" \
         --metadata date="$(date +'%Y-%m-%d')" \
         --metadata language=en \
         --metadata lang=en-GB \
-        --metadata=include-before= \
-        --metadata=header-includes= \
         --epub-cover-image="images/book-cover.png" \
         2>&1; then
 
@@ -589,10 +587,8 @@ generate_other_formats() {
     fi
 
     echo "Generating DOCX format..."
-    pandoc --defaults=pandoc.yaml "${NON_LATEX_CHAPTER_FILES[@]}" "${NON_LATEX_DEFAULTS_ARGS[@]}" \
+    pandoc "${NON_LATEX_CHAPTER_FILES[@]}" "${NON_LATEX_DEFAULTS_ARGS[@]}" \
         -t docx \
-        --metadata=include-before= \
-        --metadata=header-includes= \
         -o "$OUTPUT_DOCX"
     echo "DOCX generated: $OUTPUT_DOCX"
     cp "$OUTPUT_DOCX" "$RELEASE_DOCX"

--- a/docs/pandoc-nonlatex.yaml
+++ b/docs/pandoc-nonlatex.yaml
@@ -4,8 +4,6 @@ toc: true
 toc-depth: 3
 number-sections: true
 
-top-level-division: chapter
-
 highlight-style: tango
 
 epub-chapter-level: 1
@@ -16,7 +14,4 @@ metadata:
   author: "Gunnar Nordqvist"
   date: "2025"
   language: en-GB
-  lang: en-GB
-
-variables:
   lang: en-GB

--- a/generate_book.py
+++ b/generate_book.py
@@ -147,8 +147,6 @@ def build_epub_from_chapters(chapter_paths: Sequence[Path], output_path: Path) -
                 "language=en-GB",
                 "--metadata",
                 "lang=en-GB",
-                "--metadata=include-before=",
-                "--metadata=header-includes=",
             ]
         )
 


### PR DESCRIPTION
The Docker-based build was failing with pandoc exit code 64
(PandocShouldDisplayUsageError) when generating the EPUB.

Root causes fixed:

1. generate_book.py: Remove --metadata=include-before= and
   --metadata=header-includes= from the pandoc command. These flags
   set empty metadata values which triggered a pandoc 3.1.9 parsing
   issue. They were also redundant since pandoc-nonlatex.yaml does
   not define those template variables.

2. docs/pandoc-nonlatex.yaml: Remove the 'variables' block (lang
   is already set in the metadata section) and remove
   'top-level-division: chapter' (epub-chapter-level: 1 is the
   correct EPUB-specific control for chapter structure).

3. docs/build_book.sh: Stop passing --defaults=pandoc.yaml for EPUB
   and DOCX builds. That file sets 'template: eisvogel.latex' which
   is a LaTeX-only template incompatible with EPUB/DOCX output.
   EPUB/DOCX builds now rely solely on pandoc-nonlatex.yaml, which
   contains the correct non-LaTeX defaults. Also remove the same
   spurious --metadata=include-before= and --metadata=header-includes=
   flags from both format builds.

https://claude.ai/code/session_01BEAo1HeP1nHGfGNnERQV8S