### PR TITLE
fix: add --create-pptx flag to generate_presentation.py in release workflow

### DIFF
--- a/.github/workflows/unified-build-release.yml
+++ b/.github/workflows/unified-build-release.yml
@@ -257,7 +257,7 @@ jobs:
                   ;;
                 'presentations-only')
                   echo '🎤 Building presentations only...' &&
-                  python3 generate_presentation.py --release &&
+                  python3 generate_presentation.py --release --create-pptx &&
                   echo '📝 Verifying presentation files...' &&
                   ls -la releases/presentation/ || echo '⚠️ No presentation files found'
                   ;;
@@ -291,7 +291,7 @@ jobs:
 
                   # Generate presentations
                   echo '🎤 Step 3: Generating presentations...' &&
-                  python3 generate_presentation.py --release &&
+                  python3 generate_presentation.py --release --create-pptx &&
                   python --version &&
                   python3 --version &&
                   echo '📝 Verifying presentation files...' &&


### PR DESCRIPTION
Without --create-pptx, the script only generates helper scripts and data
files but never creates the .pptx file. The release action then fails with
"Pattern 'final-release/presentation/architecture_as_code_presentation.pptx'
does not match any files." because fail_on_unmatched_files is true.

python-pptx is already installed in the Docker image via requirements.txt,
so adding --create-pptx is sufficient to fix the release upload failure.

https://claude.ai/code/session_01V9oA3Yk9Md4BWSYqyMdXN1