### PR TITLE
Improve diagram readability: convert mindmaps to graph TD, redesign key diagrams

### DIFF
--- a/docs/images/diagram_02_v_model.mmd
+++ b/docs/images/diagram_02_v_model.mmd
@@ -1,40 +1,30 @@
-graph TB
-    subgraph "Requirements & Design"
-        BR[Business Requirements]:::kv-primary
-        FR[Functional Requirements]:::kv-accent
-        NFR[Non-Functional Requirements]:::kv-highlight
-        SD[System Design]:::kv-accent
-        DD[Detailed Design]:::kv-primary
+flowchart LR
+    subgraph spec["Specification"]
+        direction TB
+        BR["Business Requirements"]
+        FR["Functional Requirements"]
+        NFR["Non-Functional Requirements"]
+        SD["System Design"]
+        DD["Detailed Design"]
+        BR --> FR --> NFR --> SD --> DD
     end
-    
-    subgraph "Implementation"
-        CODE[Implementation as Code]:::kv-highlight
+
+    CODE["Implementation\nas Code"]
+
+    subgraph verif["Verification & Validation"]
+        direction TB
+        OV["Operational Validation"]
+        AT["Acceptance Testing"]
+        ST["System Testing"]
+        IT["Integration Testing"]
+        UT["Unit Testing"]
+        OV --> AT --> ST --> IT --> UT
     end
-    
-    subgraph "Verification & Validation"
-        UT[Unit Testing<br/>NFR Verification]:::kv-highlight
-        IT[Integration Testing<br/>NFR Verification]:::kv-accent
-        ST[System Testing<br/>NFR Verification]:::kv-accent
-        AT[Acceptance Testing<br/>FR Validation]:::kv-primary
-        OT[Operational Validation<br/>FR Validation]:::kv-primary
-    end
-    
-    BR --> FR
-    BR --> NFR
-    FR --> SD
-    NFR --> SD
-    SD --> DD
-    DD --> CODE
-    
-    CODE --> UT
-    UT --> IT
-    IT --> ST
-    ST --> AT
-    AT --> OT
-    
-    DD -.Testing.-> UT
-    SD -.Testing.-> IT
-    NFR -.Testing.-> ST
-    FR -.Validation.-> AT
-    BR -.Validation.-> OT
-    
+
+    DD --> CODE --> UT
+
+    BR -. "Validates" .-> OV
+    FR -. "Validates" .-> AT
+    NFR -. "Verifies" .-> ST
+    SD -. "Verifies" .-> IT
+    DD -. "Verifies" .-> UT

--- a/docs/images/diagram_06_structurizr_overview.mmd
+++ b/docs/images/diagram_06_structurizr_overview.mmd
@@ -1,25 +1,27 @@
 %% Diagram: Structurizr Overview
 %% Shows the Structurizr DSL workflow from version-controlled source through
 %% CI/CD pipeline to a published documentation site.
-graph TB
-    subgraph "Structurizr Workflow"
-        DSL[Structurizr DSL\nworkspace.dsl]:::kv-primary
-        Model[Architecture Model]:::kv-accent
-        Views[Generated Views]:::kv-highlight
-        Diagrams[Diagram Outputs]:::kv-accent
+flowchart TD
+    DSL["Structurizr DSL
+    workspace.dsl"]
+
+    subgraph arch["Architecture Pipeline"]
+        direction LR
+        Model["Architecture Model"]
+        Views["Generated Views"]
+        Diagrams["Diagram Outputs"]
+        Model -->|Generate| Views -->|Export| Diagrams
     end
 
-    subgraph "Integration"
-        VCS[Version Control\nGit]:::kv-primary
-        CI[CI/CD Pipeline]:::kv-accent
-        Docs[Documentation Site]:::kv-highlight
+    subgraph deploy["Deployment Pipeline"]
+        direction LR
+        VCS["Version Control
+        Git"]
+        CI["CI/CD Pipeline"]
+        Docs["Documentation Site"]
+        VCS -->|Trigger| CI -->|Build & Deploy| Docs
     end
 
     DSL -->|Parse| Model
-    Model -->|Generate| Views
-    Views -->|Export| Diagrams
-
     DSL -->|Commit| VCS
-    VCS -->|Trigger| CI
-    CI -->|Build & Deploy| Docs
     Diagrams -->|Embed| Docs

--- a/docs/images/diagram_27_technical_structure.mmd
+++ b/docs/images/diagram_27_technical_structure.mmd
@@ -1,0 +1,43 @@
+%% Diagram: Architecture as Code – Technical Structure
+%% Shows the layered relationship between declarative definitions,
+%% automation pipelines, and governance controls.
+flowchart TB
+    subgraph defs["Layer 1 — Declarative Definitions"]
+        direction LR
+        DSL["Architecture DSL
+        Structurizr"]
+        IaC["Infrastructure Code
+        Terraform / HCL"]
+        Diag["Diagram Sources
+        Mermaid"]
+        Docs["Documentation
+        Markdown"]
+    end
+
+    VCS["Version Control
+    Git — Single Source of Truth"]
+
+    subgraph pipelines["Layer 2 — Automation Pipelines"]
+        direction LR
+        Build["Build & Validate"]
+        Test["Automated Testing"]
+        Deploy["Publish & Deploy"]
+        Build --> Test --> Deploy
+    end
+
+    subgraph governance["Layer 3 — Governance Controls"]
+        direction LR
+        Policy["Policy as Code
+        OPA / Sentinel"]
+        Audit["Audit Trails"]
+        Reports["Compliance Reports"]
+    end
+
+    Artifacts["Published Artefacts
+    PDF · EPUB · Website · Diagrams"]
+
+    defs --> VCS
+    VCS --> Build
+    Deploy --> Artifacts
+    Deploy --> governance
+    governance -. "Enforce policies" .-> pipelines

--- a/docs/images/mindmap_02_principles.mmd
+++ b/docs/images/mindmap_02_principles.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Fundamental Principles))
-    Declarative Architecture
-      Desired System State
-      Benefits
-    Holistic Codification
-      Broad Scope
-      Integration
-    Immutable Patterns
-      Core Principles
-      Advantages
-    Testability
-      Testing Scope
-      Tooling
+graph TD
+    ROOT(["Fundamental Principles"])
+    ROOT --> DA["Declarative Architecture"]
+    ROOT --> HC["Holistic Codification"]
+    ROOT --> IP["Immutable Patterns"]
+    ROOT --> T["Testability"]
+    DA --> DA1["Desired System State"]
+    DA --> DA2["Benefits"]
+    HC --> HC1["Broad Scope"]
+    HC --> HC2["Integration"]
+    IP --> IP1["Core Principles"]
+    IP --> IP2["Advantages"]
+    T --> T1["Testing Scope"]
+    T --> T2["Tooling"]

--- a/docs/images/mindmap_10_security_overview.mmd
+++ b/docs/images/mindmap_10_security_overview.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Security in Architecture as Code))
-    Threat Modelling
-      Threat Landscape
-      STRIDE Methodology
-    Zero Trust Architecture
-      Core Principles
-      Implementation
-    Policy as Code
-      Automated Governance
-      Compliance Automation
-    Risk Assessment
-      Continuous Evaluation
-      Regulatory Compliance
+graph TD
+    ROOT(["Security in Architecture as Code"])
+    ROOT --> TM["Threat Modelling"]
+    ROOT --> ZT["Zero Trust Architecture"]
+    ROOT --> PC["Policy as Code"]
+    ROOT --> RA["Risk Assessment"]
+    TM --> TM1["Threat Landscape"]
+    TM --> TM2["STRIDE Methodology"]
+    ZT --> ZT1["Core Principles"]
+    ZT --> ZT2["Implementation"]
+    PC --> PC1["Automated Governance"]
+    PC --> PC2["Compliance Automation"]
+    RA --> RA1["Continuous Evaluation"]
+    RA --> RA2["Regulatory Compliance"]

--- a/docs/images/mindmap_10_security_policy.mmd
+++ b/docs/images/mindmap_10_security_policy.mmd
@@ -1,12 +1,12 @@
-mindmap
-  root((Policy as Code))
-    Automated Governance
-      OPA/Rego Policies
-      HashiCorp Sentinel
-      Cloud-native Policies
-      Real-time Enforcement
-    Compliance Automation
-      GDPR Article 32
-      PCI-DSS Requirements
-      ISO 27001
-      Swedish Regulations
+graph TD
+    ROOT(["Policy as Code"])
+    ROOT --> AG["Automated Governance"]
+    ROOT --> CA["Compliance Automation"]
+    AG --> AG1["OPA/Rego Policies"]
+    AG --> AG2["HashiCorp Sentinel"]
+    AG --> AG3["Cloud-native Policies"]
+    AG --> AG4["Real-time Enforcement"]
+    CA --> CA1["GDPR Article 32"]
+    CA --> CA2["PCI-DSS Requirements"]
+    CA --> CA3["ISO 27001"]
+    CA --> CA4["Swedish Regulations"]

--- a/docs/images/mindmap_10_security_risk.mmd
+++ b/docs/images/mindmap_10_security_risk.mmd
@@ -1,12 +1,12 @@
-mindmap
-  root((Risk Assessment))
-    Continuous Evaluation
-      Blast Radius Calculation
-      Impact Assessment
-      Dependency Analysis
-      Dynamic Risk Scoring
-    Regulatory Compliance
-      Data Protection by Design
-      Automated Audit Trails
-      Compliance-as-code
-      Regulatory Requirements
+graph TD
+    ROOT(["Risk Assessment"])
+    ROOT --> CE["Continuous Evaluation"]
+    ROOT --> RC["Regulatory Compliance"]
+    CE --> CE1["Blast Radius Calculation"]
+    CE --> CE2["Impact Assessment"]
+    CE --> CE3["Dependency Analysis"]
+    CE --> CE4["Dynamic Risk Scoring"]
+    RC --> RC1["Data Protection by Design"]
+    RC --> RC2["Automated Audit Trails"]
+    RC --> RC3["Compliance-as-code"]
+    RC --> RC4["Regulatory Requirements"]

--- a/docs/images/mindmap_10_security_threat_modeling.mmd
+++ b/docs/images/mindmap_10_security_threat_modeling.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Threat Modeling))
-    Threat Landscape
-      Supply Chain Attacks
-      Code Injection
-      Insider Threats
-      Infrastructure Exploits
-    STRIDE Methodology
-      Spoofing
-      Tampering
-      Repudiation
-      Information Disclosure
-      Denial of Service
-      Elevation of Privilege
+graph TD
+    ROOT(["Threat Modelling"])
+    ROOT --> TL["Threat Landscape"]
+    ROOT --> SM["STRIDE Methodology"]
+    TL --> TL1["Supply Chain Attacks"]
+    TL --> TL2["Code Injection"]
+    TL --> TL3["Insider Threats"]
+    TL --> TL4["Infrastructure Exploits"]
+    SM --> SM1["Spoofing"]
+    SM --> SM2["Tampering"]
+    SM --> SM3["Repudiation"]
+    SM --> SM4["Information Disclosure"]
+    SM --> SM5["Denial of Service"]
+    SM --> SM6["Elevation of Privilege"]

--- a/docs/images/mindmap_10_security_zero_trust.mmd
+++ b/docs/images/mindmap_10_security_zero_trust.mmd
@@ -1,12 +1,12 @@
-mindmap
-  root((Zero Trust Architecture))
-    Core Principles
-      Never Trust, Always Verify
-      Continuous Validation
-      Granular Access Control
-      Least Privilege
-    Implementation
-      Network Segmentation
-      Service Mesh Policies
-      IAM Configurations
-      Trust as Code
+graph TD
+    ROOT(["Zero Trust Architecture"])
+    ROOT --> CP["Core Principles"]
+    ROOT --> IMP["Implementation"]
+    CP --> CP1["Never Trust, Always Verify"]
+    CP --> CP2["Continuous Validation"]
+    CP --> CP3["Granular Access Control"]
+    CP --> CP4["Least Privilege"]
+    IMP --> IMP1["Network Segmentation"]
+    IMP --> IMP2["Service Mesh Policies"]
+    IMP --> IMP3["IAM Configurations"]
+    IMP --> IMP4["Trust as Code"]

--- a/docs/images/mindmap_17_organization.mmd
+++ b/docs/images/mindmap_17_organization.mmd
@@ -1,13 +1,13 @@
-mindmap
-  root((Organisational Change))
-    Cultural Foundations
-      Psychological Safety
-      Shared Ownership
-    Cross-functional Teams
-      Balanced Composition
-    Capability Development
-      Learning Paths
-    Role Evolution
-      Leadership & Technical
-    Change Management
-      Co-design approach
+graph TD
+    ROOT(["Organisational Change"])
+    ROOT --> CF["Cultural Foundations"]
+    ROOT --> CT["Cross-functional Teams"]
+    ROOT --> CD["Capability Development"]
+    ROOT --> RE["Role Evolution"]
+    ROOT --> CM["Change Management"]
+    CF --> CF1["Psychological Safety"]
+    CF --> CF2["Shared Ownership"]
+    CT --> CT1["Balanced Composition"]
+    CD --> CD1["Learning Paths"]
+    RE --> RE1["Leadership & Technical"]
+    CM --> CM1["Co-design Approach"]

--- a/docs/images/mindmap_17a_culture_collaboration.mmd
+++ b/docs/images/mindmap_17a_culture_collaboration.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Culture & Collaboration))
-    Cultural foundations
-      Psychological safety
-      Shared ownership
-      Transparent communication
-      Blameless learning
-    Cross-functional teams
-      Software engineering
-      Platform operations
-      Security & product
-    Decision principles
-      Delegated authority
-      Lightweight governance
-      Service objectives
+graph TD
+    ROOT(["Culture & Collaboration"])
+    ROOT --> CF["Cultural Foundations"]
+    ROOT --> CT["Cross-functional Teams"]
+    ROOT --> DP["Decision Principles"]
+    CF --> CF1["Psychological Safety"]
+    CF --> CF2["Shared Ownership"]
+    CF --> CF3["Transparent Communication"]
+    CF --> CF4["Blameless Learning"]
+    CT --> CT1["Software Engineering"]
+    CT --> CT2["Platform Operations"]
+    CT --> CT3["Security & Product"]
+    DP --> DP1["Delegated Authority"]
+    DP --> DP2["Lightweight Governance"]
+    DP --> DP3["Service Objectives"]

--- a/docs/images/mindmap_17b_capability_roles.mmd
+++ b/docs/images/mindmap_17b_capability_roles.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Capability & Role Development))
-    Learning paths
-      Micro-learning series
-      Mentoring & pairing
-      Practice communities
-      Certification support
-    Knowledge enablers
-      Self-service playbooks
-      Experimentation budgets
-      Rotational programmes
-    Role evolution
-      Servant leadership
-      Dual career tracks
-      Integrated security
+graph TD
+    ROOT(["Capability & Role Development"])
+    ROOT --> LP["Learning Paths"]
+    ROOT --> KE["Knowledge Enablers"]
+    ROOT --> RE["Role Evolution"]
+    LP --> LP1["Micro-learning Series"]
+    LP --> LP2["Mentoring & Pairing"]
+    LP --> LP3["Practice Communities"]
+    LP --> LP4["Certification Support"]
+    KE --> KE1["Self-service Playbooks"]
+    KE --> KE2["Experimentation Budgets"]
+    KE --> KE3["Rotational Programmes"]
+    RE --> RE1["Servant Leadership"]
+    RE --> RE2["Dual Career Tracks"]
+    RE --> RE3["Integrated Security"]

--- a/docs/images/mindmap_17c_change_management.mmd
+++ b/docs/images/mindmap_17c_change_management.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Change Management))
-    Co-design approach
-      Stakeholder engagement
-      Collaborative planning
-      Inclusive decision-making
-    Communication strategy
-      Narrative-led approach
-      Clear messaging
-      Regular updates
-    Evidence-based iteration
-      Metrics & KPIs
-      Feedback loops
-      Continuous improvement
+graph TD
+    ROOT(["Change Management"])
+    ROOT --> CD["Co-design Approach"]
+    ROOT --> CS["Communication Strategy"]
+    ROOT --> EI["Evidence-based Iteration"]
+    CD --> CD1["Stakeholder Engagement"]
+    CD --> CD2["Collaborative Planning"]
+    CD --> CD3["Inclusive Decision-making"]
+    CS --> CS1["Narrative-led Approach"]
+    CS --> CS2["Clear Messaging"]
+    CS --> CS3["Regular Updates"]
+    EI --> EI1["Metrics & KPIs"]
+    EI --> EI2["Feedback Loops"]
+    EI --> EI3["Continuous Improvement"]

--- a/docs/images/mindmap_19_digitalization.mmd
+++ b/docs/images/mindmap_19_digitalization.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Digitalisation through IaC))
-    Challenges
-      Regulatory & Organisational
-      Operational Costs
-    Cloud-first Strategy
-      Automated Infrastructure
-      Data Residency
-    Success Examples
-      Spotify & Klarna
-      Volvo Cars
-    IaC Benefits
-      Cost Efficiency
-      Security & Sovereignty
+graph TD
+    ROOT(["Digitalisation through IaC"])
+    ROOT --> CH["Challenges"]
+    ROOT --> CF["Cloud-first Strategy"]
+    ROOT --> SE["Success Examples"]
+    ROOT --> IB["IaC Benefits"]
+    CH --> CH1["Regulatory & Organisational"]
+    CH --> CH2["Operational Costs"]
+    CF --> CF1["Automated Infrastructure"]
+    CF --> CF2["Data Residency"]
+    SE --> SE1["Spotify & Klarna"]
+    SE --> SE2["Volvo Cars"]
+    IB --> IB1["Cost Efficiency"]
+    IB --> IB2["Security & Sovereignty"]

--- a/docs/images/mindmap_21_digitalisation.mmd
+++ b/docs/images/mindmap_21_digitalisation.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Digital Transformation))
-    Technical Dimensions
-      Cloud Migration
-      Infrastructure Automation
-      Modern Architectures
-    Organisational Dimensions
-      Team Structures
-      Governance
-      Change Management
-    Business Dimensions
-      Value Delivery
-      Risk Management
-      Innovation
+graph TD
+    ROOT(["Digital Transformation"])
+    ROOT --> TD["Technical Dimensions"]
+    ROOT --> OD["Organisational Dimensions"]
+    ROOT --> BD["Business Dimensions"]
+    TD --> TD1["Cloud Migration"]
+    TD --> TD2["Infrastructure Automation"]
+    TD --> TD3["Modern Architectures"]
+    OD --> OD1["Team Structures"]
+    OD --> OD2["Governance"]
+    OD --> OD3["Change Management"]
+    BD --> BD1["Value Delivery"]
+    BD --> BD2["Risk Management"]
+    BD --> BD3["Innovation"]

--- a/docs/images/mindmap_21a_technical.mmd
+++ b/docs/images/mindmap_21a_technical.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Technical Foundation))
-    Cloud Migration
-      Multi-cloud strategy
-      Hybrid architectures
-      Serverless computing
-    Infrastructure Automation
-      Declarative configuration
-      Version control
-      Automated testing
-      Continuous deployment
-    Modern Architectures
-      Microservices
-      API-first design
-      Event-driven systems
+graph TD
+    ROOT(["Technical Foundation"])
+    ROOT --> CM["Cloud Migration"]
+    ROOT --> IA["Infrastructure Automation"]
+    ROOT --> MA["Modern Architectures"]
+    CM --> CM1["Multi-cloud Strategy"]
+    CM --> CM2["Hybrid Architectures"]
+    CM --> CM3["Serverless Computing"]
+    IA --> IA1["Declarative Configuration"]
+    IA --> IA2["Version Control"]
+    IA --> IA3["Automated Testing"]
+    IA --> IA4["Continuous Deployment"]
+    MA --> MA1["Microservices"]
+    MA --> MA2["API-first Design"]
+    MA --> MA3["Event-driven Systems"]

--- a/docs/images/mindmap_21b_organisational.mmd
+++ b/docs/images/mindmap_21b_organisational.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Organisational Change))
-    Team Structures
-      Cross-functional teams
-      DevOps culture
-      Platform teams
-    Governance
-      Policy as code
-      Compliance automation
-      Audit trails
-      Access controls
-    Change Management
-      Training programmes
-      Knowledge sharing
-      Community of practice
+graph TD
+    ROOT(["Organisational Change"])
+    ROOT --> TS["Team Structures"]
+    ROOT --> GV["Governance"]
+    ROOT --> CM["Change Management"]
+    TS --> TS1["Cross-functional Teams"]
+    TS --> TS2["DevOps Culture"]
+    TS --> TS3["Platform Teams"]
+    GV --> GV1["Policy as Code"]
+    GV --> GV2["Compliance Automation"]
+    GV --> GV3["Audit Trails"]
+    GV --> GV4["Access Controls"]
+    CM --> CM1["Training Programmes"]
+    CM --> CM2["Knowledge Sharing"]
+    CM --> CM3["Community of Practice"]

--- a/docs/images/mindmap_21c_business.mmd
+++ b/docs/images/mindmap_21c_business.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Business Value))
-    Value Delivery
-      Faster time-to-market
-      Improved quality
-      Cost optimisation
-    Risk Management
-      Security automation
-      Disaster recovery
-      Business continuity
-      Regulatory compliance
-    Innovation
-      Experimentation
-      Data-driven decisions
-      Continuous improvement
+graph TD
+    ROOT(["Business Value"])
+    ROOT --> VD["Value Delivery"]
+    ROOT --> RM["Risk Management"]
+    ROOT --> IN["Innovation"]
+    VD --> VD1["Faster Time-to-market"]
+    VD --> VD2["Improved Quality"]
+    VD --> VD3["Cost Optimisation"]
+    RM --> RM1["Security Automation"]
+    RM --> RM2["Disaster Recovery"]
+    RM --> RM3["Business Continuity"]
+    RM --> RM4["Regulatory Compliance"]
+    IN --> IN1["Experimentation"]
+    IN --> IN2["Data-driven Decisions"]
+    IN --> IN3["Continuous Improvement"]

--- a/docs/images/mindmap_22_best_practices.mmd
+++ b/docs/images/mindmap_22_best_practices.mmd
@@ -1,17 +1,17 @@
-mindmap
-  root((Best Practices Overview))
-    Code Organisation
-      Repository Structure
-      Versioning
-    Security & Compliance
-      Security-first Design
-      Secret Management
-    Performance & Scaling
-      Optimisation
-      Multi-region
-    Governance & Policy
-      Policy-as-code
-      Frameworks
-    International
-      Global Practices
-      Open Source
+graph TD
+    ROOT(["Best Practices Overview"])
+    ROOT --> CO["Code Organisation"]
+    ROOT --> SC["Security & Compliance"]
+    ROOT --> PS["Performance & Scaling"]
+    ROOT --> GP["Governance & Policy"]
+    ROOT --> INT["International"]
+    CO --> CO1["Repository Structure"]
+    CO --> CO2["Versioning"]
+    SC --> SC1["Security-first Design"]
+    SC --> SC2["Secret Management"]
+    PS --> PS1["Optimisation"]
+    PS --> PS2["Multi-region"]
+    GP --> GP1["Policy-as-code"]
+    GP --> GP2["Frameworks"]
+    INT --> INT1["Global Practices"]
+    INT --> INT2["Open Source"]

--- a/docs/images/mindmap_22a_code_organization.mmd
+++ b/docs/images/mindmap_22a_code_organization.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Code Organisation))
-    Repository Structure
-      Shared modules
-      Environment configs
-      Application infra
-    Module Design
-      Reusability principles
-      Composability
-      Clear interfaces
-      Documentation
-    Versioning
-      Semantic versioning
-      Immutable releases
-      Upgrade paths
+graph TD
+    ROOT(["Code Organisation"])
+    ROOT --> RS["Repository Structure"]
+    ROOT --> MD["Module Design"]
+    ROOT --> VER["Versioning"]
+    RS --> RS1["Shared Modules"]
+    RS --> RS2["Environment Configs"]
+    RS --> RS3["Application Infra"]
+    MD --> MD1["Reusability Principles"]
+    MD --> MD2["Composability"]
+    MD --> MD3["Clear Interfaces"]
+    MD --> MD4["Documentation"]
+    VER --> VER1["Semantic Versioning"]
+    VER --> VER2["Immutable Releases"]
+    VER --> VER3["Upgrade Paths"]

--- a/docs/images/mindmap_22b_security_compliance.mmd
+++ b/docs/images/mindmap_22b_security_compliance.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Security & Compliance))
-    Security-first Design
-      Defense-in-depth
-      Least privilege
-      Zero-trust architecture
-    Regional Regulatory
-      GDPR compliance
-      Data residency
-      Encryption requirements
-      Audit logging
-    Secret Management
-      Automated rotation
-      Audit trails
-      Lifecycle management
+graph TD
+    ROOT(["Security & Compliance"])
+    ROOT --> SD["Security-first Design"]
+    ROOT --> RR["Regional Regulatory"]
+    ROOT --> SM["Secret Management"]
+    SD --> SD1["Defence-in-depth"]
+    SD --> SD2["Least Privilege"]
+    SD --> SD3["Zero-trust Architecture"]
+    RR --> RR1["GDPR Compliance"]
+    RR --> RR2["Data Residency"]
+    RR --> RR3["Encryption Requirements"]
+    RR --> RR4["Audit Logging"]
+    SM --> SM1["Automated Rotation"]
+    SM --> SM2["Audit Trails"]
+    SM --> SM3["Lifecycle Management"]

--- a/docs/images/mindmap_22c_performance.mmd
+++ b/docs/images/mindmap_22c_performance.mmd
@@ -1,15 +1,15 @@
-mindmap
-  root((Performance & Scaling))
-    Optimisation
-      Cost efficiency
-      Resource utilisation
-      Response time
-    Multi-region
-      Global scalability
-      Data sovereignty
-      Latency optimisation
-      Disaster recovery
-    Observability
-      System visibility
-      Real-time insights
-      Performance metrics
+graph TD
+    ROOT(["Performance & Scaling"])
+    ROOT --> OPT["Optimisation"]
+    ROOT --> MR["Multi-region"]
+    ROOT --> OBS["Observability"]
+    OPT --> OPT1["Cost Efficiency"]
+    OPT --> OPT2["Resource Utilisation"]
+    OPT --> OPT3["Response Time"]
+    MR --> MR1["Global Scalability"]
+    MR --> MR2["Data Sovereignty"]
+    MR --> MR3["Latency Optimisation"]
+    MR --> MR4["Disaster Recovery"]
+    OBS --> OBS1["System Visibility"]
+    OBS --> OBS2["Real-time Insights"]
+    OBS --> OBS3["Performance Metrics"]

--- a/docs/images/mindmap_22d_governance.mmd
+++ b/docs/images/mindmap_22d_governance.mmd
@@ -1,17 +1,17 @@
-mindmap
-  root((Governance & Policy))
-    Governance Frameworks
-      Developer autonomy
-      Organisational control
-      Automated enforcement
-      Exception handling
-    Policy-as-code
-      Codified policies
-      Version controlled
-      Automated enforcement
-      Transparency
-    Sustainability
-      Environmental consciousness
-      Collaborative development
-      Sustainability patterns
-      Long-term viability
+graph TD
+    ROOT(["Governance & Policy"])
+    ROOT --> GF["Governance Frameworks"]
+    ROOT --> PAC["Policy-as-code"]
+    ROOT --> SUS["Sustainability"]
+    GF --> GF1["Developer Autonomy"]
+    GF --> GF2["Organisational Control"]
+    GF --> GF3["Automated Enforcement"]
+    GF --> GF4["Exception Handling"]
+    PAC --> PAC1["Codified Policies"]
+    PAC --> PAC2["Version Controlled"]
+    PAC --> PAC3["Automated Enforcement"]
+    PAC --> PAC4["Transparency"]
+    SUS --> SUS1["Environmental Consciousness"]
+    SUS --> SUS2["Collaborative Development"]
+    SUS --> SUS3["Sustainability Patterns"]
+    SUS --> SUS4["Long-term Viability"]

--- a/docs/images/mindmap_22e_global_practices.mmd
+++ b/docs/images/mindmap_22e_global_practices.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Global Best Practices))
-    Cross-cultural
-      Global collaboration
-      Technical consistency
-      Local adaptation
-    Open Source
-      Community contribution
-      Knowledge sharing
-      Sustainable practices
-    Continuous Improvement
-      Feedback loops
-      Iterative refinement
-      Learning culture
+graph TD
+    ROOT(["Global Best Practices"])
+    ROOT --> CC["Cross-cultural"]
+    ROOT --> OS["Open Source"]
+    ROOT --> CI["Continuous Improvement"]
+    CC --> CC1["Global Collaboration"]
+    CC --> CC2["Technical Consistency"]
+    CC --> CC3["Local Adaptation"]
+    OS --> OS1["Community Contribution"]
+    OS --> OS2["Knowledge Sharing"]
+    OS --> OS3["Sustainable Practices"]
+    CI --> CI1["Feedback Loops"]
+    CI --> CI2["Iterative Refinement"]
+    CI --> CI3["Learning Culture"]

--- a/docs/images/mindmap_23_soft_as_code.mmd
+++ b/docs/images/mindmap_23_soft_as_code.mmd
@@ -1,16 +1,16 @@
-mindmap
-  root((Soft "as code" Interplay))
-    Shared DNA
-      Structured & versioned
-      Automatable
-    Compliance as Code
-      Codified controls
-    Architecture as Code
-      Central hub
-    Documentation as Code
-      Communication layer
-    Knowledge & Culture
-      Cultural benefits
-    Synergies
-      Cross-pollination
-      Enhanced pace
+graph TD
+    ROOT(["Soft 'as Code' Interplay"])
+    ROOT --> SD["Shared DNA"]
+    ROOT --> CC["Compliance as Code"]
+    ROOT --> AAC["Architecture as Code"]
+    ROOT --> DAC["Documentation as Code"]
+    ROOT --> KC["Knowledge & Culture"]
+    ROOT --> SYN["Synergies"]
+    SD --> SD1["Structured & Versioned"]
+    SD --> SD2["Automatable"]
+    CC --> CC1["Codified Controls"]
+    AAC --> AAC1["Central Hub"]
+    DAC --> DAC1["Communication Layer"]
+    KC --> KC1["Cultural Benefits"]
+    SYN --> SYN1["Cross-pollination"]
+    SYN --> SYN2["Enhanced Pace"]

--- a/docs/images/mindmap_23_soft_as_code_overview.mmd
+++ b/docs/images/mindmap_23_soft_as_code_overview.mmd
@@ -1,19 +1,19 @@
-mindmap
-  root((Soft "as code" Interplay))
-    Shared DNA
-      Structured & versioned
-      Automatable
-    Compliance as Code
-      Codified controls
-      Quality engine
-    Architecture as Code
-      Central hub
-      Connecting layers
-    Documentation as Code
-      Communication layer
-      Toolchain integration
-    Knowledge & Culture
-      Organisational benefits
-    Synergies
-      Cross-pollination
-      Enhanced pace
+graph TD
+    ROOT(["Soft 'as Code' Interplay"])
+    ROOT --> SD["Shared DNA"]
+    ROOT --> CC["Compliance as Code"]
+    ROOT --> AAC["Architecture as Code"]
+    ROOT --> DAC["Documentation as Code"]
+    ROOT --> KC["Knowledge & Culture"]
+    ROOT --> SYN["Synergies"]
+    SD --> SD1["Structured & Versioned"]
+    SD --> SD2["Automatable"]
+    CC --> CC1["Codified Controls"]
+    CC --> CC2["Quality Engine"]
+    AAC --> AAC1["Central Hub"]
+    AAC --> AAC2["Connecting Layers"]
+    DAC --> DAC1["Communication Layer"]
+    DAC --> DAC2["Toolchain Integration"]
+    KC --> KC1["Organisational Benefits"]
+    SYN --> SYN1["Cross-pollination"]
+    SYN --> SYN2["Enhanced Pace"]

--- a/docs/images/mindmap_23a_shared_dna.mmd
+++ b/docs/images/mindmap_23a_shared_dna.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Shared DNA of "as code"))
-    Structured representation
-      Machine-readable formats
-      YAML, JSON, Markdown
-      Domain-specific languages
-    Version control
-      Git workflows
-      Pull request reviews
-      History & traceability
-    Automatability
-      Report generation
-      Compliance verification
-      Dashboard updates
+graph TD
+    ROOT(["Shared DNA of 'as Code'"])
+    ROOT --> SR["Structured Representation"]
+    ROOT --> VC["Version Control"]
+    ROOT --> AUTO["Automatability"]
+    SR --> SR1["Machine-readable Formats"]
+    SR --> SR2["YAML, JSON, Markdown"]
+    SR --> SR3["Domain-specific Languages"]
+    VC --> VC1["Git Workflows"]
+    VC --> VC2["Pull Request Reviews"]
+    VC --> VC3["History & Traceability"]
+    AUTO --> AUTO1["Report Generation"]
+    AUTO --> AUTO2["Compliance Verification"]
+    AUTO --> AUTO3["Dashboard Updates"]

--- a/docs/images/mindmap_23b_compliance.mmd
+++ b/docs/images/mindmap_23b_compliance.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Compliance as Code))
-    Quality engine
-      Rule reuse
-      Continuous validation
-      Transparency
-    Codified controls
-      Open Policy Agent
-      HashiCorp Sentinel
-      Custom frameworks
-    Integration benefits
-      Automated verification
-      Validation chain
-      Shared policy files
+graph TD
+    ROOT(["Compliance as Code"])
+    ROOT --> QE["Quality Engine"]
+    ROOT --> CC["Codified Controls"]
+    ROOT --> IB["Integration Benefits"]
+    QE --> QE1["Rule Reuse"]
+    QE --> QE2["Continuous Validation"]
+    QE --> QE3["Transparency"]
+    CC --> CC1["Open Policy Agent"]
+    CC --> CC2["HashiCorp Sentinel"]
+    CC --> CC3["Custom Frameworks"]
+    IB --> IB1["Automated Verification"]
+    IB --> IB2["Validation Chain"]
+    IB --> IB3["Shared Policy Files"]

--- a/docs/images/mindmap_23c_architecture.mmd
+++ b/docs/images/mindmap_23c_architecture.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Architecture as Code))
-    Central hub
-      Traceability to compliance
-      Real-time documentation
-      Automated quality gates
-    Model approaches
-      Structurizr DSL
-      C4 models
-      Terraform patterns
-    Connecting layers
-      Technical implementation
-      Policy integration
-      Documentation sync
+graph TD
+    ROOT(["Architecture as Code"])
+    ROOT --> CH["Central Hub"]
+    ROOT --> MA["Model Approaches"]
+    ROOT --> CL["Connecting Layers"]
+    CH --> CH1["Traceability to Compliance"]
+    CH --> CH2["Real-time Documentation"]
+    CH --> CH3["Automated Quality Gates"]
+    MA --> MA1["Structurizr DSL"]
+    MA --> MA2["C4 Models"]
+    MA --> MA3["Terraform Patterns"]
+    CL --> CL1["Technical Implementation"]
+    CL --> CL2["Policy Integration"]
+    CL --> CL3["Documentation Sync"]

--- a/docs/images/mindmap_23d_documentation.mmd
+++ b/docs/images/mindmap_23d_documentation.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Documentation as Code))
-    Communication layer
-      Narratives around rules
-      Why & how explanations
-      Relationship mapping
-    Toolchain integration
-      Markdown files
-      Static site generators
-      CI/CD publishing
-    Feedback loops
-      Pull request reviews
-      Collective ownership
-      Structured discussion
+graph TD
+    ROOT(["Documentation as Code"])
+    ROOT --> CL["Communication Layer"]
+    ROOT --> TI["Toolchain Integration"]
+    ROOT --> FL["Feedback Loops"]
+    CL --> CL1["Narratives Around Rules"]
+    CL --> CL2["Why & How Explanations"]
+    CL --> CL3["Relationship Mapping"]
+    TI --> TI1["Markdown Files"]
+    TI --> TI2["Static Site Generators"]
+    TI --> TI3["CI/CD Publishing"]
+    FL --> FL1["Pull Request Reviews"]
+    FL --> FL2["Collective Ownership"]
+    FL --> FL3["Structured Discussion"]

--- a/docs/images/mindmap_23e_knowledge_culture.mmd
+++ b/docs/images/mindmap_23e_knowledge_culture.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Knowledge & Culture))
-    Knowledge as Code
-      Formalised knowledge bases
-      Lessons learned
-      Semi-structured formats
-    Culture as Code
-      Values expression
-      Decision-making practices
-      Working norms
-    Organisational benefits
-      Structured onboarding
-      Adherence tracking
-      Experience preservation
+graph TD
+    ROOT(["Knowledge & Culture"])
+    ROOT --> KC["Knowledge as Code"]
+    ROOT --> CC["Culture as Code"]
+    ROOT --> OB["Organisational Benefits"]
+    KC --> KC1["Formalised Knowledge Bases"]
+    KC --> KC2["Lessons Learned"]
+    KC --> KC3["Semi-structured Formats"]
+    CC --> CC1["Values Expression"]
+    CC --> CC2["Decision-making Practices"]
+    CC --> CC3["Working Norms"]
+    OB --> OB1["Structured Onboarding"]
+    OB --> OB2["Adherence Tracking"]
+    OB --> OB3["Experience Preservation"]

--- a/docs/images/mindmap_23f_synergies.mmd
+++ b/docs/images/mindmap_23f_synergies.mmd
@@ -1,14 +1,14 @@
-mindmap
-  root((Synergies & Implementation))
-    Cross-pollination
-      Shared tools & processes
-      Pull request collaboration
-      Unified validation
-    Collaborative effects
-      Cross-functional teams
-      Shared ownership
-      Technical transparency
-    Implementation Strategy
-      Shared principles
-      Compatible tooling
-      Cross-functional training
+graph TD
+    ROOT(["Synergies & Implementation"])
+    ROOT --> CP["Cross-pollination"]
+    ROOT --> CE["Collaborative Effects"]
+    ROOT --> IS["Implementation Strategy"]
+    CP --> CP1["Shared Tools & Processes"]
+    CP --> CP2["Pull Request Collaboration"]
+    CP --> CP3["Unified Validation"]
+    CE --> CE1["Cross-functional Teams"]
+    CE --> CE2["Shared Ownership"]
+    CE --> CE3["Technical Transparency"]
+    IS --> IS1["Shared Principles"]
+    IS --> IS2["Compatible Tooling"]
+    IS --> IS3["Cross-functional Training"]


### PR DESCRIPTION
- Convert all 29 mindmap_*.mmd files from Mermaid mindmap syntax to
  graph TD flowcharts for significantly better readability in PDF/EPUB/print
- Redesign diagram_02_v_model.mmd as a proper V-shape flowchart (LR layout
  with Specification on left, Verification on right, Implementation at bottom)
- Redesign diagram_06_structurizr_overview.mmd with clear TD subgraphs and
  proper linebreaks replacing raw \n escapes
- Add diagram_27_technical_structure.mmd (source file was missing; new TB
  flowchart showing three-layer platform: Definitions → Pipelines → Governance)

https://claude.ai/code/session_01MvgAdhgfepHj2YQVEfXERy