### PR TITLE
fix: replace libasound2 with libasound2t64 for Ubuntu 24.04 compatibility

### DIFF
--- a/.github/workflows/verify-mermaid-diagrams.yml
+++ b/.github/workflows/verify-mermaid-diagrams.yml
@@ -43,7 +43,7 @@ jobs:
             libgtk-3-0 \
             libnss3 \
             libxss1 \
-            libasound2 \
+            libasound2t64 \
             libdrm2 \
             libxkbcommon0 \
             libgbm1 \


### PR DESCRIPTION
On Ubuntu Noble (24.04), the libasound2 package was renamed to libasound2t64.
The old package name has no installation candidate, causing CI to fail.

https://claude.ai/code/session_01EruNCfi43Y5FwJM2r1sD7V