### PR TITLE
fix: extract valid changes from stale PR #1802

### DIFF
--- a/docs/29_about_the_author.md
+++ b/docs/29_about_the_author.md
@@ -139,4 +139,5 @@ As technology continues to evolve, the principles outlined in this book—declar
 
 1. **Kvadrat AB (2024).** *Gunnar Nordqvist – Chief Architect Profile.* Consultant Profile. [https://www.kvadrat.se/anlita-kvadrat/hitta-konsult/gunnar-nordqvist/](https://www.kvadrat.se/anlita-kvadrat/hitta-konsult/gunnar-nordqvist/)
 2. **Kvadrat AB (2024).** *Technology Consulting Excellence.* Company Profile. [https://www.kvadrat.se/](https://www.kvadrat.se/)
-3. **GitHub Open Source Community (2024).** *Collaborative Software Development.* Platform Documentation.
+3. **Thoughtworks (2024).** *Architecture as Code: The Next Evolution.* Technology Radar. [Source [1]](33_references.md#source-1)
+4. **GitHub Open Source Community (2024).** *Collaborative Software Development.* Platform Documentation.

--- a/tests/test_reference_consistency.py
+++ b/tests/test_reference_consistency.py
@@ -44,6 +44,7 @@ _SOURCES_EXEMPT: frozenset[str] = frozenset({
     "33_references.md",               # IS the bibliography
     "28_glossary.md",                  # reference lookup table
     "29_about_the_author.md",          # author biography
+    "30_appendix_code_examples.md",    # code-only appendix
     "appendix_templates_and_tools.md", # templates appendix
     "appendix_d_control_mapping_matrix_template.md",  # template
     "adr_catalogue.md",                # ADR technical catalogue


### PR DESCRIPTION
- tests/test_reference_consistency.py: exempt 30_appendix_code_examples.md
  (code-only appendix, no narrative Sources section needed)
- docs/29_about_the_author.md: add Thoughtworks Source [1] citation to
  Sources section for completeness

All other changes in PR #1802 would regress improvements already merged
via PRs #1821, #1829, #1831 (source links, Sources [21-32], diagram
orientations).

https://claude.ai/code/session_01KFWBPxhfEttAse5Futu8aH